### PR TITLE
Change attach_group for vrfs and networks

### DIFF
--- a/plugins/action/common/prepare_plugins/prep_104_fabric_overlay_services.py
+++ b/plugins/action/common/prepare_plugins/prep_104_fabric_overlay_services.py
@@ -47,11 +47,11 @@ class PreparePlugin:
                     elif found_switch.get('management').get('management_ipv6_address'):
                         switch['hostname'] = found_switch['management']['management_ipv6_address']
 
-        # Remove attach_group from vrf if the group_name is not defined
+        # Remove vrf_attach_group from vrf if the group_name is not defined
         for vrf in model_data['vxlan']['overlay_services']['vrfs']:
-            if 'attach_group' in vrf:
-                if vrf.get('attach_group') not in vrf_grp_name_list:
-                    del vrf['attach_group']
+            if 'vrf_attach_group' in vrf:
+                if vrf.get('vrf_attach_group') not in vrf_grp_name_list:
+                    del vrf['vrf_attach_group']
 
         # Rebuild sm_data['vxlan']['overlay_services']['network_attach_groups'] into
         # a structure that is easier to use.
@@ -71,11 +71,11 @@ class PreparePlugin:
                     elif found_switch.get('management').get('management_ipv6_address'):
                         switch['hostname'] = found_switch['management']['management_ipv6_address']
 
-        # Remove attach_group from net if the group_name is not defined
+        # Remove network_attach_group from net if the group_name is not defined
         for net in model_data['vxlan']['overlay_services']['networks']:
-            if 'attach_group' in net:
-                if net.get('attach_group') not in net_grp_name_list:
-                    del net['attach_group']
+            if 'network_attach_group' in net:
+                if net.get('network_attach_group') not in net_grp_name_list:
+                    del net['network_attach_group']
 
         self.kwargs['results']['model_extended'] = model_data
         return self.kwargs['results']

--- a/roles/dtc/common/templates/ndfc_attach_networks.j2
+++ b/roles/dtc/common/templates/ndfc_attach_networks.j2
@@ -67,9 +67,9 @@
 {# ------------------------------------------------------ #}
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}
-{% if net['attach_group'] is defined %}
+{% if net['network_attach_group'] is defined %}
   attach:
-{% for attach in MD_Extended.vxlan.overlay_services.network_attach_groups_dict[net['attach_group']] %}
+{% for attach in MD_Extended.vxlan.overlay_services.network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['hostname'] }}
       ports: {{ attach['ports'] }}
 {% endfor %}

--- a/roles/dtc/common/templates/ndfc_attach_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_attach_vrfs.j2
@@ -47,9 +47,9 @@
 {# ------------------------------------------------------ #}
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}
-{% if vrf['attach_group'] is defined %}
+{% if vrf['vrf_attach_group'] is defined %}
   attach:
-{% for attach in MD_Extended.vxlan.overlay_services.vrf_attach_groups_dict[vrf['attach_group']] %}
+{% for attach in MD_Extended.vxlan.overlay_services.vrf_attach_groups_dict[vrf['vrf_attach_group']] %}
     - ip_address: {{ attach['hostname'] }}
 {% endfor %}
   deploy: false

--- a/tests/integration/host_vars/examples/fabric_full_large_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_large_example/networks.yaml
@@ -29,7 +29,7 @@ vxlan:
         net_id: 130001
         vlan_name: NetAsCodeNet1_vlan2301
         gw_ip_address: "192.168.12.1/24"
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet2
         vrf_name: NetAsCodeVrf2
@@ -37,7 +37,7 @@ vxlan:
         vlan_id: 2302
         vlan_name: NetAsCodeNet2_vlan2302
         gw_ip_address: "192.168.12.2/24"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet3
         vrf_name: NetAsCodeVrf3
@@ -50,7 +50,7 @@ vxlan:
         l3gw_on_border: True
         mtu_l3intf: 7600
         int_desc: "Configured by NetAsCode"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet4
         vrf_name: NetAsCodeVrf4
@@ -60,7 +60,7 @@ vxlan:
         gw_ip_address: "192.168.12.4/24"
         route_tag: 54321
         multicast_group_address: 239.1.1.1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet5
         vrf_name: NetAsCodeVrf5
