### PR TITLE
updates for SHA auth_proto for integration tests

### DIFF
--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/global.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/global.yaml
@@ -19,21 +19,36 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
-
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+---
+vxlan:
+  global:
+    name: << fabric_name >>
+    bgp_asn: 787878
+    route_reflectors: 4
+    anycast_gateway_mac: 20:20:00:00:00:aa
+    auth_proto: SHA
+    dns_servers:
+      - ip_address: 1.1.1.1
+        vrf: test
+      - ip_address: 5.5.5.1
+        vrf: test
+      - ip_address: 8.8.8.8
+        vrf: engineering
+    ntp_servers:
+      - ip_address: 15.3.3.3
+        vrf: test
+      - ip_address: 16.3.3.3
+        vrf: engineering
+      - ip_address: 17.3.3.3
+        vrf: engineering
+      - ip_address: 18.3.3.3
+        vrf: engineering
+    vpc:
+      peer_link_vlan: 3600
+      peer_keep_alive: management
+      auto_recovery_time: 300
+      delay_restore_time: 175
+      peer_link_port_channel_id: 555
+      advertise_pip: False
+      advertise_pip_border_only: True
+      domain_id_range: 1-100

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/networks.yaml
@@ -1,0 +1,104 @@
+# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+vxlan:
+  overlay_services:
+    networks:
+      - name: NetAsCodeNet1
+        vrf_name: NetAsCodeVrf1
+        vlan_id: 2301
+        net_id: 130001
+        vlan_name: NetAsCodeNet1_vlan2301
+        gw_ip_address: "192.168.12.1/24"
+        attach_group: all_leaf
+
+      - name: NetAsCodeNet2
+        vrf_name: NetAsCodeVrf2
+        net_id: 130002
+        vlan_id: 2302
+        vlan_name: NetAsCodeNet2_vlan2302
+        gw_ip_address: "192.168.12.2/24"
+        attach_group: leaf1_leaf2
+
+      - name: NetAsCodeNet3
+        vrf_name: NetAsCodeVrf3
+        net_id: 130003
+        vlan_id: 2303
+        vlan_name: NetAsCodeNet3_vlan2303
+        gw_ip_address: "192.168.12.3/24"
+        gw_ipv6_address: '2001::1/64'
+        route_target_both: True
+        l3gw_on_border: True
+        mtu_l3intf: 7600
+        int_desc: "Configured by NetAsCode"
+        attach_group: leaf1_leaf2
+
+      - name: NetAsCodeNet4
+        vrf_name: NetAsCodeVrf4
+        net_id: 130004
+        vlan_id: 2304
+        vlan_name: NetAsCodeNet4_vlan2304
+        gw_ip_address: "192.168.12.4/24"
+        attach_group: leaf1_leaf2
+
+      - name: NetAsCodeNet_Default
+        is_l2_only: False
+        vrf_name: NetAsCodeVrf_Default
+        net_id: 130020
+        vlan_id: 2320
+        vlan_name: NetAsCodeVrf_Default_vlan2320
+        gw_ip_address: "192.168.12.1/24"
+        arp_suppress: False
+        dhcp_loopback_id: 55
+        dhcp_servers:
+          - ip_address: 172.55.1.1
+            vrf: NetAsCodeVrf_Default
+        gw_ipv6_address: '2001::1/64'
+        int_desc: "Configured by NetAsCode"
+        l3gw_on_border: True
+        mtu_l3intf: 7600
+        multicast_group_address: 239.1.1.1
+        netflow_enable: False
+        route_target_both: True
+        route_tag: 12345
+        secondary_ip_addresses:
+          - ip_address: 10.10.10.1
+            route_tag: 12345
+        trm_enable: False
+        vlan_netflow_monitor: vlan55
+        attach_group: all_leaf
+
+    network_attach_groups:
+      - name: all_leaf
+        switches:
+          - {hostname: << leaf1_ip >>, ports: [Ethernet1/13, Ethernet1/14]}
+          - {hostname: << leaf2_ip >>, ports: [Ethernet1/13, Ethernet1/14]}
+      - name: leaf1_leaf2
+        switches:
+          - {hostname: << leaf1_ip >>, ports: []}
+          - {hostname: << leaf2_ip >>, ports: []}
+      - name: leaf1
+        switches:
+          - {hostname: << leaf1_ip >>, ports: []}
+      - name: leaf2
+        switches:
+          - {hostname: << leaf2_ip >>, ports: []}

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_edge_connections.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_edge_connections.yaml
@@ -19,21 +19,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
-
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+---
+vxlan:
+  topology:
+    edge_connections:
+      - dest_fabric: "dest_fabric"
+        source_device: "source_device"
+        dest_device: "dest_device"
+        source_interface: "Ethernet1/1"
+        dest_interface: "Ethernet1/2"
+      - dest_fabric: "dest_fabric2"
+        source_device: "source_device"
+        dest_device: "dest_device"
+        source_interface: "Ethernet1/1"
+        dest_interface: "Ethernet1/2"

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_fabric_links.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_fabric_links.yaml
@@ -19,21 +19,15 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
-
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+---
+vxlan:
+  topology:
+    fabric_links:
+      - source_device: "source_device"
+        source_interface: "Ethernet1/1"
+        dest_device: "dest_device"
+        dest_interface: "Ethernet1/2"
+      - source_device: "source_device2"
+        source_interface: "Ethernet1/1"
+        dest_device: "dest_device2"
+        dest_interface: "Ethernet1/2"

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_access.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_access.yaml
@@ -19,21 +19,26 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces: []
 
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces:
+          - name: Ethernet1/30
+            mode: access
+            description: "NaC Access for vlan55 leaf1"
+            mtu: default
+            speed: auto
+            enabled: true
+            access_vlan: 55
+            spanning_tree_portfast: false
+            enable_bpdu_guard: false
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces: []

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_access_po.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_access_po.yaml
@@ -1,0 +1,63 @@
+# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces: []
+
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces:
+          - name: Port-Channel55
+            mode: access
+            description: "NaC Access Port-Channel for vlan 55 leaf1"
+            # vpc_id: 1
+            mtu: default
+            speed: auto
+            enabled: true
+            spanning_tree_portfast: false
+            enable_bpdu_guard: false
+            pc_mode: passive
+            members:
+              - Ethernet1/32
+              - Ethernet1/33
+            access_vlan: 55
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces:
+          - name: Port-Channel55
+            mode: access
+            description: "NaC Access Port-Channel for vlan 55 leaf2"
+            # vpc_id: 1
+            mtu: default
+            speed: auto
+            enabled: true
+            spanning_tree_portfast: false
+            enable_bpdu_guard: false
+            pc_mode: passive
+            members:
+              - Ethernet1/32
+              - Ethernet1/33
+            access_vlan: 55

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_loopback.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_loopback.yaml
@@ -1,0 +1,122 @@
+# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces:
+          - name: lo55
+            mode: loopback
+            description: 'NaC Loopback Interface Spine1'
+            vrf: red
+            enabled: true
+            ipv4_address: 10.55.55.1
+            ipv4_route_tag: 12345
+            # Secondary not supported on NDFC?
+            # --------------------------------
+            # secondary_ipv4_addresses:
+            #   - ip_address: 192.10.55.1/32
+            #     route_tag: 56789
+            ipv6_address: 2055:55:55:55::1
+            ipv6_route_tag: 12345
+            # Secondary not supported on NDFC?
+            # --------------------------------
+            # secondary_ipv6_addresses:
+            #   - ip_address: 2056:55:55:55::1
+            #     route_tag: 8888
+
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces:
+          - name: lo55
+            mode: loopback
+            description: 'NaC Loopback Interface Leaf1'
+            vrf: red
+            enabled: true
+            ipv4_address: 10.55.55.21
+            ipv4_route_tag: 12345
+            secondary_ipv4_addresses:
+              - ip_address: 192.10.55.21/32
+                route_tag: 56789
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces:
+          - name: Loopback55
+            mode: loopback
+            description: 'NaC Loopback Interface Leaf2'
+            vrf: red
+            enabled: true
+            ipv4_address: 10.55.55.22
+            ipv4_route_tag: 12345
+            secondary_ipv4_addresses:
+              - ip_address: 192.10.55.22/32
+                route_tag: 56789
+          - name: Loopback56
+            mode: loopback
+            ipv4_address: 10.55.55.56
+          - name: Loopback57
+            mode: loopback
+            ipv4_address: 10.55.55.57
+          - name: Loopback58
+            mode: loopback
+            ipv4_address: 10.55.55.58
+          - name: Loopback59
+            mode: loopback
+            ipv4_address: 10.55.55.59
+          - name: Loopback60
+            mode: loopback
+            ipv4_address: 10.55.55.60
+          - name: Loopback61
+            mode: loopback
+            ipv4_address: 10.55.55.61
+          - name: Loopback62
+            mode: loopback
+            ipv4_address: 10.55.55.62
+          - name: Loopback63
+            mode: loopback
+            ipv4_address: 10.55.55.63
+          - name: Loopback64
+            mode: loopback
+            ipv4_address: 10.55.55.64
+          - name: Loopback65
+            mode: loopback
+            ipv4_address: 10.55.55.65
+          - name: Loopback66
+            mode: loopback
+            ipv4_address: 10.55.55.66
+          - name: Loopback67
+            mode: loopback
+            ipv4_address: 10.55.55.67
+          - name: Loopback68
+            mode: loopback
+            ipv4_address: 10.55.55.68
+          - name: Loopback69
+            mode: loopback
+            ipv4_address: 10.55.55.69
+          - name: Loopback70
+            mode: loopback
+            ipv4_address: 10.55.55.70
+          - name: Loopback71
+            mode: loopback
+            ipv4_address: 10.55.55.71

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_loopback_fabric.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_loopback_fabric.yaml
@@ -19,21 +19,21 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces: []
+          # - name: lo0
+          #   description: 'NetAsCode Fabric Loopback Interface'
+          #   mode: fabric_loopback
+          #   ipv4_address: 10.2.0.3
 
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces: []
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces: []

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_routed.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_routed.yaml
@@ -19,21 +19,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces: []
 
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces: []
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces: []

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_routed_po.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_routed_po.yaml
@@ -19,21 +19,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces: []
 
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces: []
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces: []

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_routed_subint.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_routed_subint.yaml
@@ -19,21 +19,17 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces: []
 
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces: []
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces: []

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_trunk.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_trunk.yaml
@@ -19,21 +19,30 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces: []
 
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces:
+          - name: Ethernet1/31
+            mode: trunk
+            description: "NaC Trunk for leaf1"
+            mtu: default
+            speed: auto
+            enabled: true
+            trunk_allowed_vlans:
+              - from: 10
+                to: 100
+              - from: 150
+                to: 200
+            spanning_tree_portfast: false
+            enable_bpdu_guard: false
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces: []

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_trunk_po.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_int_trunk_po.yaml
@@ -19,21 +19,39 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        interfaces: []
 
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        interfaces:
+          - name: Port-Channel56
+            mode: trunk
+            description: "NaC Trunk Port-Channel for leaf1"
+            # This is not working check with Rameez
+            # ----------
+            # vpc_id: 1
+            mtu: default
+            speed: auto
+            enabled: true
+            spanning_tree_portfast: false
+            enable_bpdu_guard: false
+            pc_mode: passive
+            members:
+              - Ethernet1/34
+              - Ethernet1/35
+            trunk_allowed_vlans:
+              - from: 25
+                to: 99
+              - from: 101
+                to: 155
+              - from: 158
+                to: 159
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        interfaces: []

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_switches.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_switches.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+vxlan:
+  topology:
+    switches:
+      - name: << spine1_hostname >>
+        serial_number: << spine1_serial >>
+        role: spine
+        management:
+          default_gateway_v4: << default_gateway_v4 >>
+          default_gateway_v6: 2055:55:55:55::55/64
+          management_ipv4_address: << spine1_ip >>
+          management_ipv6_address: 2055:55:55:55::55/64
+        routing_loopback_id: 0
+        vtep_loopback_id: 1
+
+      - name: << leaf1_hostname >>
+        serial_number: << leaf1_serial >>
+        role: leaf
+        management:
+          default_gateway_v4: << default_gateway_v4 >>
+          default_gateway_v6: 2055:55:55:55::55/64
+          management_ipv4_address: << leaf1_ip >>
+          management_ipv6_address: 2055:55:55:55::55/64
+        routing_loopback_id: 0
+        vtep_loopback_id: 1
+
+      - name: << leaf2_hostname >>
+        serial_number: << leaf2_serial >>
+        role: leaf
+        management:
+          default_gateway_v4: << default_gateway_v4 >>
+          default_gateway_v6: 2055:55:55:55::55/64
+          management_ipv4_address: << leaf2_ip >>
+          management_ipv6_address: 2055:55:55:55::55/64
+        routing_loopback_id: 0
+        vtep_loopback_id: 1

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_vpc.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/topology_vpc.yaml
@@ -19,21 +19,20 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
-
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+---
+vxlan:
+  topology:
+    vpc_peers:
+      - peer1: << leaf1_hostname >>
+        peer1_peerlink_interfaces:
+          - name: Ethernet1/3
+          - name: Ethernet1/4
+        peer2: << leaf2_hostname >>
+        peer2_peerlink_interfaces:
+          - name: Ethernet1/3
+          - name: Ethernet1/4
+        fabric_peering: false
+        domain_id: 100
+        vtep_vip: "10.10.88.1"
+        vpc_interfaces:
+          - vpc_id: 30

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/underlay.yaml
@@ -1,0 +1,83 @@
+# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+vxlan:
+  underlay:
+    general:
+      routing_protocol: ospf
+      enable_ipv6_underlay: False
+      replication_mode: multicast
+      fabric_interface_numbering: p2p
+      subnet_mask: 30
+      manual_underlay_allocation: False
+      underlay_routing_loopback_id: 0
+      underlay_vtep_loopback_id: 1
+      underlay_routing_protocol_tag: UNDERLAY
+      underlay_rp_loopback_id: 3
+      intra_fabric_interface_mtu: 9216
+      layer2_host_interfacde_mtu: 9216
+      unshut_host_interfaces: True
+    ipv4:
+      underlay_routing_loopback_ip_range: 10.2.0.0/22
+      underlay_vtep_loopback_ip_range: 10.3.0.0/22
+      underlay_rp_loopback_ip_range: 10.254.254.0/24
+      underlay_subnet_ip_range: 10.4.0.0/16
+    ipv6:
+      enable_ipv6_link_local_address: True
+      underlay_subnet_mask: 64
+    ospf:
+      area_id: 0.0.0.0
+      authentication_enable: False
+      authentication_key_id: 0
+      authentication_key: ""
+    bgp:
+      authentication_enable: False
+      authentication_key_type: 3
+      authentication_key: ""
+    isis:
+      level: level-2
+      network_point_to_point: True
+      authentication_enable: False
+      authentication_key_id: 0
+      authentication_key: ""
+      overload_bit: False
+      overload_bit_elapsed_time: 5
+    multicast:
+      group_subnet: 239.1.1.0/25
+      rendezvous_points: 2
+      rp_mode: asm
+      underlay_rp_loopback_id: 254
+      trm_enable: False
+      trm_default_group: 239.1.1.0
+      underlay_primary_rp_loopback_id: 0
+      underlay_backup_rp_loopback_id: 1
+      underlay_second_backup_rp_loopback_id: 2
+      underlay_third_backup_rp_loopback_id: 3
+    bfd:
+      enable: False
+      ibgp: False
+      ospf: False
+      isis: False
+      pim: False
+      authentication_enable: False
+      authentication_key_id: 0
+      authentication_key: ""

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/vrfs.yaml
@@ -1,0 +1,96 @@
+# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+vxlan:
+  overlay_services:
+    vrfs:
+      - name: NetAsCodeVrf1
+        vrf_id: 150001
+        vlan_id: 2001
+        attach_group: all_leaf
+
+      - name: NetAsCodeVrf2
+        vrf_id: 150002
+        vlan_id: 2002
+        attach_group: leaf1_leaf2
+
+      - name: NetAsCodeVrf3
+        vrf_id: 150003
+        vlan_id: 2003
+        attach_group: leaf1_leaf2
+
+      - name: NetAsCodeVrf4
+        vrf_id: 150004
+        vlan_id: 2004
+        attach_group: leaf1_leaf2
+
+      - name: NetAsCodeVrf_Default
+        vrf_id: 150020
+        vlan_id: 2020
+        vrf_vlan_name: NetAsCodeVrf_Default_vlan2020
+        vrf_intf_desc: NetAsCodeVrf_Default
+        vrf_description: NetAsCodeVrf_Default
+        vrf_int_mtu: 9216
+        loopback_route_tag: 12345
+        max_bgp_paths: 8
+        max_ibgp_paths: 8
+        ipv6_linklocal_enable: True
+        adv_host_routes: True
+        adv_default_routes: True
+        static_default_route: True
+        # bgp_password: cisco
+        # bgp_password_encryption_type: 3
+        disable_rt_auto: True
+        export_evpn_rt: ""
+        export_mvpn_rt: ""
+        export_vpn_rt: ""
+        import_evpn_rt: ""
+        import_mvpn_rt: ""
+        import_vpn_rt: ""
+        netflow_enable: False
+        netflow_monitor: ""
+        no_rp: False
+        overlay_multicast_group: ""
+        redist_direct_routemap: ""
+        rp_address: 192.168.1.1/24
+        rp_external: False
+        rp_loopback_id: 0
+        trm_enable: False
+        trm_bgw_msite: False
+        underlay_mcast_ip: "224.1.1.1/32"
+        attach_group: all_leaf
+
+    vrf_attach_groups:
+      - name: all_leaf
+        switches:
+          - {hostname: << leaf1_ip >>}
+          - {hostname: << leaf2_ip >>}
+      - name: leaf1_leaf2
+        switches:
+          - {hostname: << leaf1_ip >>}
+          - {hostname: << leaf2_ip >>}
+      - name: leaf1
+        switches:
+          - {hostname: << leaf1_ip >>}
+      - name: leaf2
+        switches:
+          - {hostname: << leaf2_ip >>}

