### PR TITLE
Delete vpc link remove task

### DIFF
--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -67,16 +67,6 @@
       - "-------------------------------------------------------------------------------------------------------"
   when: not ((vpc_peering_delete_mode is defined) and (vpc_peering_delete_mode is true|bool))
 
-- debug: msg="Removing all Unmanaged links. This could take several minutes..."
-- name: Remove Intra Fabric Links for vpc peering
-  cisco.dcnm.dcnm_links:
-    state: replaced
-    src_fabric: "{{ MD_Extended.fabric.global.name }}"
-    config: "{{ link_vpc_peering }}"
-  vars:
-      ansible_command_timeout: 3000
-      ansible_connect_timeout: 3000
-
 - debug: msg="Removing Unmanaged Fabric Switches. This could take several minutes..."
 - name: Remove NDFC Fabric Devices {{ MD.fabric.global.name }}
   cisco.dcnm.dcnm_inventory:


### PR DESCRIPTION
as dcnm_links not support overridden state, this task here is nothing different than what we do in create role.

We have agreed to leave the links as is, as the vpc _peering delete is anyway shutting down the peer interfaces.

this may be considered in the future as an enhancement if needed

