### PR TITLE
fix-issues_252_and_253

### DIFF
--- a/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_ebgp.j2
+++ b/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_ebgp.j2
@@ -48,7 +48,18 @@ router bgp {{ MD_Extended.vxlan.global.bgp_asn }}
   {% elif item.bgp.local_as %}
     local-as {{ item.bgp.local_as }}
   {% endif %}
-  {% if switch_item.bgp.address_family_ipv4_unicast %}
+  {# Check if address_family is enabled for redistribution #}
+  {% set address_family = {'address_family_v4': false, 'address_family_v6': false } %}
+  {% if switch_item.bgp_peers is defined %}
+    {% for peer in switch_item.bgp_peers %}
+      {% if "address_family_ipv4_unicast" in peer %}
+        {% set _ = address_family.update({'address_family_v4': true}) %}
+      {% elif "address_family_ipv6_unicast" in peer %}
+        {% set _ = address_family.update({'address_family_v6': true}) %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+  {% if switch_item.bgp.address_family_ipv4_unicast or address_family["address_family_v4"] is true %}
     address-family ipv4 unicast
     {% if (switch_item.bgp.address_family_ipv4_unicast.ebgp_distance or switch_item.bgp.address_family_ipv4_unicast.ibgp_distance or switch_item.bgp.address_family_ipv4_unicast.local_distance) %}
       distance {{ switch_item.bgp.address_family_ipv4_unicast.ebgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.ebgp_distance)  }} {{ switch_item.bgp.address_family_ipv4_unicast.ibgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.ibgp_distance)  }} {{ switch_item.bgp.address_family_ipv4_unicast.local_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.local_distance) }}
@@ -67,14 +78,14 @@ router bgp {{ MD_Extended.vxlan.global.bgp_asn }}
     {% endif %}
     {% if switch_item.redistribution %}
       {% for switch_redist in switch_item.redistribution %}
-        {% if switch_redist.source == 'static' and switch_redist.route_map %}
-      redistribute static route-map {{ switch_redist.route_map }}
+        {% if switch_redist.source == 'static' and switch_redist.route_map_ipv4 %}
+      redistribute static route-map {{ switch_redist.route_map_ipv4 }}
         {% endif %}
       {% endfor %}
     {% endif %}
 !
   {% endif %}
-  {% if switch_item.bgp.address_family_ipv6_unicast %}
+  {% if switch_item.bgp.address_family_ipv6_unicast or address_family["address_family_v6"] is true %}
     address-family ipv6 unicast
     {% if (switch_item.bgp.address_family_ipv6_unicast.ebgp_distance or switch_item.bgp.address_family_ipv6_unicast.ibgp_distance or switch_item.bgp.address_family_ipv6_unicast.local_distance) %}
       distance {{ switch_item.bgp.address_family_ipv6_unicast.ebgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.ebgp_distance)  }} {{ switch_item.bgp.address_family_ipv6_unicast.ibgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.ibgp_distance)  }} {{ switch_item.bgp.address_family_ipv6_unicast.local_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.local_distance) }}
@@ -93,8 +104,8 @@ router bgp {{ MD_Extended.vxlan.global.bgp_asn }}
     {% endif %}
     {% if switch_item.redistribution %}
       {% for switch_redist in switch_item.redistribution %}
-        {% if switch_redist.source == 'static' and switch_redist.route_map %}
-      redistribute static route-map {{ switch_redist.route_map }}
+        {% if switch_redist.source == 'static' and switch_redist.route_map_ipv6 %}
+      redistribute static route-map {{ switch_redist.route_map_ipv6 }}
         {% endif %}
       {% endfor %}
     {% endif %}

--- a/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_ospf.j2
+++ b/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_ospf.j2
@@ -128,17 +128,17 @@ router ospf {{ item.ospf['process'] }}
     {% endif %}
     {% if switch_item.redistribution %}
       {% for switch_redist in switch_item.redistribution %}
-        {% if switch_redist.source == 'direct' and switch_redist.route_map %}
-    redistribute direct route-map {{ switch_redist.route_map }}
+        {% if switch_redist.source == 'direct' and switch_redist.route_map_ipv4 %}
+    redistribute direct route-map {{ switch_redist.route_map_ipv4 }}
         {% endif %}
-        {% if switch_redist.source == 'static' and switch_redist.route_map %}
-    redistribute static route-map {{ switch_redist.route_map }}
+        {% if switch_redist.source == 'static' and switch_redist.route_map_ipv4 %}
+    redistribute static route-map {{ switch_redist.route_map_ipv4 }}
         {% endif %}
-        {% if switch_redist.source == 'bgp' and switch_redist.route_map %}
-    redistribute bgp {{ MD_Extended.vxlan.global.bgp_asn }} route-map {{ switch_redist.route_map }}
+        {% if switch_redist.source == 'bgp' and switch_redist.route_map_ipv4 %}
+    redistribute bgp {{ MD_Extended.vxlan.global.bgp_asn }} route-map {{ switch_redist.route_map_ipv4 }}
         {% endif %}
-        {% if switch_redist.source == 'ospf' and switch_redist.route_map %}
-          {% set _ = redistribute.update({'ospf': switch_redist.route_map}) %}
+        {% if switch_redist.source == 'ospf' and switch_redist.route_map_ipv4 %}
+          {% set _ = redistribute.update({'ospf': switch_redist.route_map_ipv4}) %}
         {% endif %}
       {% endfor %}
     {% endif %}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

fixes #252, #253 
Replace PR #255

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [x] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

In bgp template, loop across bgp_peers to search if address_family is defined and create temporary dict to save if AF exist to render redistribution under address_family.

Update route_map to route_map_ipv[4|6] in BGP based on Address Family.
Update route_map to route_map_ipv4 for OSPF only. OSPFv6 is not supported yet.

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