@@ -84,14 +84,14 @@ vxlan:
           - ip_address: 10.255.255.103
             vrf: default
         dhcp_loopback_id: 35
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet6
         is_l2_only: True
         net_id: 130006
         vlan_id: 2306
         vlan_name: NetAsCodeNet6_vlan2306
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet7
         vrf_name: NetAsCodeVrf7
@@ -100,7 +100,7 @@ vxlan:
         vlan_name: NetAsCodeNet7_vlan2307
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet8
         vrf_name: NetAsCodeVrf8
@@ -108,7 +108,7 @@ vxlan:
         vlan_id: 2308
         vlan_name: NetAsCodeNet8_vlan2308
         trm_enable: True
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet9
         vrf_name: NetAsCodeVrf9
@@ -117,7 +117,7 @@ vxlan:
         vlan_name: NetAsCodeNet9_vlan2309
         multicast_group_address: 239.1.1.1
         arp_suppress: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet_Default
         is_l2_only: False
@@ -143,7 +143,7 @@ vxlan:
             route_tag: 12345
         trm_enable: False
         netflow_enable: False
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet_Full
         is_l2_only: False
@@ -176,7 +176,7 @@ vxlan:
         trm_enable: True
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
     network_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_large_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_large_example/vrfs.yaml
@@ -26,24 +26,24 @@ vxlan:
       - name: NetAsCodeVrf1
         vrf_id: 150001
         vlan_id: 2001
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf2
         vrf_id: 150002
         vlan_id: 2002
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf3
         vrf_id: 150003
         vlan_id: 2003
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf4
         vrf_id: 150004
         vlan_id: 2004
         vrf_int_mtu: 9000
         loopback_route_tag: 54321
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf5
         vrf_id: 150005
@@ -51,7 +51,7 @@ vxlan:
         vrf_description: NetAsCodeVrf5_Netflow_only
         netflow_enable: true
         netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf6
         vrf_id: 150006
@@ -65,7 +65,7 @@ vxlan:
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
         trm_bgw_msite: true
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf7
         vrf_id: 150007
@@ -74,7 +74,7 @@ vxlan:
         trm_enable: true
         no_rp: true
         underlay_mcast_ip: 239.1.1.0
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf8
         vrf_id: 150008
@@ -85,7 +85,7 @@ vxlan:
         rp_address: 10.100.100.100
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf9
         vrf_id: 150009
@@ -95,7 +95,7 @@ vxlan:
         max_ibgp_paths: 4
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf_Default
         vrf_id: 150020
@@ -131,7 +131,7 @@ vxlan:
         trm_enable: True
         trm_bgw_msite: False
         underlay_mcast_ip: "224.1.1.1"
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf_Full
         vrf_id: 150030
@@ -166,7 +166,7 @@ vxlan:
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
         trm_bgw_msite: False
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
     vrf_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_ingress_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_ingress_example/networks.yaml
@@ -29,7 +29,7 @@ vxlan:
         net_id: 130001
         vlan_name: NetAsCodeNet1_vlan2301
         gw_ip_address: "192.168.12.1/24"
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet2
         vrf_name: NetAsCodeVrf2
@@ -37,7 +37,7 @@ vxlan:
         vlan_id: 2302
         vlan_name: NetAsCodeNet2_vlan2302
         gw_ip_address: "192.168.12.2/24"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet3
         vrf_name: NetAsCodeVrf3
@@ -50,7 +50,7 @@ vxlan:
         l3gw_on_border: True
         mtu_l3intf: 7600
         int_desc: "Configured by NetAsCode"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet4
         vrf_name: NetAsCodeVrf4
@@ -60,7 +60,7 @@ vxlan:
         gw_ip_address: "192.168.12.4/24"
         route_tag: 54321
         multicast_group_address: 239.1.1.1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet5
         vrf_name: NetAsCodeVrf5
@@ -84,14 +84,14 @@ vxlan:
           - ip_address: 10.255.255.103
             vrf: default
         dhcp_loopback_id: 35
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet6
         is_l2_only: True
         net_id: 130006
         vlan_id: 2306
         vlan_name: NetAsCodeNet6_vlan2306
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet7
         vrf_name: NetAsCodeVrf7
@@ -100,7 +100,7 @@ vxlan:
         vlan_name: NetAsCodeNet7_vlan2307
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet8
         vrf_name: NetAsCodeVrf8
