### PR TITLE
fixed the issue with the prep_107_vrf_lites.py

### DIFF
--- a/plugins/action/common/prepare_plugins/prep_107_vrf_lites.py
+++ b/plugins/action/common/prepare_plugins/prep_107_vrf_lites.py
@@ -234,7 +234,7 @@ class PreparePlugin:
                         #                   ebgp_distance: 25
                         #                   ibgp_distance: 180
                         #                   local_distance: 200
-                        if "bgp" in vrf_lite:
+                        if "bgp" in vrf_lite and vrf_lite["bgp"] is not None:
                             for af in ["address_family_ipv4_unicast", "address_family_ipv6_unicast"]:
                                 if af in vrf_lite["bgp"]:
                                     switch_bgp_af = switch.setdefault("bgp", {}).setdefault(af, {})

--- a/plugins/action/common/prepare_plugins/prep_107_vrf_lites.py
+++ b/plugins/action/common/prepare_plugins/prep_107_vrf_lites.py
@@ -234,7 +234,7 @@ class PreparePlugin:
                         #                   ebgp_distance: 25
                         #                   ibgp_distance: 180
                         #                   local_distance: 200
-                        if "bgp" in vrf_lite and vrf_lite["bgp"] is not None:
+                        if vrf_lite.get("bgp") is not None:
                             for af in ["address_family_ipv4_unicast", "address_family_ipv6_unicast"]:
                                 if af in vrf_lite["bgp"]:
                                     switch_bgp_af = switch.setdefault("bgp", {}).setdefault(af, {})


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
Aims to resolve #256 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [x] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Fix the issue with the prep_107_vrf_lites.py plugin. Error is encountered if 'vxlan>overlay_extensions>vrf_lites>bgp' key is null.


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2.1

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
