### PR TITLE
fix for rule 304 init vars

### DIFF
--- a/roles/validate/files/rules/required_rules/304_overlay_services_cross_reference.py
+++ b/roles/validate/files/rules/required_rules/304_overlay_services_cross_reference.py
@@ -46,6 +46,7 @@ class Rule:
                         results.append(" and re-run the playbook")
 
         # Cross reference VRF attach groups hostnames with inventory topology switch names
+        vrf_attach_groups = []
         if inventory.get("vxlan"):
             if inventory.get("vxlan").get("overlay_services"):
                 if inventory.get("vxlan").get("overlay_services").get("vrf_attach_groups"):
@@ -64,6 +65,7 @@ class Rule:
                                 results.append("VRF attach group {0} hostname {1} does not match any switch in the topology".format(vag, hn))
 
         # Cross reference Network attach groups hostnames with inventory topology switch names
+        network_attach_groups = []
         if inventory.get("vxlan"):
             if inventory.get("vxlan").get("overlay_services"):
                 if inventory.get("vxlan").get("overlay_services").get("network_attach_groups"):


### PR DESCRIPTION
vrf_attach_groups and network_attach_groups need to be initialized as lists before use.

Fixes the following error when running validation:
```
    for vrf_attach_group in vrf_attach_groups:
UnboundLocalError: local variable 'vrf_attach_groups' referenced before assignment
fatal: [fabric_empty]: FAILED! => {
    "msg": "Unexpected failure during module execution: local variable 'vrf_attach_groups' referenced before assignment",
```
The same error is present for for network_attach_groups