### PR TITLE
Add hostname policy to discovery step

### DIFF
--- a/roles/dtc/create/tasks/build_hostname_policy_payload.yml
+++ b/roles/dtc/create/tasks/build_hostname_policy_payload.yml
@@ -4,9 +4,13 @@
   ansible.builtin.set_fact:
     query: "response.DATA[?(@.templateName==`host_11_1` && @.serialNumber=='{{ item }}')]"
 
-- name: Get Hostname Policy ID for {{ item }} from NDFC Response
+- name: Get Hostname Policy for {{ item }} from NDFC Response
   ansible.builtin.set_fact:
     policy: "{{ result | community.general.json_query(query) }}"
+
+- name: Get Current Hostname from Policy for {{ item }} from NDFC Response
+  ansible.builtin.set_fact:
+    ndfc_switch_hostname: "{{ policy[0].switchName }}"
 
 - name: Build Hostname Query using Switch Serial Number
   ansible.builtin.set_fact:
@@ -14,12 +18,14 @@
 
 - name: Get Hostname for {{ item }} from Data Model
   ansible.builtin.set_fact:
-    switch_hostname: "{{ MD.fabric.topology.switches | community.general.json_query(query) }}"
+    md_switch_hostname: "{{ MD.fabric.topology.switches | community.general.json_query(query) }}"
 
 - name: Update Hostname Policy for {{ item }} from NDFC Response
   ansible.builtin.set_fact:
-    policy: "{{ policy[0] | combine({'nvPairs': {'SWITCH_NAME': switch_hostname[0]}}, recursive=True) }}"
+    policy: "{{ policy[0] | combine({'nvPairs': {'SWITCH_NAME': md_switch_hostname[0]}}, recursive=True) }}"
+  when: ndfc_switch_hostname != md_switch_hostname[0]
 
 - name: Update Hostname Policy Payload List
   ansible.builtin.set_fact:
     policy_payload: "{{ policy_payload + [policy] }}"
+  when: ndfc_switch_hostname != md_switch_hostname[0]

--- a/roles/dtc/create/tasks/devices_discovery.yml
+++ b/roles/dtc/create/tasks/devices_discovery.yml
@@ -18,16 +18,16 @@
 
 - name: Create List of Switch Serial Numbers from Data Model
   ansible.builtin.set_fact:
-    serial_numbers_list: "{{ MD_Extended.fabric.topology.switches | map(attribute='serial_number') | list }}"
+    md_serial_numbers_list: "{{ MD_Extended.fabric.topology.switches | map(attribute='serial_number') | list }}"
 
 - name: Concatenate Switch Serial Numbers
   ansible.builtin.set_fact:
-    serial_numbers: "{{ serial_numbers_list | join('%2C') }}"
+    md_serial_numbers: "{{ md_serial_numbers_list | join('%2C') }}"
 
 - name: Get NDFC Fabric Default Switch Policies
   cisco.dcnm.dcnm_rest:
     method: GET
-    path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/switches?serialNumber={{ serial_numbers }}"
+    path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/switches?serialNumber={{ md_serial_numbers }}"
   register: result
 
 - name: Default Policy Payload Variable
@@ -36,7 +36,7 @@
 
 - name: Build Payload for NDFC Switch Hostname Policy Update
   ansible.builtin.include_tasks: build_hostname_policy_payload.yml
-  loop: "{{ serial_numbers_list }}"
+  loop: "{{ md_serial_numbers_list }}"
 
 - name: Build Policy ID Query from NDFC Response
   ansible.builtin.set_fact:
@@ -44,14 +44,12 @@
 
 - name: Create List of Switch Hostname Policy IDs from NDFC
   ansible.builtin.set_fact:
-    policy_id_list: "{{ result | community.general.json_query(query) }}"
-
-- name: Concatenate Switch Hostname Policy IDs
-  ansible.builtin.set_fact:
-    policy_ids: "{{ policy_id_list | join('%2C') }}"
+    policy_ids: "{{ policy_payload | map(attribute='policyId') | list | join('%2C') }}"
+  when: policy_payload | length > 0
 
 - name: Update Switch Hostname Policy in NDFC
   cisco.dcnm.dcnm_rest:
     method: PUT
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/{{ policy_ids }}/bulk"
     json_data: "{{ policy_payload | to_json }}"
+  when: policy_payload | length > 0


### PR DESCRIPTION
Since we're not POAPing as part of MVP, we need a mechanism to set the switch hostname from the data model.