@@ -108,7 +108,7 @@ vxlan:
         vlan_id: 2308
         vlan_name: NetAsCodeNet8_vlan2308
         trm_enable: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet9
         vrf_name: NetAsCodeVrf9
@@ -117,7 +117,7 @@ vxlan:
         vlan_name: NetAsCodeNet9_vlan2309
         multicast_group_address: 239.1.1.1
         arp_suppress: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet_Default
         is_l2_only: False
@@ -144,7 +144,7 @@ vxlan:
             route_tag: 12345
         trm_enable: False
         vlan_netflow_monitor: vlan55
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet_Full
         is_l2_only: False
@@ -177,7 +177,7 @@ vxlan:
         trm_enable: False
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf2
+        network_attach_group: leaf2
 
     network_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_ingress_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_ingress_example/vrfs.yaml
@@ -26,24 +26,24 @@ vxlan:
       - name: NetAsCodeVrf1
         vrf_id: 150001
         vlan_id: 2001
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf2
         vrf_id: 150002
         vlan_id: 2002
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf3
         vrf_id: 150003
         vlan_id: 2003
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf4
         vrf_id: 150004
         vlan_id: 2004
         vrf_int_mtu: 9000
         loopback_route_tag: 54321
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf5
         vrf_id: 150005
@@ -51,7 +51,7 @@ vxlan:
         vrf_description: NetAsCodeVrf5_Netflow_only
         netflow_enable: true
         netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf6
         vrf_id: 150006
@@ -59,7 +59,7 @@ vxlan:
         vrf_description: NetAsCodeVrf6_No_TRM_No_NetFlow
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf9
         vrf_id: 150009
@@ -69,7 +69,7 @@ vxlan:
         max_ibgp_paths: 4
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf_Default
         vrf_id: 150020
@@ -105,7 +105,7 @@ vxlan:
         trm_enable: True
         trm_bgw_msite: False
         underlay_mcast_ip: "224.1.1.1"
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf_Full
         vrf_id: 150030
@@ -137,7 +137,7 @@ vxlan:
         rp_external: False
         overlay_multicast_group: ""
         trm_bgw_msite: False
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
     vrf_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_asm_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_asm_example/networks.yaml
@@ -29,7 +29,7 @@ vxlan:
         net_id: 130001
         vlan_name: NetAsCodeNet1_vlan2301
         gw_ip_address: "192.168.12.1/24"
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet2
         vrf_name: NetAsCodeVrf2
@@ -37,7 +37,7 @@ vxlan:
         vlan_id: 2302
         vlan_name: NetAsCodeNet2_vlan2302
         gw_ip_address: "192.168.12.2/24"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet3
         vrf_name: NetAsCodeVrf3
@@ -50,7 +50,7 @@ vxlan:
         l3gw_on_border: True
         mtu_l3intf: 7600
         int_desc: "Configured by NetAsCode"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet4
         vrf_name: NetAsCodeVrf4
@@ -60,7 +60,7 @@ vxlan:
         gw_ip_address: "192.168.12.4/24"
         route_tag: 54321
         multicast_group_address: 239.1.1.1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet5
         vrf_name: NetAsCodeVrf5
@@ -84,14 +84,14 @@ vxlan:
           - ip_address: 10.255.255.103
             vrf: default
         dhcp_loopback_id: 35
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet6
         is_l2_only: True
         net_id: 130006
         vlan_id: 2306
         vlan_name: NetAsCodeNet6_vlan2306
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet7
         vrf_name: NetAsCodeVrf7
@@ -100,7 +100,7 @@ vxlan:
         vlan_name: NetAsCodeNet7_vlan2307
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet8
         vrf_name: NetAsCodeVrf8
@@ -108,7 +108,7 @@ vxlan:
         vlan_id: 2308
         vlan_name: NetAsCodeNet8_vlan2308
         trm_enable: True
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet9
         vrf_name: NetAsCodeVrf9
@@ -117,7 +117,7 @@ vxlan:
         vlan_name: NetAsCodeNet9_vlan2309
         multicast_group_address: 239.1.1.1
         arp_suppress: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet_Default
         is_l2_only: False
@@ -144,7 +144,7 @@ vxlan:
             route_tag: 12345
         trm_enable: False
         vlan_netflow_monitor: vlan55
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet_Full
         is_l2_only: False
