### PR TITLE
Fix Route tag variable mapping for Loopback

### DIFF
--- a/roles/dtc/common/templates/ndfc_loopback_interfaces.j2
+++ b/roles/dtc/common/templates/ndfc_loopback_interfaces.j2
@@ -1,5 +1,5 @@
 ---
-# This NDFC loopback interface data is auto-generated
+# This NDFC loopback interface data structure is auto-generated
 # DO NOT EDIT MANUALLY
 #
 {% for switch in MD_Extended.fabric.topology.switches %}


### PR DESCRIPTION
route_tag variable belongs to ipv4_route_tag