### PR TITLE
add timeout for remove vpc_peering

### DIFF
--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -99,6 +99,9 @@
     deploy: true
     state: overridden
     config: "{{ vpc_peering }}"
+  vars:
+      ansible_command_timeout: 1000
+      ansible_connect_timeout: 1000  
   when:
     - switch_list.response.DATA | length > 0
     - (vpc_delete_mode is defined) and (vpc_delete_mode is true|bool)


### PR DESCRIPTION
This resolves a timeout issue when the remove role is trying to remove vpc_peering.  The following error was seen when running the tests/integration vxlan_large playbook:

ansible.module_utils.connection.ConnectionError: command timeout triggered, timeout value is 30 secs.
See the timeout setting options in the Network Debug and Troubleshooting Guide.". Please verify your login credentials, access permissions and fabric details and try again

Added the timeout and the task was successfully processed.