### PR TITLE
Remove DNS & NTP from Empty Fabric

### DIFF
--- a/tests/integration/host_vars/examples/fabric_empty_example/global.yaml
+++ b/tests/integration/host_vars/examples/fabric_empty_example/global.yaml
@@ -27,22 +27,6 @@ vxlan:
     route_reflectors: 4
     anycast_gateway_mac: 20:20:00:00:00:aa
     auth_proto: MD5
-    dns_servers:
-      - ip_address: 1.1.1.1
-        vrf: test
-      - ip_address: 5.5.5.1
-        vrf: test
-      - ip_address: 8.8.8.8
-        vrf: engineering
-    ntp_servers:
-      - ip_address: 15.3.3.3
-        vrf: test
-      - ip_address: 16.3.3.3
-        vrf: engineering
-      - ip_address: 17.3.3.3
-        vrf: engineering
-      - ip_address: 18.3.3.3
-        vrf: engineering
     vpc:
       peer_link_vlan: 3600
       peer_keep_alive: management


### PR DESCRIPTION
Remove DNS & NTP from empty fabric to create and have an no existing DNS and NTP data in the empty fabric. DNS & NTP are defined in other test scenarios already.