### PR TITLE
Get Credentials and Remove Role Fixes

### DIFF
--- a/plugins/action/common/get_credentials.py
+++ b/plugins/action/common/get_credentials.py
@@ -34,21 +34,23 @@ display = Display()
 class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
-        # self._supports_async = True
         results = super(ActionModule, self).run(tmp, task_vars)
-        results['failed'] = False
+        results['retrieve_failed'] = False
 
-        inv_list = self._task.args['inv_list']
-        username = task_vars.get('ndfc_device_username')
-        password = task_vars.get('ndfc_device_password')
+        key_username = 'ndfc_device_username'
+        key_password = 'ndfc_device_password'
+
+        ndfc_host_name = task_vars['inventory_hostname']
+        username = task_vars['hostvars'][ndfc_host_name].get(key_username, '')
+        password = task_vars['hostvars'][ndfc_host_name].get(key_password, '')
 
         # Fail if username and password are not set
-        if username is None or password is None:
-            results['failed'] = True
-            results['msg'] = "ndfc_device_username and ndfc_device_username must be set in group_vars or as environment variables!"
-            # TODO: Add support for environemnt variables
+        if username == '' or password == '':
+            results['retrieve_failed'] = True
+            results['msg'] = "{0} and {1} must be set in group_vars or as environment variables!".format(key_username, key_password)
             return results
 
+        inv_list = self._task.args['inv_list']
         # Create a new list and deep copy each dict item to avoid modifying the original and dict items
         updated_inv_list = []
         for device in inv_list:

--- a/roles/dtc/common/tasks/ndfc_inventory.yml
+++ b/roles/dtc/common/tasks/ndfc_inventory.yml
@@ -48,3 +48,8 @@
     inv_list: "{{ inv_config }}"
   register: updated_inv_config
   no_log: true
+
+- name: Credential Retrieval Failed
+  ansible.builtin.fail:
+    msg: "{{ updated_inv_config }}"
+  when: updated_inv_config['retrieve_failed']

--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -50,13 +50,6 @@
     - switch_list.response.DATA | length > 0
     - (interface_delete_mode is defined) and (interface_delete_mode is true|bool)
 
-- ansible.builtin.debug:
-    msg:
-      - "-------------------------------------------------------------------------------------------------------------------"
-      - "+ SKIPPING Remove Unmanaged Fabric Interfaces task because interface_delete_mode flag is set to False  +"
-      - "-------------------------------------------------------------------------------------------------------------------"
-  when: not ((interface_delete_mode is defined) and (interface_delete_mode is true|bool))
-
 - ansible.builtin.debug: msg="Removing Unmanaged Fabric Networks. This could take several minutes..."
 
 - cisco.dcnm.dcnm_network:
@@ -67,13 +60,6 @@
     - switch_list.response.DATA | length > 0
     - (network_delete_mode is defined) and (network_delete_mode is true|bool)
 
-- ansible.builtin.debug:
-    msg:
-      - "---------------------------------------------------------------------------------------------------------------"
-      - "+ SKIPPING Remove Unmanaged Fabric Networks task because network_delete_mode flag is set to False  +"
-      - "---------------------------------------------------------------------------------------------------------------"
-  when: not ((network_delete_mode is defined) and (network_delete_mode is true|bool))
-
 - ansible.builtin.debug: msg="Removing Unmanaged Fabric VRFs. This could take several minutes..."
 
 - cisco.dcnm.dcnm_vrf:
@@ -83,13 +69,6 @@
   when:
     - switch_list.response.DATA | length > 0
     - (vrf_delete_mode is defined) and (vrf_delete_mode is true|bool)
-
-- ansible.builtin.debug:
-    msg:
-      - "--------------------------------------------------------------------------------------------------------"
-      - "+ SKIPPING Remove Unmanaged Fabric VRFs task because vrf_delete_mode flag is set to False   +"
-      - "--------------------------------------------------------------------------------------------------------"
-  when: not ((vrf_delete_mode is defined) and (vrf_delete_mode is true|bool))
 
 - ansible.builtin.debug: msg="Removing all Unmanaged vPC Peering. This could take several minutes..."
 
@@ -105,13 +84,6 @@
   when:
     - switch_list.response.DATA | length > 0
     - (vpc_delete_mode is defined) and (vpc_delete_mode is true|bool)
-
-- ansible.builtin.debug:
-    msg:
-      - "-------------------------------------------------------------------------------------------------------"
-      - "+ SKIPPING Remove Unmanaged vPC Peering task because vpc_peering_delete_mode flag is set to False  +"
-      - "-------------------------------------------------------------------------------------------------------"
-  when: not ((vpc_peering_delete_mode is defined) and (vpc_peering_delete_mode is true|bool))
 
 - ansible.builtin.debug: msg="Removing all Unmanaged links. This could take several minutes..."
 
@@ -141,6 +113,34 @@
       ansible_connect_timeout: 3000
   when:
     - (inventory_delete_mode is defined) and (inventory_delete_mode is true|bool)
+
+- ansible.builtin.debug:
+    msg:
+      - "-------------------------------------------------------------------------------------------------------------------"
+      - "+ SKIPPING Remove Unmanaged Fabric Interfaces task because interface_delete_mode flag is set to False  +"
+      - "-------------------------------------------------------------------------------------------------------------------"
+  when: not ((interface_delete_mode is defined) and (interface_delete_mode is true|bool))
+
+- ansible.builtin.debug:
+    msg:
+      - "---------------------------------------------------------------------------------------------------------------"
+      - "+ SKIPPING Remove Unmanaged Fabric Networks task because network_delete_mode flag is set to False  +"
+      - "---------------------------------------------------------------------------------------------------------------"
+  when: not ((network_delete_mode is defined) and (network_delete_mode is true|bool))
+
+- ansible.builtin.debug:
+    msg:
+      - "--------------------------------------------------------------------------------------------------------"
+      - "+ SKIPPING Remove Unmanaged Fabric VRFs task because vrf_delete_mode flag is set to False   +"
+      - "--------------------------------------------------------------------------------------------------------"
+  when: not ((vrf_delete_mode is defined) and (vrf_delete_mode is true|bool))
+
+- ansible.builtin.debug:
+    msg:
+      - "-------------------------------------------------------------------------------------------------------"
+      - "+ SKIPPING Remove Unmanaged vPC Peering task because vpc_peering_delete_mode flag is set to False  +"
+      - "-------------------------------------------------------------------------------------------------------"
+  when: not ((vpc_peering_delete_mode is defined) and (vpc_peering_delete_mode is true|bool))
 
 - ansible.builtin.debug:
     msg:


### PR DESCRIPTION
**Summary of Changes:**

* Update to allows `'ndfc_device_username'` and `'ndfc_device_password'` credentials to be stored as environment variables or set directly under group_vars and retrieved properly.
* Refactor `remove` role to generate skip messages at the end to make them more noticeable/readable.