--- a/tests/integration/test_update_model_data.yml
+++ b/tests/integration/test_update_model_data.yml
@@ -53,7 +53,7 @@
   gather_facts: no
 
   tasks:
-    - name: Create New Directories for fabric_empty, fabric_full_large, fabric_full_small
+    - name: Create New Directories for fabric_empty, fabric_full_large, fabric_full_small, fabric_full_small_sha
       ansible.builtin.file:
         path: "{{ playbook_dir }}/host_vars/{{ item }}"
         state: directory
@@ -62,8 +62,9 @@
         - fabric_empty
         - fabric_full_large
         - fabric_full_small
+        - fabric_full_small_sha
 
-    - name: Copy content from host_vars/examples/fabric_* to fabric_empty, fabric_full_large, fabric_full_small
+    - name: Copy content from host_vars/examples/fabric_* to fabric_empty, fabric_full_large, fabric_full_small, fabric_full_small_sha
       ansible.builtin.copy:
         src: "{{ playbook_dir }}/host_vars/examples/{{ item.source_name }}/"
         dest: "{{ playbook_dir }}/host_vars/{{ item.dest_name }}"
@@ -75,6 +76,8 @@
           dest_name: fabric_full_large
         - source_name: fabric_full_small_example
           dest_name: fabric_full_small
