### PR TITLE
IPv6 Underlay support

### DIFF
--- a/roles/dtc/common/templates/ndfc_create_fabric.j2
+++ b/roles/dtc/common/templates/ndfc_create_fabric.j2
@@ -107,9 +107,11 @@
   FABRIC_MTU: {{ underlay.general.intra_fabric_interface_mtu | default(defaults.vxlan.underlay.general.intra_fabric_interface_mtu) }}
   L2_HOST_INTF_MTU: {{ underlay.general.layer2_host_interfacde_mtu | default(defaults.vxlan.underlay.general.layer2_host_interfacde_mtu) }}
   HOST_INTF_ADMIN_STATE: {{ underlay.general.unshut_host_interfaces | default(defaults.vxlan.underlay.general.unshut_host_interfaces) }}
+{% if (underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) == 'False' %}
   FABRIC_INTERFACE_TYPE: {{ underlay.general.fabric_interface_numbering | default(defaults.vxlan.underlay.general.fabric_interface_numbering) }}
   SUBNET_TARGET_MASK: {{ underlay.general.subnet_mask | default(defaults.vxlan.underlay.general.subnet_mask) }}
   REPLICATION_MODE: {{ underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title }}
+{% endif %}
   LINK_STATE_ROUTING: {{ underlay.general.routing_protocol | default(defaults.vxlan.underlay.general.routing_protocol) }}
   LINK_STATE_ROUTING_TAG: {{ underlay.general.underlay_routing_protocol_tag | default(defaults.vxlan.underlay.general.underlay_routing_protocol_tag) }}
   UNDERLAY_IS_V6: {{ (underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) }}
@@ -158,7 +160,9 @@
 {# ------------------------------------------------------ #}
 {% elif (underlay.general.routing_protocol | default(defaults.vxlan.underlay.general.routing_protocol)) == 'ospf' %}
   OSPF_AREA_ID: {{ ospf.area_id | default(defaults.vxlan.underlay.ospf.area_id) }}
+{% if (underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) == 'False' %}
   OSPF_AUTH_ENABLE: {{ (ospf.authentication_enable | default(defaults.vxlan.underlay.ospf.authentication_enable) | title) }}
+{% endif %}
 {% if (underlay.ospf.authentication_enable | default(defaults.vxlan.underlay.ospf.authentication_enable) | title) == 'True' %}
   OSPF_AUTH_KEY_ID: {{ ospf.authentication_key_id | default(defaults.vxlan.underlay.ospf.authentication_key_id) }}
   OSPF_AUTH_KEY: {{ ospf.authentication_key | default(omit) }}
@@ -171,9 +175,11 @@
 {# Underlay IPv4 Parameters                               #}
 {# ------------------------------------------------------ #}
 {% if (underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | title) == 'False' %}
+{% if (underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) == 'False' %}
   LOOPBACK0_IP_RANGE: {{ ipv4.underlay_routing_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_routing_loopback_ip_range) }}
   LOOPBACK1_IP_RANGE: {{ ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
   SUBNET_RANGE: {{ ipv4.underlay_subnet_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_subnet_ip_range) }}
+{% endif %}
   ANYCAST_RP_IP_RANGE: {{ ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
 {% endif %}
 {# ------------------------------------------------------ #}
@@ -188,7 +194,9 @@
 {# ------------------------------------------------------ #}
 {# Underlay BGP Parameters                                #}
 {# ------------------------------------------------------ #}
+{% if (underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) == 'False' %}
   BGP_AUTH_ENABLE: {{ (bgp.authentication_enable | default(defaults.vxlan.underlay.bgp.authentication_enable) | title)}}
+{% endif %}
 {% if (bgp.authentication_enable | default(defaults.vxlan.underlay.bgp.authentication_enable) | title) == 'True' %}
   BGP_AUTH_KEY_TYPE: {{ bgp.authentication_key_type | default(defaults.vxlan.underlay.bgp.authentication_key_type) }}
   BGP_AUTH_KEY: {{ bgp.authentication_key | default(omit) }}
@@ -196,7 +204,9 @@
 {# ------------------------------------------------------ #}
 {# Underlay BFD Parameters                                #}
 {# ------------------------------------------------------ #}
+{% if (underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) == 'False' %}
   BFD_ENABLE: {{ bfd.enable | default(defaults.vxlan.underlay.bfd.enable) }}
+{% endif %}
 {% if (bfd.enable | default(defaults.vxlan.underlay.bfd.enable) | title) == 'True' %}
   BFD_IBGP_ENABLE: {{ bfd.ibgp | default(defaults.vxlan.underlay.bfd.ibgp) }}
   BFD_PIM_ENABLE: {{ bfd.pim | default(defaults.vxlan.underlay.bfd.pim) }}
@@ -209,5 +219,7 @@
 {# ------------------------------------------------------ #}
 {# Overlay Services Parameters                            #}
 {# ------------------------------------------------------ #}
+{% if (underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) == 'False' %}
   ENABLE_NETFLOW: {{ MD_Extended.vxlan.overlay_services.vrfs.netflow_enable | default(defaults.vxlan.overlay_services.vrfs.netflow_enable) }}
+{% endif %}
   NETFLOW_MONITOR_LIST: {{ MD_Extended.vxlan.overlay_services.vrfs.netflow_monitor | default(omit) }}


### PR DESCRIPTION
Updated ndfc_create_fabric.j2 to support the IPv6 underlay. Tested it the underlay config below and it works. 

`---
vxlan:
  underlay:
    general:
      enable_ipv6_underlay: true
      routing_protocol: ospf
      replication_mode: ingress
      underlay_routing_loopback_id: 0
      underlay_vtep_loopback_id: 1
      underlay_routing_protocol_tag: UNDERLAY
      intra_fabric_interface_mtu: 9216
      layer2_host_interfacde_mtu: 9216
      unshut_host_interfaces: True
    ipv6:
      enable_ipv6_link_local_address: true
      underlay_subnet_mask: 64
    ospf:
      area_id: 0.0.0.0`