### PR TITLE
fixing a parameter name in the test update data model

### DIFF
--- a/tests/integration/roles/test_update_model_data/tasks/main.yml
+++ b/tests/integration/roles/test_update_model_data/tasks/main.yml
@@ -63,7 +63,7 @@
   ansible.builtin.replace:
     path: "{{ playbook_dir }}/group_vars/ndfc/main.yml"
     regexp: 'ndfc_switch_password\:\s+(\S+)'
-    replace: "ndfc_switch_password: {{ fabric_switch_password }}"
+    replace: "ndfc_switch_password: {{ ndfc_switch_password }}"
   delegate_to: 127.0.0.1
 
 - name: Replace << fabric_name >> in test data model files


### PR DESCRIPTION
test_update_model_data.yml is failing due to a typo in the test_update_model_data/tasks/main.yml

Error:

fatal: [fabric_full_small_isis_ingress -> 127.0.0.1]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'fabric_switch_password' is undefined. 'fabric_switch_password' is undefined\n\nThe error appears to be in '/Users/devegupt/Library/CloudStorage/OneDrive-Cisco/SaC/sac-workspace/sac-ndfc/nac-ndfc/collections/ansible_collections/cisco/nac_dc_vxlan/tests/integration/roles/test_update_model_data/tasks/main.yml': line 62, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Replace ndfc_switch_password Password in Group Vars\n  ^ here\n"}