### PR TITLE
Update ndfc_policy.j2

### DIFF
--- a/roles/dtc/common/templates/ndfc_policy.j2
+++ b/roles/dtc/common/templates/ndfc_policy.j2
@@ -22,12 +22,12 @@
           policy_vars:
 {% if policy_match.template_vars is defined and policy_match.template_vars %}
 {% for key, value in policy_match.template_vars.items() %}
-{% if key == 'CONF' and policy_match.template_name == 'switch_freeform' %}
+{% if key == 'CONF' and policy_match.template_name != 'switch_freeform' %}
+              {{ key }}: |2-
+                {{ value | indent(16) }}            
+{% elif key == 'CONF' %}
             {{ key }}: |-
               {{ value | indent(14) }}
-{% elif key == 'CONF' %}
-              {{ key }}: |2-
-                {{ value | indent(16) }}
 {% else %}
               {{ key }}: {{ value | to_nice_yaml(indent=2) | indent(10) | trim }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_policy.j2
+++ b/roles/dtc/common/templates/ndfc_policy.j2
@@ -22,9 +22,12 @@
           policy_vars:
 {% if policy_match.template_vars is defined and policy_match.template_vars %}
 {% for key, value in policy_match.template_vars.items() %}
-{% if key == 'CONF' %}
+{% if key == 'CONF' and policy_match.template_name == 'switch_freeform' %}
             {{ key }}: |-
               {{ value | indent(14) }}
+{% elif key == 'CONF' %}
+              {{ key }}: |2-
+                {{ value | indent(16) }}
 {% else %}
               {{ key }}: {{ value | to_nice_yaml(indent=2) | indent(10) | trim }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_policy.j2
+++ b/roles/dtc/common/templates/ndfc_policy.j2
@@ -22,10 +22,10 @@
           policy_vars:
 {% if policy_match.template_vars is defined and policy_match.template_vars %}
 {% for key, value in policy_match.template_vars.items() %}
-{% if key == 'CONF' and policy_match.template_name != 'switch_freeform' %}
+{% if key == "CONF" and policy_match.template_name != "switch_freeform" %}
               {{ key }}: |2-
                 {{ value | indent(16) }}            
-{% elif key == 'CONF' %}
+{% elif key == "CONF" %}
             {{ key }}: |-
               {{ value | indent(14) }}
 {% else %}
@@ -33,10 +33,10 @@
 {% endif %}
 {% endfor %}
 {% elif policy_match.filename is defined and policy_match.filename and (".yaml" in policy_match.filename or ".yml" in policy_match.filename) %}
-            {{ lookup('ansible.builtin.file', policy_match.filename) | indent(12) }}
+            {{ lookup("ansible.builtin.file", policy_match.filename) | indent(12) }}
 {% elif policy_match.filename is defined and policy_match.filename and ".cfg" in policy_match.filename %}
             CONF: |-
-              {{ lookup('ansible.builtin.file', policy_match.filename) | indent(14) | trim }}
+              {{ lookup("ansible.builtin.file", policy_match.filename) | indent(14) | trim }}
 {% endif %}
           priority: {{ policy.priority | default(policy_group_match.priority) | default(defaults.vxlan.policy.priority) }}
 {% endfor %}


### PR DESCRIPTION
Will now correctly handle other policies other than freeform that have a conf field (example we used is bgp_peer_template)

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [x] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [ ] vxlan.overlay_extensions
* [x] vxlan.policy
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Found a bug where a policy has a key of CONF, the indentation is done incorrectly, tested this new piece of code with both a scaler and string input, both work successfully

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
