### PR TITLE
updates for border_spine for full integration tests

### DIFF
--- a/tests/integration/fabric_vars_example.yml
+++ b/tests/integration/fabric_vars_example.yml
@@ -57,3 +57,7 @@ border_gateway:
   hostname: << border_gateway_hostname >>
   serial: << border_gateway_serial >>
   ip: << border_gateway_ip >>
+border_spine:
+  hostname: << border_spine_hostname >>
+  serial: << border_spine_serial >>
+  ip: << border_spine_ip >>

--- a/tests/integration/host_vars/examples/fabric_full_large_example/topology_switches.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_large_example/topology_switches.yaml
@@ -110,3 +110,14 @@ vxlan:
           management_ipv6_address: 2055:55:55:55::55/64
         routing_loopback_id: 0
         vtep_loopback_id: 1
+
+      - name: << border_spine_hostname >> 
+        serial_number: << border_spine_serial >>
+        role: border_spine
+        management:
+          default_gateway_v4: << default_gateway_v4 >>
+          default_gateway_v6: 2055:55:55:55::55/64
+          management_ipv4_address: << border_spine_ip >>
+          management_ipv6_address: 2055:55:55:55::55/64
+        routing_loopback_id: 0
+        vtep_loopback_id: 1

--- a/tests/integration/roles/test_update_model_data/tasks/main.yml
+++ b/tests/integration/roles/test_update_model_data/tasks/main.yml
@@ -281,3 +281,28 @@
     replace: "{{ border_gateway.ip }}"
   loop: "{{ files_names }}"
   delegate_to: 127.0.0.1
+
+# -- Border Spine --
+- name: Replace << border_spine_hostname >> in test data model files
+  ansible.builtin.replace:
+    path: "{{ playbook_dir }}/host_vars/{{ inventory_hostname}}/{{ item}}"
+    regexp: '<< border_spine_hostname >>'
+    replace: "{{ border_spine.hostname }}"
+  loop: "{{ files_names }}"
+  delegate_to: 127.0.0.1
+
+- name: Replace << border_spine_serial >> in test data model files
+  ansible.builtin.replace:
+    path: "{{ playbook_dir }}/host_vars/{{ inventory_hostname}}/{{ item}}"
+    regexp: '<< border_spine_serial >>'
+    replace: "{{ border_spine.serial }}"
+  loop: "{{ files_names }}"
+  delegate_to: 127.0.0.1
+
+- name: Replace << border_spine_ip >> in test data model files
+  ansible.builtin.replace:
+    path: "{{ playbook_dir }}/host_vars/{{ inventory_hostname}}/{{ item}}"
+    regexp: '<< border_spine_ip >>'
+    replace: "{{ border_spine.ip }}"
+  loop: "{{ files_names }}"
+  delegate_to: 127.0.0.1


### PR DESCRIPTION
You can use the following fabric_vars.yml for testing on Fabric4:
```
fabric_name: netascode_fabric4
fabric_password: 
fabric_device_password: 
default_gateway_v4: 192.168.112.254
spine1:
  hostname: netascode4-spine1
  serial: 9RPK63KD8TR
  ip: 192.168.112.151
spine2:
  hostname: netascode4-spine2
  serial: 92UBV39S1YQ
  ip: 192.168.112.152
leaf1:
  hostname: netascode4-leaf1
  serial: 9SJP2G16MPF
  ip: 192.168.112.1
leaf2:
  hostname: netascode4-leaf2
  serial: 91IRW2OO4TX
  ip: 192.168.112.2
leaf3:
  hostname: netascode4-leaf3
  serial: 9JOCTUYC1EV
  ip: 192.168.112.3
leaf4:
  hostname: netascode4-leaf4
  serial: 936D48XQN1P
  ip: 192.168.112.4
border:
  hostname: netascode4-border
  serial: 9QBPYQ3QLH5
  ip: 192.168.112.5
border_gateway:
  hostname: netascode4-bg
  serial: 9THEDSXPUJ1
  ip: 192.168.112.6
border_spine:
  hostname: netascode4-border-spine
  serial: 99KD5B6DIT1
  ip: 192.168.112.7
```