### PR TITLE
Fix tags

### DIFF
--- a/plugins/action/common/check_roles.py
+++ b/plugins/action/common/check_roles.py
@@ -38,7 +38,7 @@ class ActionModule(ActionBase):
         results['save_previous'] = False
 
         roles = self._task.args['role_list']
-        for role in ['cisco.nac_dc_vxlan.create', 'cisco.nac_dc_vxlan.remove']:
+        for role in ['cisco.nac_dc_vxlan.create', 'cisco.nac_dc_vxlan.deploy', 'cisco.nac_dc_vxlan.remove']:
             if role in roles:
                 results['save_previous'] = True
 

--- a/roles/common_global/vars/main.yml
+++ b/roles/common_global/vars/main.yml
@@ -24,8 +24,7 @@
 nac_tags:
   # All Create and Remove Tags
   all:
-    - cc_connectivity_check
-    - cc_version
+    - cc_verify
     # -------------------------
     - cr_manage_fabric
     - cr_manage_switches
@@ -47,8 +46,59 @@ nac_tags:
     - role_remove
   # All Connectivity Check Tags
   connectivity_check:
-    - cc_connectivity_check
-    - cc_version
+    - cc_verify
+    - role_create
+    - role_deploy
+    - role_remove
+    - cr_manage_fabric
+    - cr_manage_switches
+    - cr_manage_vpc_peers
+    - cr_manage_interfaces
+    - cr_manage_vrfs_networks
+    - cr_manage_policy
+    - rr_manage_interfaces
+    - rr_manage_networks
+    - rr_manage_vrfs
+    - rr_manage_vpc_peers
+    - rr_manage_links
+    - rr_manage_switches
+  # We need the ability to pass tags to the common role but we don't need the following
+  #   - validate, cc_connectivity_check or cc_version
+  common_role:
+    - role_create
+    - role_deploy
+    - role_remove
+    - cr_manage_fabric
+    - cr_manage_switches
+    - cr_manage_vpc_peers
+    - cr_manage_interfaces
+    - cr_manage_vrfs_networks
+    - cr_manage_policy
+    - rr_manage_interfaces
+    - rr_manage_networks
+    - rr_manage_vrfs
+    - rr_manage_vpc_peers
+    - rr_manage_links
+    - rr_manage_switches
+  # We need the ability to pass tags to the common role but we don't need the following
+  #   - validate, cc_connectivity_check or cc_version
+  validate_role:
+    - role_validate
+    - role_create
+    - role_deploy
+    - role_remove
+    - cr_manage_fabric
+    - cr_manage_switches
+    - cr_manage_vpc_peers
+    - cr_manage_interfaces
+    - cr_manage_vrfs_networks
+    - cr_manage_policy
+    - rr_manage_interfaces
+    - rr_manage_networks
+    - rr_manage_vrfs
+    - rr_manage_vpc_peers
+    - rr_manage_links
+    - rr_manage_switches
   # All Create Tags
   create:
     - cr_manage_fabric

--- a/roles/common_global/vars/main.yml
+++ b/roles/common_global/vars/main.yml
@@ -139,5 +139,7 @@ nac_tags:
     - rr_manage_links
   remove_switches:
     - rr_manage_switches
-  
+  deploy:
+    - role_deploy
+
   

--- a/roles/common_global/vars/main.yml
+++ b/roles/common_global/vars/main.yml
@@ -63,7 +63,7 @@ nac_tags:
     - rr_manage_links
     - rr_manage_switches
   # We need the ability to pass tags to the common role but we don't need the following
-  #   - validate, cc_connectivity_check or cc_version
+  #   - validate, cc_verify
   common_role:
     - role_create
     - role_deploy
@@ -80,8 +80,8 @@ nac_tags:
     - rr_manage_vpc_peers
     - rr_manage_links
     - rr_manage_switches
