### PR TITLE
Updates for border gateway role for integration tests

### DIFF
--- a/plugins/action/common/prepare_plugins/prep_103_topology_switches.py
+++ b/plugins/action/common/prepare_plugins/prep_103_topology_switches.py
@@ -27,10 +27,17 @@ class PreparePlugin:
 
     def prepare(self):
         model_data = self.kwargs['results']['model_extended']
-
+#  Loop over all the roles in vxlan.topology.switches.role
         model_data['vxlan']['topology']['spine'] = {}
         model_data['vxlan']['topology']['leaf'] = {}
         model_data['vxlan']['topology']['border'] = {}
+        model_data['vxlan']['topology']['border_spine'] = {}
+        model_data['vxlan']['topology']['border_gateway'] = {}
+        model_data['vxlan']['topology']['border_gateway_spine'] = {}
+        model_data['vxlan']['topology']['super_spine'] = {}
+        model_data['vxlan']['topology']['border_super_spine'] = {}
+        model_data['vxlan']['topology']['border_gateway_super_spine'] = {}
+        model_data['vxlan']['topology']['tor'] = {}
         sm_switches = model_data['vxlan']['topology']['switches']
         for switch in sm_switches:
             # Build list of switch IP's based on role keyed by switch name

--- a/tests/integration/fabric_vars_example.yml
+++ b/tests/integration/fabric_vars_example.yml
@@ -53,3 +53,7 @@ border:
   hostname: << border_hostname >>
   serial: << border_serial >>
   ip: << border_ip >>
+border_gateway:
+  hostname: << border_gateway_hostname >>
+  serial: << border_gateway_serial >>
+  ip: << border_gateway_ip >>

--- a/tests/integration/host_vars/examples/fabric_full_large_example/topology_switches.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_large_example/topology_switches.yaml
@@ -99,3 +99,14 @@ vxlan:
           management_ipv6_address: 2055:55:55:55::55/64
         routing_loopback_id: 0
         vtep_loopback_id: 1
+
+      - name: << border_gateway_hostname >>
+        serial_number: << border_gateway_serial >>
+        role: border_gateway
+        management:
+          default_gateway_v4: << default_gateway_v4 >>
+          default_gateway_v6: 2055:55:55:55::55/64
+          management_ipv4_address: << border_gateway_ip >>
+          management_ipv6_address: 2055:55:55:55::55/64
+        routing_loopback_id: 0
+        vtep_loopback_id: 1

--- a/tests/integration/roles/test_update_model_data/tasks/main.yml
+++ b/tests/integration/roles/test_update_model_data/tasks/main.yml
@@ -256,3 +256,28 @@
     replace: "{{ border.ip }}"
   loop: "{{ files_names }}"
   delegate_to: 127.0.0.1
+
+# -- Border Gateway --
+- name: Replace << border_gateway_hostname >> in test data model files
+  ansible.builtin.replace:
+    path: "{{ playbook_dir }}/host_vars/{{ inventory_hostname}}/{{ item}}"
+    regexp: '<< border_gateway_hostname >>'
+    replace: "{{ border_gateway.hostname }}"
+  loop: "{{ files_names }}"
+  delegate_to: 127.0.0.1
+
+- name: Replace << border_gateway_serial >> in test data model files
+  ansible.builtin.replace:
+    path: "{{ playbook_dir }}/host_vars/{{ inventory_hostname}}/{{ item}}"
+    regexp: '<< border_gateway_serial >>'
+    replace: "{{ border_gateway.serial }}"
+  loop: "{{ files_names }}"
+  delegate_to: 127.0.0.1
+
+- name: Replace << border_gateway_ip >> in test data model files
+  ansible.builtin.replace:
+    path: "{{ playbook_dir }}/host_vars/{{ inventory_hostname}}/{{ item}}"
+    regexp: '<< border_gateway_ip >>'
+    replace: "{{ border_gateway.ip }}"
+  loop: "{{ files_names }}"
+  delegate_to: 127.0.0.1


### PR DESCRIPTION
This adds a border_gateway config for the tests/integration/test_vxlan_large.yml and fixes prep_103_topology_switches.py to allow for all additional roles.