@@ -177,7 +177,7 @@ vxlan:
         trm_enable: True
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf2
+        network_attach_group: leaf2
 
     network_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_asm_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_asm_example/vrfs.yaml
@@ -26,24 +26,24 @@ vxlan:
       - name: NetAsCodeVrf1
         vrf_id: 150001
         vlan_id: 2001
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf2
         vrf_id: 150002
         vlan_id: 2002
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf3
         vrf_id: 150003
         vlan_id: 2003
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf4
         vrf_id: 150004
         vlan_id: 2004
         vrf_int_mtu: 9000
         loopback_route_tag: 54321
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf5
         vrf_id: 150005
@@ -51,7 +51,7 @@ vxlan:
         vrf_description: NetAsCodeVrf5_Netflow_only
         netflow_enable: true
         netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf6
         vrf_id: 150006
@@ -65,7 +65,7 @@ vxlan:
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
         trm_bgw_msite: true
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf7
         vrf_id: 150007
@@ -74,7 +74,7 @@ vxlan:
         trm_enable: true
         no_rp: true
         underlay_mcast_ip: 239.1.1.0
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf8
         vrf_id: 150008
@@ -85,7 +85,7 @@ vxlan:
         rp_address: 10.100.100.100
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf9
         vrf_id: 150009
@@ -95,7 +95,7 @@ vxlan:
         max_ibgp_paths: 4
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf_Default
         vrf_id: 150020
@@ -131,7 +131,7 @@ vxlan:
         trm_enable: True
         trm_bgw_msite: False
         underlay_mcast_ip: "224.1.1.1"
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf_Full
         vrf_id: 150030
@@ -166,7 +166,7 @@ vxlan:
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
         trm_bgw_msite: False
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
     vrf_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_bidir_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_bidir_example/networks.yaml
@@ -29,7 +29,7 @@ vxlan:
         net_id: 130001
         vlan_name: NetAsCodeNet1_vlan2301
         gw_ip_address: "192.168.12.1/24"
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet2
         vrf_name: NetAsCodeVrf2
@@ -37,7 +37,7 @@ vxlan:
         vlan_id: 2302
         vlan_name: NetAsCodeNet2_vlan2302
         gw_ip_address: "192.168.12.2/24"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet3
         vrf_name: NetAsCodeVrf3
@@ -50,7 +50,7 @@ vxlan:
         l3gw_on_border: True
         mtu_l3intf: 7600
         int_desc: "Configured by NetAsCode"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet4
         vrf_name: NetAsCodeVrf4
@@ -60,7 +60,7 @@ vxlan:
         gw_ip_address: "192.168.12.4/24"
         route_tag: 54321
         multicast_group_address: 239.1.1.1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet5
         vrf_name: NetAsCodeVrf5
@@ -84,14 +84,14 @@ vxlan:
           - ip_address: 10.255.255.103
             vrf: default
         dhcp_loopback_id: 35
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet6
         is_l2_only: True
         net_id: 130006
         vlan_id: 2306
         vlan_name: NetAsCodeNet6_vlan2306
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet7
         vrf_name: NetAsCodeVrf7
@@ -100,7 +100,7 @@ vxlan:
         vlan_name: NetAsCodeNet7_vlan2307
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet8
         vrf_name: NetAsCodeVrf8
@@ -108,7 +108,7 @@ vxlan:
         vlan_id: 2308
         vlan_name: NetAsCodeNet8_vlan2308
         trm_enable: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet9
         vrf_name: NetAsCodeVrf9
@@ -117,7 +117,7 @@ vxlan:
         vlan_name: NetAsCodeNet9_vlan2309
         multicast_group_address: 239.1.1.1
         arp_suppress: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet_Default
         is_l2_only: False
@@ -144,7 +144,7 @@ vxlan:
             route_tag: 12345
         trm_enable: False
         vlan_netflow_monitor: vlan55
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet_Full
         is_l2_only: False
@@ -177,7 +177,7 @@ vxlan:
         trm_enable: False
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf2
+        network_attach_group: leaf2
 
     network_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_bidir_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_bidir_example/vrfs.yaml