-  # We need the ability to pass tags to the common role but we don't need the following
-  #   - validate, cc_connectivity_check or cc_version
+  # We need the ability to pass tags to the validate role but we don't need the following
+  #   - cc_verify
   validate_role:
     - role_validate
     - role_create

--- a/roles/dtc/common/meta/main.yml
+++ b/roles/dtc/common/meta/main.yml
@@ -25,4 +25,5 @@ galaxy_info:
   license: LICENSE
   min_ansible_version: 2.14.15
 
-dependencies: [cisco.nac_dc_vxlan.common_global]
+dependencies:
+  - cisco.nac_dc_vxlan.common_global

--- a/roles/dtc/common/tasks/main.yml
+++ b/roles/dtc/common/tasks/main.yml
@@ -23,4 +23,4 @@
 
 - name: Import Role Tasks
   ansible.builtin.import_tasks: sub_main.yml
-  # tags: "{{ nac_tags.all }}" # Tags defined in roles/common_global/vars/main.yml
+  tags: "{{ nac_tags.common_role }}" # Tags defined in roles/common_global/vars/main.yml

--- a/roles/dtc/common/tasks/main.yml
+++ b/roles/dtc/common/tasks/main.yml
@@ -23,4 +23,4 @@
 
 - name: Import Role Tasks
   ansible.builtin.import_tasks: sub_main.yml
-  tags: "{{ nac_tags.all }}" # Tags defined in roles/common_global/vars/main.yml
+  # tags: "{{ nac_tags.all }}" # Tags defined in roles/common_global/vars/main.yml

--- a/roles/dtc/connectivity_check/tasks/main.yml
+++ b/roles/dtc/connectivity_check/tasks/main.yml
@@ -25,11 +25,17 @@
   ansible.builtin.include_tasks: verify_ndfc_connectivity.yml
   tags:
     - cc_connectivity_check
+    - role_create
+    - role_deploy
+    - role_remove
 
 - name: Verify Authorization to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
   ansible.builtin.include_tasks: verify_ndfc_authorization.yml
   tags:
     - cc_connectivity_check
+    - role_create
+    - role_deploy
+    - role_remove
 
 - name: Get Cisco ND Version
   ansible.builtin.uri:
@@ -43,12 +49,18 @@
   delegate_to: localhost
   tags:
     - cc_version
+    - role_create
+    - role_deploy
+    - role_remove
 
 - name: Set Cisco ND Version Var
   ansible.builtin.set_fact:
     nd_version: "{{ nd_version_response.json.major }}.{{ nd_version_response.json.minor }}.{{ nd_version_response.json.maintenance }}{{ nd_version_response.json.patch }}"
   tags:
-  - cc_version
+    - cc_version
+    - role_create
+    - role_deploy
+    - role_remove
 
 - name: Get Cisco NDFC Version
   cisco.dcnm.dcnm_rest:
@@ -57,9 +69,15 @@
   register: ndfc_version
   tags:
     - cc_version
+    - role_create
+    - role_deploy
+    - role_remove
 
 - name: Set Cisco NDFC Version Var
   ansible.builtin.set_fact:
     ndfc_version: "{{ ndfc_version.response.DATA.version }}"
   tags:
     - cc_version
+    - role_create
+    - role_deploy
+    - role_remove

--- a/roles/dtc/connectivity_check/tasks/main.yml
+++ b/roles/dtc/connectivity_check/tasks/main.yml
@@ -23,19 +23,11 @@
 
 - name: Verify Connection to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
   ansible.builtin.include_tasks: verify_ndfc_connectivity.yml
-  tags:
-    - cc_connectivity_check
-    - role_create
-    - role_deploy
-    - role_remove
+  tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
 
 - name: Verify Authorization to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
   ansible.builtin.include_tasks: verify_ndfc_authorization.yml
-  tags:
-    - cc_connectivity_check
-    - role_create
-    - role_deploy
-    - role_remove
+  tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
 
 - name: Get Cisco ND Version
   ansible.builtin.uri:
