### PR TITLE
Fixing Fabric Create, default typo

### DIFF
--- a/roles/dtc/common/templates/ndfc_create_fabric.j2
+++ b/roles/dtc/common/templates/ndfc_create_fabric.j2
@@ -118,8 +118,10 @@
   ISIS_AUTH_KEYCHAIN_NAME: {{ isis.authentication_keychain_name | default(omit) }}
   ISIS_AUTH_KEYCHAIN_KEY_ID: {{ isis.authentication_key_id | default(defaults.vxlan.underlay.isis.authentication_key_id) }}
 {% endif %}
-  ISIS_OVERLOAD_ELAPSE_TIME: {{ isis.overload_bit_elapsed_time | default(defaults.vxlan.underlay.isis.overload_bit_elapsed_time) }}
   ISIS_OVERLOAD_ENABLE: {{ isis.overload_bit | default(defaults.vxlan.underlay.isis.overload_bit) }}
+{% if (isis.overload_bit | default(defaults.vxlan.underlay.isis.overload_bit) | title) == 'True' %}
+  ISIS_OVERLOAD_ELAPSE_TIME: {{ isis.overload_bit_elapsed_time | default(defaults.vxlan.underlay.isis.overload_bit_elapsed_time) }}
+{% endif %}
   ISIS_P2P_ENABLE: {{ isis.network_point_to_point | default(defaults.vxlan.underlay.isis.network_point_to_point) }}
 {% if (bfd.enable | default(defaults.vxlan.underlay.bfd.enable) | title) == 'True' %}
   BFD_ISIS_ENABLE: {{ bfd.isis | default(defaults.vxlan.underlay.bfd.isis) }}

--- a/roles/validate/defaults/main.yml
+++ b/roles/validate/defaults/main.yml
@@ -104,7 +104,7 @@ defaults:
         authentication_enable: false
         authentication_key_id: 127
       isis:
-        level: level2
+        level: level-2
         network_point_to_point: true
         authentication_enable: false
         authentication_key_id: 127

--- a/tests/integration/roles/test_create/tests/test.yml
+++ b/tests/integration/roles/test_create/tests/test.yml
@@ -7,6 +7,9 @@
     fabric: "{{ MD_Extended.vxlan.global.name }}"
     state: query
   register: fabric_query
+  vars:
+      ansible_command_timeout: 1000
+      ansible_connect_timeout: 1000
 
 - name: Run inventory tests
   cisco.nac_dc_vxlan.test.inventory:


### PR DESCRIPTION
This PR has below fix:

1. Corrected the isis.level value in the defaults file, as per schema and ndfc.
2. Fixed the fabric create Jinja file. "overload_bit_elapsed_time" should only be configured if "overload_bit" is set to True.
4. Added "ansible_command_timeout: 1000" in the tests/test.yml file as dcnm_inventory Query is timing out.