### PR TITLE
Add validate role as dependency to create, deploy & remove roles

### DIFF
--- a/roles/dtc/create/meta/main.yml
+++ b/roles/dtc/create/meta/main.yml
@@ -25,4 +25,6 @@ galaxy_info:
   license: LICENSE
   min_ansible_version: 2.14.15
 
-dependencies: [cisco.nac_dc_vxlan.dtc.common]
+dependencies:
+  - cisco.nac_dc_vxlan.validate
+  - cisco.nac_dc_vxlan.dtc.common

--- a/roles/dtc/deploy/meta/main.yml
+++ b/roles/dtc/deploy/meta/main.yml
@@ -25,4 +25,6 @@ galaxy_info:
   license: LICENSE
   min_ansible_version: 2.14.15
 
-dependencies: [cisco.nac_dc_vxlan.dtc.common]
+dependencies:
+  - cisco.nac_dc_vxlan.validate
+  - cisco.nac_dc_vxlan.dtc.common

--- a/roles/dtc/remove/meta/main.yml
+++ b/roles/dtc/remove/meta/main.yml
@@ -25,4 +25,6 @@ galaxy_info:
   license: LICENSE
   min_ansible_version: 2.14.15
 
-dependencies: [cisco.nac_dc_vxlan.dtc.common]
+dependencies:
+  - cisco.nac_dc_vxlan.validate
+  - cisco.nac_dc_vxlan.dtc.common


### PR DESCRIPTION
Add validate role as dependency to create, deploy & remove roles as validate is what produces the runtime data structure for all roles to-date. This will allow consumers to use each role independently if desired with minimal overhead.