@@ -47,37 +39,21 @@
     timeout: 30
   register: nd_version_response
   delegate_to: localhost
-  tags:
-    - cc_version
-    - role_create
-    - role_deploy
-    - role_remove
+  tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
 
 - name: Set Cisco ND Version Var
   ansible.builtin.set_fact:
     nd_version: "{{ nd_version_response.json.major }}.{{ nd_version_response.json.minor }}.{{ nd_version_response.json.maintenance }}{{ nd_version_response.json.patch }}"
-  tags:
-    - cc_version
-    - role_create
-    - role_deploy
-    - role_remove
+  tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
 
 - name: Get Cisco NDFC Version
   cisco.dcnm.dcnm_rest:
     method: GET
     path: /appcenter/cisco/ndfc/api/about/version
   register: ndfc_version
-  tags:
-    - cc_version
-    - role_create
-    - role_deploy
-    - role_remove
+  tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
 
 - name: Set Cisco NDFC Version Var
   ansible.builtin.set_fact:
     ndfc_version: "{{ ndfc_version.response.DATA.version }}"
-  tags:
-    - cc_version
-    - role_create
-    - role_deploy
-    - role_remove
+  tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml

--- a/roles/dtc/connectivity_check/tasks/main.yml
+++ b/roles/dtc/connectivity_check/tasks/main.yml
@@ -22,11 +22,11 @@
 ---
 
 - name: Verify Connection to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
-  ansible.builtin.include_tasks: verify_ndfc_connectivity.yml
+  ansible.builtin.import_tasks: verify_ndfc_connectivity.yml
   tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
 
 - name: Verify Authorization to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
-  ansible.builtin.include_tasks: verify_ndfc_authorization.yml
+  ansible.builtin.import_tasks: verify_ndfc_authorization.yml
   tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
 
 - name: Get Cisco ND Version

--- a/roles/dtc/connectivity_check/tasks/verify_ndfc_authorization.yml
+++ b/roles/dtc/connectivity_check/tasks/verify_ndfc_authorization.yml
@@ -20,11 +20,6 @@
       register: response
       # no_log: true
       delegate_to: localhost
-      tags:
-        - cc_connectivity_check
-        - role_create
-        - role_deploy
-        - role_remove
 
   rescue:
     - name: Fail Play If NDFC Authorization Test Failed

--- a/roles/dtc/connectivity_check/tasks/verify_ndfc_authorization.yml
+++ b/roles/dtc/connectivity_check/tasks/verify_ndfc_authorization.yml
@@ -22,6 +22,9 @@
       delegate_to: localhost
       tags:
         - cc_connectivity_check
+        - role_create
+        - role_deploy
+        - role_remove
 
   rescue:
     - name: Fail Play If NDFC Authorization Test Failed

--- a/roles/dtc/connectivity_check/tasks/verify_ndfc_connectivity.yml
+++ b/roles/dtc/connectivity_check/tasks/verify_ndfc_connectivity.yml
@@ -13,3 +13,6 @@
   delegate_to: localhost
   tags:
     - cc_connectivity_check
+    - role_create
+    - role_deploy
+    - role_remove

--- a/roles/dtc/connectivity_check/tasks/verify_ndfc_connectivity.yml
+++ b/roles/dtc/connectivity_check/tasks/verify_ndfc_connectivity.yml
@@ -11,8 +11,3 @@
     state: started
     msg: Timed out waiting to connect to NDFC at https://{{ ansible_host }}:{{ ansible_httpapi_port | default(443) }}. Check the NDFC is reachable from the Ansible Controller.
   delegate_to: localhost
-  tags:
-    - cc_connectivity_check
-    - role_create
-    - role_deploy
-    - role_remove

