### PR TITLE
Handle stale serial number issue for hostname policy

### DIFF
--- a/plugins/action/helper_functions.py
+++ b/plugins/action/helper_functions.py
@@ -51,8 +51,13 @@ def ndfc_get_switch_policy(self, task_vars, tmp, template_name, switch_serial_nu
         tmp=tmp
     )
 
-    policy_match = next(
-        (item for item in policy_data["response"]["DATA"] if item["templateName"] == template_name and item['serialNumber'] == switch_serial_number)
-    )
+    try:
+        policy_match = next(
+            (item for item in policy_data["response"]["DATA"] if item["templateName"] == template_name and item['serialNumber'] == switch_serial_number)
+        )
+    except StopIteration:
+        err_msg = f"Policy for template {template_name} and switch {switch_serial_number} not found!"
+        err_msg += f" Please ensure switch with serial number {switch_serial_number} is part of the fabric"
+        raise Exception(err_msg)
 
     return policy_match

--- a/plugins/action/helper_functions.py
+++ b/plugins/action/helper_functions.py
@@ -57,7 +57,7 @@ def ndfc_get_switch_policy(self, task_vars, tmp, template_name, switch_serial_nu
         )
     except StopIteration:
         err_msg = f"Policy for template {template_name} and switch {switch_serial_number} not found!"
-        err_msg += f" Please ensure switch with serial number {switch_serial_number} is part of the fabric"
+        err_msg += f" Please ensure switch with serial number {switch_serial_number} is part of the fabric."
         raise Exception(err_msg)
 
     return policy_match

--- a/roles/validate/tasks/main.yml
+++ b/roles/validate/tasks/main.yml
@@ -20,11 +20,13 @@
 # SPDX-License-Identifier: MIT
 
 ---
-- debug: msg="{{ nac_tags.all}}"
+- debug: msg="{{ nac_tags.all }}"
 
 - name: Import Role Tasks
   ansible.builtin.import_tasks: sub_main.yml
   tags: "{{ nac_tags.all }}" # Tags defined in roles/common_global/vars/main.yml
+  # Problems with lower versions of python and ansible
+  # Python 3.9.16 and Ansible 7.3.0 (Ansible-Core 2.14.4)
   # Could ignore errors and try again with tags specified as below as a work around ...
   # tags:
   #   - cr_manage_fabric


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Found a problem if a the serial number for a switch defined in the data model does not exist in the fabric.  A `StopIteration` exception is raised because we get to the end of the list without finding a match.  This fix moves the logic into a `try`, `except` block with a message to the user to check the fabric.

## Test Notes
<!--- Please provide notes or description of testing -->

The following message is generated when the serial number referenced in the data model does not exist

TASK [cisco.nac_dc_vxlan.create : Build Switch Hostname Policy Payload from Data Model Update] *********************************************************************************************
Thursday 31 October 2024  11:09:41 -0400 (0:00:00.037)       0:00:33.120 ****** 
Thursday 31 October 2024  11:09:41 -0400 (0:00:00.037)       0:00:33.119 ****** 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: Exception: Policy for template host_11_1 and switch 9LWGEUPJOCM not found! Please ensure switch with serial number 9LWGEUPJOCM is part of the fabric
fatal: [nac-ndfc1-full]: FAILED! => {"msg": "Unexpected failure during module execution: Policy for template host_11_1 and switch 9LWGEUPJOCM not found! Please ensure switch with serial number 9LWGEUPJOCM is part of the fabric", "stdout": ""}


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