@@ -26,17 +26,17 @@ vxlan:
       - name: NetAsCodeVrf1
         vrf_id: 150001
         vlan_id: 2001
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf2
         vrf_id: 150002
         vlan_id: 2002
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf3
         vrf_id: 150003
         vlan_id: 2003
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf5
         vrf_id: 150005
@@ -44,7 +44,7 @@ vxlan:
         vrf_description: NetAsCodeVrf5_Netflow_only
         netflow_enable: true
         netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf6
         vrf_id: 150006
@@ -52,7 +52,7 @@ vxlan:
         vrf_description: NetAsCodeVrf6_No_TRM_No_NetFlow
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf9
         vrf_id: 150009
@@ -62,7 +62,7 @@ vxlan:
         max_ibgp_paths: 4
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf_Default
         vrf_id: 150020
@@ -98,7 +98,7 @@ vxlan:
         trm_enable: True
         trm_bgw_msite: False
         underlay_mcast_ip: "224.1.1.1"
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf_Full
         vrf_id: 150030
@@ -130,7 +130,7 @@ vxlan:
         rp_external: False
         overlay_multicast_group: ""
         trm_bgw_msite: False
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
     vrf_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_ingress_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_ingress_example/networks.yaml
@@ -29,7 +29,7 @@ vxlan:
         net_id: 130001
         vlan_name: NetAsCodeNet1_vlan2301
         gw_ip_address: "192.168.12.1/24"
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet2
         vrf_name: NetAsCodeVrf2
@@ -37,7 +37,7 @@ vxlan:
         vlan_id: 2302
         vlan_name: NetAsCodeNet2_vlan2302
         gw_ip_address: "192.168.12.2/24"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet3
         vrf_name: NetAsCodeVrf3
@@ -50,7 +50,7 @@ vxlan:
         l3gw_on_border: True
         mtu_l3intf: 7600
         int_desc: "Configured by NetAsCode"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet4
         vrf_name: NetAsCodeVrf4
@@ -60,7 +60,7 @@ vxlan:
         gw_ip_address: "192.168.12.4/24"
         route_tag: 54321
         multicast_group_address: 239.1.1.1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet5
         vrf_name: NetAsCodeVrf5
@@ -84,14 +84,14 @@ vxlan:
           - ip_address: 10.255.255.103
             vrf: default
         dhcp_loopback_id: 35
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet6
         is_l2_only: True
         net_id: 130006
         vlan_id: 2306
         vlan_name: NetAsCodeNet6_vlan2306
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet7
         vrf_name: NetAsCodeVrf7
@@ -100,7 +100,7 @@ vxlan:
         vlan_name: NetAsCodeNet7_vlan2307
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet8
         vrf_name: NetAsCodeVrf8
@@ -108,7 +108,7 @@ vxlan:
         vlan_id: 2308
         vlan_name: NetAsCodeNet8_vlan2308
         trm_enable: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet9
         vrf_name: NetAsCodeVrf9
@@ -117,7 +117,7 @@ vxlan:
         vlan_name: NetAsCodeNet9_vlan2309
         multicast_group_address: 239.1.1.1
         arp_suppress: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet_Default
         is_l2_only: False
@@ -144,7 +144,7 @@ vxlan:
             route_tag: 12345
         trm_enable: False
         vlan_netflow_monitor: vlan55
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet_Full
         is_l2_only: False
@@ -177,7 +177,7 @@ vxlan:
         trm_enable: False
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf2
+        network_attach_group: leaf2
 
     network_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_ingress_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_ingress_example/vrfs.yaml
@@ -26,17 +26,17 @@ vxlan:
       - name: NetAsCodeVrf1
         vrf_id: 150001
         vlan_id: 2001
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf2
         vrf_id: 150002
         vlan_id: 2002
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf3
         vrf_id: 150003
         vlan_id: 2003
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf5
         vrf_id: 150005
@@ -44,7 +44,7 @@ vxlan:
         vrf_description: NetAsCodeVrf5_Netflow_only
         netflow_enable: true
         netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf6
         vrf_id: 150006
@@ -52,7 +52,7 @@ vxlan:
         vrf_description: NetAsCodeVrf6_No_TRM_No_NetFlow
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf9
         vrf_id: 150009
@@ -62,7 +62,7 @@ vxlan:
         max_ibgp_paths: 4
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf_Default
         vrf_id: 150020
