### PR TITLE
Handle VRF and Network Attach Group Hostname Mapping to Mgmt IP

### DIFF
--- a/plugins/action/common/prepare_plugins/104_prep_fabric_overlay_services.py
+++ b/plugins/action/common/prepare_plugins/104_prep_fabric_overlay_services.py
@@ -6,6 +6,7 @@ class PreparePlugin:
 
     def prepare(self):
         model_data = self.kwargs['results']['model_extended']
+        switches = model_data['vxlan']['topology']['switches']
 
         # Rebuild sm_data['vxlan']['overlay_services']['vrf_attach_groups'] into
         # a structure that is easier to use.
@@ -16,6 +17,14 @@ class PreparePlugin:
             vrf_grp_name_list.append(grp['name'])
             for switch in grp['switches']:
                 model_data['vxlan']['overlay_services']['vrf_attach_groups_dict'][grp['name']].append(switch)
+            # If the switch is in the switch list and a hostname is used, replace the hostname with the management IP
+            for switch in model_data['vxlan']['overlay_services']['vrf_attach_groups_dict'][grp['name']]:
+                if any(sw['name'] == switch['hostname'] for sw in switches):
+                    found_switch = next((item for item in switches if item["name"] == switch['hostname']))
+                    if found_switch.get('management').get('management_ipv4_address'):
+                        switch['hostname'] = found_switch['management']['management_ipv4_address']
+                    elif found_switch.get('management').get('management_ipv6_address'):
+                        switch['hostname'] = found_switch['management']['management_ipv6_address']
 
         # Remove attach_group from vrf if the group_name is not defined
         for vrf in model_data['vxlan']['overlay_services']['vrfs']:
@@ -32,6 +41,14 @@ class PreparePlugin:
             net_grp_name_list.append(grp['name'])
             for switch in grp['switches']:
                 model_data['vxlan']['overlay_services']['network_attach_groups_dict'][grp['name']].append(switch)
+            # If the switch is in the switch list and a hostname is used, replace the hostname with the management IP
+            for switch in model_data['vxlan']['overlay_services']['network_attach_groups_dict'][grp['name']]:
+                if any(sw['name'] == switch['hostname'] for sw in switches):
+                    found_switch = next((item for item in switches if item["name"] == switch['hostname']))
+                    if found_switch.get('management').get('management_ipv4_address'):
+                        switch['hostname'] = found_switch['management']['management_ipv4_address']
+                    elif found_switch.get('management').get('management_ipv6_address'):
+                        switch['hostname'] = found_switch['management']['management_ipv6_address']
 
         # Remove attach_group from net if the group_name is not defined
         for net in model_data['vxlan']['overlay_services']['networks']:


### PR DESCRIPTION
Handle VRF and Network attach group hostname mapping to mgmt IP by updating prepare overlay services code. Cross reference of hostname to topology switch handled in a rule.

Resolves #5 & #6 