### PR TITLE
Fix connectivity check role for IPv6 management

### DIFF
--- a/roles/dtc/connectivity_check/tasks/verify_ndfc_connectivity.yml
+++ b/roles/dtc/connectivity_check/tasks/verify_ndfc_connectivity.yml
@@ -23,7 +23,10 @@
 
 - name: Verify Connection to NDFC {{ ansible_host }} on Port {{ ansible_httpapi_port | default(443) }}
   ansible.builtin.wait_for:
-    host: "{{ ansible_host }}"
+    # The ansible_host here could be an IPv4 or IPv6 address
+    # The replace filters are used to remove square brackets from IPv6 addresses
+    # Example: [2001:420:448b:8006::30] -> 2001:420:448b:8006::30
+    host: "{{ ansible_host | replace('[', '') | replace(']', '') }}"
     port: "{{ ansible_httpapi_port | default(443) }}"
     connect_timeout: 5
     delay: 0


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

Fix to resolve #236 

Update to docs PR: https://github.com/netascode/ansible-dc-vxlan-example/pull/27

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [x] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] defaults.vxlan
* [x] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

The preferred method for specifying an ipv6 management address in the hosts/inventory file is using the `[]` notation around the address.

For Example:
```
---

all:
  children:
    ndfc:
      hosts:
        marehler_vnd3:
          ansible_host: "[2001:420:448b:8006::30]"
```

The `ansible.builtin.wait_for` module unfortunately does not play nicely with the `[]` so this update removes them for this specific case.

All of our other modules in the DCNM/NDFC collection handle the `"[]"` notation without any issues.

## Test Notes
<!--- Please provide notes or description of testing -->

Tested using a NDFC that is accessible using an IPv6 management ip.  

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->

ND: `Version 3.2.1i`
Fabric Controller: `Version 12.2.2.241`


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