@@ -98,7 +98,7 @@ vxlan:
         trm_enable: True
         trm_bgw_msite: False
         underlay_mcast_ip: "224.1.1.1"
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf_Full
         vrf_id: 150030
@@ -130,7 +130,7 @@ vxlan:
         rp_external: False
         overlay_multicast_group: ""
         trm_bgw_msite: False
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
     vrf_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_asm_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_asm_example/networks.yaml
@@ -29,7 +29,7 @@ vxlan:
         net_id: 130001
         vlan_name: NetAsCodeNet1_vlan2301
         gw_ip_address: "192.168.12.1/24"
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet2
         vrf_name: NetAsCodeVrf2
@@ -37,7 +37,7 @@ vxlan:
         vlan_id: 2302
         vlan_name: NetAsCodeNet2_vlan2302
         gw_ip_address: "192.168.12.2/24"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet3
         vrf_name: NetAsCodeVrf3
@@ -50,7 +50,7 @@ vxlan:
         l3gw_on_border: True
         mtu_l3intf: 7600
         int_desc: "Configured by NetAsCode"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet4
         vrf_name: NetAsCodeVrf4
@@ -60,7 +60,7 @@ vxlan:
         gw_ip_address: "192.168.12.4/24"
         route_tag: 54321
         multicast_group_address: 239.1.1.1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet5
         vrf_name: NetAsCodeVrf5
@@ -84,14 +84,14 @@ vxlan:
           - ip_address: 10.255.255.103
             vrf: default
         dhcp_loopback_id: 35
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet6
         is_l2_only: True
         net_id: 130006
         vlan_id: 2306
         vlan_name: NetAsCodeNet6_vlan2306
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet7
         vrf_name: NetAsCodeVrf7
@@ -100,7 +100,7 @@ vxlan:
         vlan_name: NetAsCodeNet7_vlan2307
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet8
         vrf_name: NetAsCodeVrf8
@@ -108,7 +108,7 @@ vxlan:
         vlan_id: 2308
         vlan_name: NetAsCodeNet8_vlan2308
         trm_enable: True
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet9
         vrf_name: NetAsCodeVrf9
@@ -117,7 +117,7 @@ vxlan:
         vlan_name: NetAsCodeNet9_vlan2309
         multicast_group_address: 239.1.1.1
         arp_suppress: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet_Default
         is_l2_only: False
@@ -144,7 +144,7 @@ vxlan:
             route_tag: 12345
         trm_enable: False
         vlan_netflow_monitor: vlan55
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet_Full
         is_l2_only: False
@@ -177,7 +177,7 @@ vxlan:
         trm_enable: True
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf2
+        network_attach_group: leaf2
 
     network_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_asm_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_asm_example/vrfs.yaml
@@ -26,24 +26,24 @@ vxlan:
       - name: NetAsCodeVrf1
         vrf_id: 150001
         vlan_id: 2001
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf2
         vrf_id: 150002
         vlan_id: 2002
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf3
         vrf_id: 150003
         vlan_id: 2003
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf4
         vrf_id: 150004
         vlan_id: 2004
         vrf_int_mtu: 9000
         loopback_route_tag: 54321
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf5
         vrf_id: 150005
@@ -51,7 +51,7 @@ vxlan:
         vrf_description: NetAsCodeVrf5_Netflow_only
         netflow_enable: true
         netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf6
         vrf_id: 150006
@@ -65,7 +65,7 @@ vxlan:
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
         trm_bgw_msite: true
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf7
         vrf_id: 150007
@@ -74,7 +74,7 @@ vxlan:
         trm_enable: true
         no_rp: true
         underlay_mcast_ip: 239.1.1.0
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf8
         vrf_id: 150008
@@ -85,7 +85,7 @@ vxlan:
         rp_address: 10.100.100.100
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf9
         vrf_id: 150009
@@ -95,7 +95,7 @@ vxlan:
         max_ibgp_paths: 4
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
 
       - name: NetAsCodeVrf_Default
@@ -132,7 +132,7 @@ vxlan:
         trm_enable: True
         trm_bgw_msite: False
         underlay_mcast_ip: "224.1.1.1"
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf_Full
         vrf_id: 150030
@@ -167,7 +167,7 @@ vxlan:
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
         trm_bgw_msite: False
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
     vrf_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_bidir_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_bidir_example/networks.yaml
