### PR TITLE
Organize Rules Into Groups Aligned to Model & Add New Rules for VRFs & Networks

### DIFF
--- a/roles/validate/files/rules/required_rules/304_topology_switch_interfaces_members_unique.py
+++ b/roles/validate/files/rules/required_rules/304_topology_switch_interfaces_members_unique.py
@@ -2,7 +2,7 @@ import re
 
 
 class Rule:
-    id = "305"
+    id = "304"
     description = "\n1)Verify Interface names are Unique per switch\n2)Verify member interfaces are not repeated within a switch\n"
     severity = "HIGH"
 

--- a/roles/validate/files/rules/required_rules/305_topology_switch_interfaces_vpc.py
+++ b/roles/validate/files/rules/required_rules/305_topology_switch_interfaces_vpc.py
@@ -2,7 +2,7 @@ import re
 
 
 class Rule:
-    id = "306"
+    id = "305"
     description = (
         "Verify vPC interfaces are compliant with vPC configuration requirements"
     )

--- a/roles/validate/files/rules/required_rules/401_overlay_services_cross_reference.py
+++ b/roles/validate/files/rules/required_rules/401_overlay_services_cross_reference.py
@@ -1,5 +1,5 @@
 class Rule:
-    id = "304"
+    id = "401"
     description = "Cross Reference VRFs and Networks items in the Service Model"
     severity = "HIGH"
 
@@ -19,11 +19,7 @@ class Rule:
             if inventory["vxlan"].get("overlay_services", None):
                 if inventory.get("vxlan").get("overlay_services").get("vrfs", None):
                     sm_vrfs = inventory.get("vxlan").get("overlay_services").get("vrfs")
-        # Build list of VRF names from sm_networks
-        # network_vrf_names = []
-        # for net in sm_networks:
-        #     if net.get('vrf_name') is not None:
-        #         network_vrf_names.append(net.get('vrf_name'))
+  
         # Build list of VRF names from sm_vrfs
         if sm_vrfs and sm_networks:
             vrf_names = []

--- a/roles/validate/files/rules/required_rules/401_overlay_services_cross_reference.py
+++ b/roles/validate/files/rules/required_rules/401_overlay_services_cross_reference.py
@@ -19,7 +19,7 @@ class Rule:
             if inventory["vxlan"].get("overlay_services", None):
                 if inventory.get("vxlan").get("overlay_services").get("vrfs", None):
                     sm_vrfs = inventory.get("vxlan").get("overlay_services").get("vrfs")
-  
+
         # Build list of VRF names from sm_vrfs
         if sm_vrfs and sm_networks:
             vrf_names = []

--- a/roles/validate/files/rules/required_rules/402_overlay_services_vrfs.py
+++ b/roles/validate/files/rules/required_rules/402_overlay_services_vrfs.py
@@ -28,7 +28,7 @@ class Rule:
         for vrf in vrfs:
             current_vrf_netflow_status = vrf.get("netflow_enable", None)
             if current_vrf_netflow_status is not None:
-                if fabric_netflow_status == False and current_vrf_netflow_status == True:
+                if fabric_netflow_status is False and current_vrf_netflow_status is True:
                     results.append(
                         f"For vxlan.overlay_services.vrfs.{vrf['name']}.netflow_enable to be enabled, "
                         f"first vxlan.global.netflow.enable must be enabled (true)."
@@ -36,7 +36,7 @@ class Rule:
 
             current_vrf_trm_status = vrf.get("trm_enable", None)
             if current_vrf_trm_status is not None:
-                if fabric_trm_status == False and current_vrf_trm_status == True:
+                if fabric_trm_status is False and current_vrf_trm_status is True:
                     results.append(
                         f"For vxlan.overlay_services.vrfs.{vrf['name']}.trm_enable to be enabled, "
                         f"first vxlan.underlay.multicast.trm_enable must be enabled (true)."

--- a/roles/validate/files/rules/required_rules/402_overlay_services_vrfs.py
+++ b/roles/validate/files/rules/required_rules/402_overlay_services_vrfs.py
@@ -24,7 +24,7 @@ class Rule:
             if inventory["vxlan"].get("overlay_services", None):
                 if inventory["vxlan"].get("overlay_services").get("vrfs", None):
                     vrfs = inventory["vxlan"]["overlay_services"]["vrfs"]
-                    
+      
         for vrf in vrfs:
             current_vrf_netflow_status = vrf.get("netflow_enable", False)
             if current_vrf_netflow_status != netflow_status:

--- a/roles/validate/files/rules/required_rules/402_overlay_services_vrfs.py
+++ b/roles/validate/files/rules/required_rules/402_overlay_services_vrfs.py
@@ -24,7 +24,7 @@ class Rule:
             if inventory["vxlan"].get("overlay_services", None):
                 if inventory["vxlan"].get("overlay_services").get("vrfs", None):
                     vrfs = inventory["vxlan"]["overlay_services"]["vrfs"]
-      
+
         for vrf in vrfs:
             current_vrf_netflow_status = vrf.get("netflow_enable", False)
             if current_vrf_netflow_status != netflow_status:

--- a/roles/validate/files/rules/required_rules/402_overlay_services_vrfs.py
+++ b/roles/validate/files/rules/required_rules/402_overlay_services_vrfs.py
@@ -1,0 +1,43 @@
+class Rule:
+    id = "402"
+    description = "Verify VRF elements are enabled in fabric overlay services"
+    severity = "HIGH"
+
+    @classmethod
+    def match(cls, inventory):
+        results = []
+        netflow_status = False
+        trm_status = False
+        vrfs = []
+
+        if inventory.get("vxlan", None):
+            if inventory["vxlan"].get("global", None):
+                if inventory["vxlan"].get("global").get("netflow", None):
+                    netflow_status = inventory["vxlan"]["global"]["netflow"].get("enable", False)
+
+        if inventory.get("vxlan", None):
+            if inventory["vxlan"].get("underlay", None):
+                if inventory["vxlan"].get("underlay").get("multicast", None):
+                    trm_status = inventory["vxlan"]["underlay"]["multicast"].get("trm_enable", False)
+
+        if inventory.get("vxlan", None):
+            if inventory["vxlan"].get("overlay_services", None):
+                if inventory["vxlan"].get("overlay_services").get("vrfs", None):
+                    vrfs = inventory["vxlan"]["overlay_services"]["vrfs"]
+                    
+        for vrf in vrfs:
+            current_vrf_netflow_status = vrf.get("netflow_enable", False)
+            if current_vrf_netflow_status != netflow_status:
+                results.append(
+                    f"For vxlan.overlay_services.vrfs.{vrf['name']}.netflow_enable to be enabled, "
+                    f"first vxlan.global.netflow.enable must be enabled (true)."
+                )
+
+            current_vrf_trm_status = vrf.get("trm_enable", False)
+            if current_vrf_trm_status != trm_status:
+                results.append(
+                    f"For vxlan.overlay_services.vrfs.{vrf['name']}.trm_enable to be enabled, "
+                    f"first vxlan.underlay.multicast.trm_enable must be enabled (true)."
+                )
+
+        return results

--- a/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
+++ b/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
@@ -18,7 +18,7 @@ class Rule:
             if inventory["vxlan"].get("overlay_services", None):
                 if inventory["vxlan"].get("overlay_services").get("networks", None):
                     networks = inventory["vxlan"]["overlay_services"]["networks"]
-                    
+       
         for network in networks:
             current_network_netflow_status = network.get("netflow_enable", False)
             if current_network_netflow_status != netflow_status:

--- a/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
+++ b/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
@@ -22,7 +22,7 @@ class Rule:
         for network in networks:
             current_network_netflow_status = network.get("netflow_enable", None)
             if current_network_netflow_status is not None:
-                if fabric_netflow_status == False and current_network_netflow_status == True:
+                if fabric_netflow_status is False and current_network_netflow_status is True:
                     results.append(
                         f"For vxlan.overlay_services.networks.{network['name']}.netflow_enable to be enabled, "
                         f"first vxlan.global.netflow.enable must be enabled (true)."

--- a/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
+++ b/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
@@ -6,13 +6,13 @@ class Rule:
     @classmethod
     def match(cls, inventory):
         results = []
-        netflow_status = False
+        fabric_netflow_status = False
         networks = []
 
         if inventory.get("vxlan", None):
             if inventory["vxlan"].get("global", None):
                 if inventory["vxlan"].get("global").get("netflow", None):
-                    netflow_status = inventory["vxlan"]["global"]["netflow"].get("enable", False)
+                    fabric_netflow_status = inventory["vxlan"]["global"]["netflow"].get("enable", False)
 
         if inventory.get("vxlan", None):
             if inventory["vxlan"].get("overlay_services", None):
@@ -20,11 +20,12 @@ class Rule:
                     networks = inventory["vxlan"]["overlay_services"]["networks"]
 
         for network in networks:
-            current_network_netflow_status = network.get("netflow_enable", False)
-            if current_network_netflow_status != netflow_status:
-                results.append(
-                    f"For vxlan.overlay_services.networks.{network['name']}.netflow_enable to be enabled, "
-                    f"first vxlan.global.netflow.enable must be enabled (true)."
-                )
+            current_network_netflow_status = network.get("netflow_enable", None)
+            if current_network_netflow_status is not None:
+                if fabric_netflow_status == False and current_network_netflow_status == True:
+                    results.append(
+                        f"For vxlan.overlay_services.networks.{network['name']}.netflow_enable to be enabled, "
+                        f"first vxlan.global.netflow.enable must be enabled (true)."
+                    )
 
         return results

--- a/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
+++ b/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
@@ -18,7 +18,7 @@ class Rule:
             if inventory["vxlan"].get("overlay_services", None):
                 if inventory["vxlan"].get("overlay_services").get("networks", None):
                     networks = inventory["vxlan"]["overlay_services"]["networks"]
-       
+
         for network in networks:
             current_network_netflow_status = network.get("netflow_enable", False)
             if current_network_netflow_status != netflow_status:

--- a/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
+++ b/roles/validate/files/rules/required_rules/403_overlay_services_networks.py
@@ -1,0 +1,30 @@
+class Rule:
+    id = "403"
+    description = "Verify Network elements are enabled in fabric overlay services"
+    severity = "HIGH"
+
+    @classmethod
+    def match(cls, inventory):
+        results = []
+        netflow_status = False
+        networks = []
+
+        if inventory.get("vxlan", None):
+            if inventory["vxlan"].get("global", None):
+                if inventory["vxlan"].get("global").get("netflow", None):
+                    netflow_status = inventory["vxlan"]["global"]["netflow"].get("enable", False)
+
+        if inventory.get("vxlan", None):
+            if inventory["vxlan"].get("overlay_services", None):
+                if inventory["vxlan"].get("overlay_services").get("networks", None):
+                    networks = inventory["vxlan"]["overlay_services"]["networks"]
+                    
+        for network in networks:
+            current_network_netflow_status = network.get("netflow_enable", False)
+            if current_network_netflow_status != netflow_status:
+                results.append(
+                    f"For vxlan.overlay_services.networks.{network['name']}.netflow_enable to be enabled, "
+                    f"first vxlan.global.netflow.enable must be enabled (true)."
+                )
+
+        return results


### PR DESCRIPTION
Organize rules to align with data model for easier sifting through over time.

Add two new rules, one for VRFs and another for Networks. 
The VRF rules check that if a user wants to enable TRM or Netflow that the fabric setting is enabled.
The Network rule checks that if a user wants to enable Netflow that the fabric setting is enabled.
