### PR TITLE
Update validate action plugin to work with iac-validate >=0.2.5

### DIFF
--- a/plugins/action/common/nac_dc_validate.py
+++ b/plugins/action/common/nac_dc_validate.py
@@ -29,6 +29,7 @@ from ansible.plugins.action import ActionBase
 
 import iac_validate.validator
 from iac_validate.yaml import load_yaml_files
+from iac_validate.cli.options import DEFAULT_SCHEMA
 import os
 
 display = Display()
@@ -65,10 +66,8 @@ class ActionModule(ActionBase):
             results['msg'] = "The data directory ({0}) for this fabric is empty!".format(mdata)
             return results
 
-        if schema is None:
-            schema = ""
-        if rules is None:
-            rules = ""
+        if schema == '':
+            schema = DEFAULT_SCHEMA
 
         validator = iac_validate.validator.Validator(schema, rules)
         if schema:

--- a/roles/validate/tasks/sub_main.yml
+++ b/roles/validate/tasks/sub_main.yml
@@ -70,6 +70,7 @@
     rules: "{{ enhanced_rules_path }}"
   vars:
     data_path: "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}"
+  when: enhanced_rules_path is defined and enhanced_rules_path
   delegate_to: localhost
 
 - name: Verify Connection to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}


### PR DESCRIPTION
- Update nac_dc_validate action plugin to work with iac-validate 0.2.5 and greater.
- Add a when condition to only execute the enhanced rules if defined and not an empty string.