@@ -29,7 +29,7 @@ vxlan:
         net_id: 130001
         vlan_name: NetAsCodeNet1_vlan2301
         gw_ip_address: "192.168.12.1/24"
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet2
         vrf_name: NetAsCodeVrf2
@@ -37,7 +37,7 @@ vxlan:
         vlan_id: 2302
         vlan_name: NetAsCodeNet2_vlan2302
         gw_ip_address: "192.168.12.2/24"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet3
         vrf_name: NetAsCodeVrf3
@@ -50,7 +50,7 @@ vxlan:
         l3gw_on_border: True
         mtu_l3intf: 7600
         int_desc: "Configured by NetAsCode"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet4
         vrf_name: NetAsCodeVrf4
@@ -60,7 +60,7 @@ vxlan:
         gw_ip_address: "192.168.12.4/24"
         route_tag: 54321
         multicast_group_address: 239.1.1.1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet5
         vrf_name: NetAsCodeVrf5
@@ -84,14 +84,14 @@ vxlan:
           - ip_address: 10.255.255.103
             vrf: default
         dhcp_loopback_id: 35
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet6
         is_l2_only: True
         net_id: 130006
         vlan_id: 2306
         vlan_name: NetAsCodeNet6_vlan2306
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet7
         vrf_name: NetAsCodeVrf7
@@ -100,7 +100,7 @@ vxlan:
         vlan_name: NetAsCodeNet7_vlan2307
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet8
         vrf_name: NetAsCodeVrf8
@@ -108,7 +108,7 @@ vxlan:
         vlan_id: 2308
         vlan_name: NetAsCodeNet8_vlan2308
         trm_enable: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet9
         vrf_name: NetAsCodeVrf9
@@ -117,7 +117,7 @@ vxlan:
         vlan_name: NetAsCodeNet9_vlan2309
         multicast_group_address: 239.1.1.1
         arp_suppress: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet_Default
         is_l2_only: False
@@ -144,7 +144,7 @@ vxlan:
             route_tag: 12345
         trm_enable: False
         vlan_netflow_monitor: vlan55
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet_Full
         is_l2_only: False
@@ -177,7 +177,7 @@ vxlan:
         trm_enable: False
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf2
+        network_attach_group: leaf2
 
     network_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_bidir_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_bidir_example/vrfs.yaml
@@ -26,17 +26,17 @@ vxlan:
       - name: NetAsCodeVrf1
         vrf_id: 150001
         vlan_id: 2001
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf2
         vrf_id: 150002
         vlan_id: 2002
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf3
         vrf_id: 150003
         vlan_id: 2003
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf5
         vrf_id: 150005
@@ -44,7 +44,7 @@ vxlan:
         vrf_description: NetAsCodeVrf5_Netflow_only
         netflow_enable: true
         netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf6
         vrf_id: 150006
@@ -52,7 +52,7 @@ vxlan:
         vrf_description: NetAsCodeVrf6_No_TRM_No_NetFlow
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf9
         vrf_id: 150009
@@ -62,7 +62,7 @@ vxlan:
         max_ibgp_paths: 4
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf_Default
         vrf_id: 150020
@@ -98,7 +98,7 @@ vxlan:
         trm_enable: True
         trm_bgw_msite: False
         underlay_mcast_ip: "224.1.1.1"
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf_Full
         vrf_id: 150030
@@ -130,7 +130,7 @@ vxlan:
         rp_external: False
         overlay_multicast_group: ""
         trm_bgw_msite: False
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
     vrf_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/networks.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/networks.yaml
@@ -29,7 +29,7 @@ vxlan:
         net_id: 130001
         vlan_name: NetAsCodeNet1_vlan2301
         gw_ip_address: "192.168.12.1/24"
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet2
         vrf_name: NetAsCodeVrf2
@@ -37,7 +37,7 @@ vxlan:
         vlan_id: 2302
         vlan_name: NetAsCodeNet2_vlan2302
         gw_ip_address: "192.168.12.2/24"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet3
         vrf_name: NetAsCodeVrf3
@@ -50,7 +50,7 @@ vxlan:
         l3gw_on_border: True
         mtu_l3intf: 7600
         int_desc: "Configured by NetAsCode"
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet4
         vrf_name: NetAsCodeVrf4