+        - source_name: fabric_full_small_sha_example
+          dest_name: fabric_full_small_sha
 
     - name: Copy content from group_vars/ndfc/examples/main.yml group_vars/ndfc/main.yml
       ansible.builtin.copy:
@@ -88,8 +91,10 @@
           dest_name: fabric_full_large
         - source_name: fabric_full_small_example
           dest_name: fabric_full_small
+        - source_name: fabric_full_small_sha_example
+          dest_name: fabric_full_small_sha
 
-- hosts: fabric_empty, fabric_full_small, fabric_full_large
+- hosts: fabric_empty, fabric_full_small, fabric_full_large, fabric_full_small_sha
   gather_facts: no
 
   roles:

--- a/tests/integration/test_vxlan_small_sha.yml
+++ b/tests/integration/test_vxlan_small_sha.yml
@@ -19,21 +19,33 @@
 #
 # SPDX-License-Identifier: MIT
 
-all:
-  vars:
-    ansible_user: "admin"
-    ansible_python_interpreter: "~/.pyenv/shims/python"
-    ansible_httpapi_validate_certs: False
-    ansible_httpapi_use_ssl: True
+---
+# This playbook Run tests agains the data under tests/integration/host_vars/fabric_full_small_sha
 
-  children:
-    ndfc:
-      hosts:
-        fabric_empty:
-          ansible_host: << ndfc_ip >>
-        fabric_full_small:
-          ansible_host: < ndfc_ip >>
-        fabric_full_small_sha:
-          ansible_host: << ndfc_ip >> 
-        fabric_full_large:
-          ansible_host: << ndfc_ip >>
+# Instructions for using this playbook:
+#
+# 1. Make sure you run the tests/integration/test_update_model_data playbook first
+#
+# 3. Run the playbook with the following command:
+#    ansible-playbook -i tests/integration/test_inventory.yml tests/integration/test_vxlan_small_sha.yml
+
+# Reset Fabric
+- hosts: fabric_empty
+  gather_facts: no
+
+  roles:
+    - test_remove
+
+# Create and Deploy Fabric Configuration
+- hosts: fabric_full_small_sha
+  gather_facts: no
+
+  roles:
+    - test_create
+
+# Reset Fabric Back to Empty
+- hosts: fabric_empty
+  gather_facts: no
+
+  roles:
+    - test_remove


### PR DESCRIPTION
This tests and proves out the SHA auth_proto instead of using MD5.   

vxlan:
  global:
    name: netascode_fabric4
    ...
    auth_proto: SHA

VXLAN uses SNMP to discover devices.
Added the following config on the CML devices to test:
conf t
snmp-server user admin1 network-admin auth sha 

For testing in Fabric4 use: ndfc_device_username: admin1    with the normal password.