--- a/roles/dtc/create/meta/main.yml
+++ b/roles/dtc/create/meta/main.yml
@@ -26,7 +26,6 @@ galaxy_info:
   min_ansible_version: 2.14.15
 
 dependencies:
-  - cisco.nac_dc_vxlan.validate
-  - cisco.nac_dc_vxlan.common_global
   - cisco.nac_dc_vxlan.dtc.connectivity_check
+  - cisco.nac_dc_vxlan.validate
   - cisco.nac_dc_vxlan.dtc.common

--- a/roles/dtc/deploy/meta/main.yml
+++ b/roles/dtc/deploy/meta/main.yml
@@ -26,6 +26,6 @@ galaxy_info:
   min_ansible_version: 2.14.15
 
 dependencies:
+  - cisco.nac_dc_vxlan.dtc.connectivity_check
   - cisco.nac_dc_vxlan.validate
-  - cisco.nac_dc_vxlan.common_global
   - cisco.nac_dc_vxlan.dtc.common

--- a/roles/dtc/deploy/tasks/main.yml
+++ b/roles/dtc/deploy/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Import Role Tasks
   ansible.builtin.import_tasks: sub_main.yml
-  tags: "{{ nac_tags.create }}" # Tags defined in roles/common_global/vars/main.yml
+  tags: "{{ nac_tags.deploy }}" # Tags defined in roles/common_global/vars/main.yml
   when: changes_detected_fabric or changes_detected_inventory or changes_detected_vpc_peering or changes_detected_interfaces or changes_detected_link_vpc_peering or changes_detected_vrfs or changes_detected_networks or changes_detected_policy
 
 - name: Mark Stage Role Deploy Completed

--- a/roles/dtc/remove/meta/main.yml
+++ b/roles/dtc/remove/meta/main.yml
@@ -26,6 +26,6 @@ galaxy_info:
   min_ansible_version: 2.14.15
 
 dependencies:
+  - cisco.nac_dc_vxlan.dtc.connectivity_check
   - cisco.nac_dc_vxlan.validate
-  - cisco.nac_dc_vxlan.common_global
   - cisco.nac_dc_vxlan.dtc.common

--- a/roles/validate/tasks/main.yml
+++ b/roles/validate/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Import Role Tasks
   ansible.builtin.import_tasks: sub_main.yml
-  tags: "{{ nac_tags.all }}" # Tags defined in roles/common_global/vars/main.yml
+  tags: "{{ nac_tags.validate_role }}" # Tags defined in roles/common_global/vars/main.yml
   # Problems with lower versions of python and ansible
   # Python 3.9.16 and Ansible 7.3.0 (Ansible-Core 2.14.4)
   # Could ignore errors and try again with tags specified as below as a work around ...


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

This simplifies how we tag our roles and fixes a problem where we cannot run the tags in isolation.

The new role `connectivity_check` needs to include tags for `create, deploy and remove` to make sure it gets run when we specify those roles

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [x] cisco.nac_dc_vxlan.dtc.deploy
* [x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->

Using the following playbook I tested the following scenarios

* All roles run together
* Roles run in isolation
* Roles run selectively using tags

```yaml
---
# This is the main entry point playbook for calling the various
# roles in this collection.
- hosts: nac-ndfc1
  any_errors_fatal: true
  gather_facts: no
  
  roles:
    # Prepare service model for all subsequent roles
    # Note - The validate role is run automatically as a prerequisite to the create, deploy, and remove roles.
    #
    # - role: cisco.nac_dc_vxlan.validate
    # -----------------------
    # DataCenter Roles
    #   Role: cisco.netascode_dc_vxlan.dtc manages direct to controller NDFC workflows
    #
    - role: cisco.nac_dc_vxlan.dtc.create
      tags: 'role_create'

    - role: cisco.nac_dc_vxlan.dtc.deploy
      tags: 'role_deploy'

    - role: cisco.nac_dc_vxlan.dtc.remove
      tags: 'role_remove'
```

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
