### PR TITLE
Prepend fabric name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ roles/dtc/deploy/files
 roles/dtc/remove/files
 roles/validate/files/schema.yaml
 roles/validate/files/run_map.yml
+roles/validate/files/*_run_map.yml
 !roles/validate/files/rules/enhanced_rules
 !roles/validate/files/rules/enhanced_rules/.gitkeep
 !roles/validate/files/rules/required_rules/*

--- a/plugins/action/common/read_run_map.py
+++ b/plugins/action/common/read_run_map.py
@@ -39,7 +39,8 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         results['diff_run'] = True
 
-        fabric_name = task_vars['inventory_hostname']
+        model_data = task_vars['model_data']['data']
+        fabric_name = model_data["vxlan"]["global"]["name"]
 
         if 'dtc' in task_vars['role_path']:
             common_role_path = os.path.dirname(task_vars['role_path'])

--- a/plugins/action/common/read_run_map.py
+++ b/plugins/action/common/read_run_map.py
@@ -39,13 +39,15 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         results['diff_run'] = True
 
+        fabric_name = task_vars['inventory_hostname']
+
         if 'dtc' in task_vars['role_path']:
             common_role_path = os.path.dirname(task_vars['role_path'])
             common_role_path = os.path.dirname(common_role_path) + '/validate/files'
         else:
             common_role_path = os.path.dirname(task_vars['role_path']) + '/validate/files'
 
-        run_map_file_path = common_role_path + '/run_map.yml'
+        run_map_file_path = common_role_path + f'/{fabric_name}_run_map.yml'
 
         if not os.path.exists(run_map_file_path):
             # Return failure if run_map file does not exist

--- a/plugins/action/common/run_map.py
+++ b/plugins/action/common/run_map.py
@@ -41,8 +41,9 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         results['failed'] = False
 
-        fabric_name = task_vars['inventory_hostname']
+        model_data = task_vars['model_data']['data']
         stage = self._task.args['stage']
+        fabric_name = model_data["vxlan"]["global"]["name"]
 
         if 'dtc' in task_vars['role_path']:
             common_role_path = os.path.dirname(task_vars['role_path'])

--- a/plugins/action/common/run_map.py
+++ b/plugins/action/common/run_map.py
@@ -41,6 +41,7 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         results['failed'] = False
 
+        fabric_name = task_vars['inventory_hostname']
         stage = self._task.args['stage']
 
         if 'dtc' in task_vars['role_path']:
@@ -52,7 +53,8 @@ class ActionModule(ActionBase):
         if not os.path.exists(common_role_path):
             # Return failure if the common role path does not exist
             results['failed'] = True
-        run_map_file_path = common_role_path + '/run_map.yml'
+
+        run_map_file_path = common_role_path + f'/{fabric_name}_run_map.yml'
 
         if stage == 'starting_execution':
             updated_run_map = {}

--- a/roles/validate/tasks/sub_main.yml
+++ b/roles/validate/tasks/sub_main.yml
@@ -31,22 +31,6 @@
 
 - ansible.builtin.debug: msg="Inventory Directory - {{ inventory_dir }}"
 
-- name: Read Run Map From Previous Run
-  cisco.nac_dc_vxlan.common.read_run_map:
-  register: run_map_read_result
-  delegate_to: localhost
-
-- name: Debug Run Map Read Result
-  ansible.builtin.debug:
-    msg: "{{ run_map_read_result }}"
-  delegate_to: localhost
-
-- name: Initialize Run Map
-  cisco.nac_dc_vxlan.common.run_map:
-    stage: starting_execution
-  register: run_map
-  delegate_to: localhost
-
 - name: Validate NDFC Service Model Data
   ansible.builtin.debug: msg="Calling Role Validate - nac_dc_vxlan.validate"
 
@@ -87,6 +71,22 @@
   vars:
     data_path: "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}"
   when: enhanced_rules_path is defined and enhanced_rules_path
+  delegate_to: localhost
+
+- name: Read Run Map From Previous Run
+  cisco.nac_dc_vxlan.common.read_run_map:
+  register: run_map_read_result
+  delegate_to: localhost
+
+- name: Debug Run Map Read Result
+  ansible.builtin.debug:
+    msg: "{{ run_map_read_result }}"
+  delegate_to: localhost
+
+- name: Initialize Run Map
+  cisco.nac_dc_vxlan.common.run_map:
+    stage: starting_execution
+  register: run_map
   delegate_to: localhost
 
 - name: Verify Connection to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}

--- a/roles/validate/tasks/sub_main.yml
+++ b/roles/validate/tasks/sub_main.yml
@@ -40,6 +40,12 @@
 - ansible.builtin.debug: msg="Workflow is Direct to Controller (DTC)"
   when: hostvars[inventory_hostname]['ansible_network_os'] == "cisco.dcnm.dcnm"
 
+- name: Verify Connection to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
+  ansible.builtin.include_tasks: verify_ndfc_connectivity.yml
+
+- name: Verify Authorization to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
+  ansible.builtin.include_tasks: verify_ndfc_authorization.yml
+
 - name: Check for Schema Path Being Defined
   ansible.builtin.set_fact:
     schema_path: ''
@@ -73,28 +79,6 @@
   when: enhanced_rules_path is defined and enhanced_rules_path
   delegate_to: localhost
 
-- name: Read Run Map From Previous Run
-  cisco.nac_dc_vxlan.common.read_run_map:
-  register: run_map_read_result
-  delegate_to: localhost
-
-- name: Debug Run Map Read Result
-  ansible.builtin.debug:
-    msg: "{{ run_map_read_result }}"
-  delegate_to: localhost
-
-- name: Initialize Run Map
-  cisco.nac_dc_vxlan.common.run_map:
-    stage: starting_execution
-  register: run_map
-  delegate_to: localhost
-
-- name: Verify Connection to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
-  ansible.builtin.include_tasks: verify_ndfc_connectivity.yml
-
-- name: Verify Authorization to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
-  ansible.builtin.include_tasks: verify_ndfc_authorization.yml
-
 - name: Prepare Service Model
   cisco.nac_dc_vxlan.common.prepare_service_model:
     inventory_hostname: "{{ inventory_hostname }}"
@@ -117,6 +101,24 @@
   cisco.nac_dc_vxlan.common.check_roles:
     role_list: "{{ role_names }}"
   register: check_roles
+  delegate_to: localhost
+
+- name: Read Run Map From Previous Run
+  cisco.nac_dc_vxlan.common.read_run_map:
+    model_data: "{{ MD_Extended }}"
+  register: run_map_read_result
+  delegate_to: localhost
+
+- name: Debug Run Map Read Result
+  ansible.builtin.debug:
+    msg: "{{ run_map_read_result }}"
+  delegate_to: localhost
+
+- name: Initialize Run Map
+  cisco.nac_dc_vxlan.common.run_map:
+    model_data: "{{ MD_Extended }}"
+    stage: starting_execution
+  register: run_map
   delegate_to: localhost
 
 - name: Manage Previous Service Model Data Files


### PR DESCRIPTION
Prepend fabric name to prevent over-writing incorrect file and fabric map.

Resolves #184 