@@ -60,7 +60,7 @@ vxlan:
         gw_ip_address: "192.168.12.4/24"
         route_tag: 54321
         multicast_group_address: 239.1.1.1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet5
         vrf_name: NetAsCodeVrf5
@@ -84,14 +84,14 @@ vxlan:
           - ip_address: 10.255.255.103
             vrf: default
         dhcp_loopback_id: 35
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet6
         is_l2_only: True
         net_id: 130006
         vlan_id: 2306
         vlan_name: NetAsCodeNet6_vlan2306
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet7
         vrf_name: NetAsCodeVrf7
@@ -100,7 +100,7 @@ vxlan:
         vlan_name: NetAsCodeNet7_vlan2307
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet8
         vrf_name: NetAsCodeVrf8
@@ -108,7 +108,7 @@ vxlan:
         vlan_id: 2308
         vlan_name: NetAsCodeNet8_vlan2308
         trm_enable: True
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet9
         vrf_name: NetAsCodeVrf9
@@ -117,7 +117,7 @@ vxlan:
         vlan_name: NetAsCodeNet9_vlan2309
         multicast_group_address: 239.1.1.1
         arp_suppress: False
-        attach_group: leaf1_leaf2
+        network_attach_group: leaf1_leaf2
 
       - name: NetAsCodeNet_Default
         is_l2_only: False
@@ -144,7 +144,7 @@ vxlan:
             route_tag: 12345
         trm_enable: False
         vlan_netflow_monitor: vlan55
-        attach_group: all_leaf
+        network_attach_group: all_leaf
 
       - name: NetAsCodeNet_Full
         is_l2_only: False
@@ -177,7 +177,7 @@ vxlan:
         trm_enable: True
         netflow_enable: True
         vlan_netflow_monitor: nac-monitor1
-        attach_group: leaf2
+        network_attach_group: leaf2
 
     network_attach_groups:
       - name: all_leaf

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/vrfs.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/vrfs.yaml
@@ -26,24 +26,24 @@ vxlan:
       - name: NetAsCodeVrf1
         vrf_id: 150001
         vlan_id: 2001
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf2
         vrf_id: 150002
         vlan_id: 2002
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf3
         vrf_id: 150003
         vlan_id: 2003
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf4
         vrf_id: 150004
         vlan_id: 2004
         vrf_int_mtu: 9000
         loopback_route_tag: 54321
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf5
         vrf_id: 150005
@@ -51,7 +51,7 @@ vxlan:
         vrf_description: NetAsCodeVrf5_Netflow_only
         netflow_enable: true
         netflow_monitor: nac-monitor1
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf6
         vrf_id: 150006
@@ -65,7 +65,7 @@ vxlan:
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
         trm_bgw_msite: true
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf7
         vrf_id: 150007
@@ -74,7 +74,7 @@ vxlan:
         trm_enable: true
         no_rp: true
         underlay_mcast_ip: 239.1.1.0
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf8
         vrf_id: 150008
@@ -85,7 +85,7 @@ vxlan:
         rp_address: 10.100.100.100
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
       - name: NetAsCodeVrf9
         vrf_id: 150009
@@ -95,7 +95,7 @@ vxlan:
         max_ibgp_paths: 4
         trm_enable: false
         netflow_enable: false
-        attach_group: leaf1_leaf2
+        vrf_attach_group: leaf1_leaf2
 
 
       - name: NetAsCodeVrf_Default
@@ -132,7 +132,7 @@ vxlan:
         trm_enable: True
         trm_bgw_msite: False
         underlay_mcast_ip: "224.1.1.1"
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
       - name: NetAsCodeVrf_Full
         vrf_id: 150030
@@ -167,7 +167,7 @@ vxlan:
         underlay_mcast_ip: 239.1.1.0
         overlay_multicast_group: 224.0.0.0/4
         trm_bgw_msite: False
-        attach_group: all_leaf
+        vrf_attach_group: all_leaf
 
     vrf_attach_groups:
       - name: all_leaf


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
https://wwwin-github.cisco.com/netascode/nac-vxlan/issues/91

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Change the generic attach_group to being more descriptive for vrfs (vrf_attach_group) and networks (network_attach_group)

## Test Notes
<!--- Please provide notes or description of testing -->
Ran the vxlan ansible playbook

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
