### PR TITLE
Update prep_108_route_control.py

### DIFF
--- a/plugins/action/common/prepare_plugins/prep_108_route_control.py
+++ b/plugins/action/common/prepare_plugins/prep_108_route_control.py
@@ -103,7 +103,8 @@ class PreparePlugin:
                                 }
                             }
 
-                            model_data["vxlan"]["policy"]["policies"].append(new_policy)
+                            if not any(policy['name'] == unique_name for policy in model_data["vxlan"]["policy"]["policies"]):
+                                model_data["vxlan"]["policy"]["policies"].append(new_policy)
 
                             if any(sw['name'] == switch['name'] for sw in model_data["vxlan"]["policy"]["switches"]):
                                 found_switch = next(([idx, i] for idx, i in enumerate(
@@ -121,7 +122,7 @@ class PreparePlugin:
                                 }
                                 model_data["vxlan"]["policy"]["switches"].append(new_switch)
 
-                            if not any(group['name'] == sw_group for group in model_data["vxlan"]["policy"]["groups"]):
+                            if not any(group['name'] == unique_name for group in model_data["vxlan"]["policy"]["groups"]):
                                 new_group = {
                                     "name": unique_name,
                                     "policies": [


### PR DESCRIPTION
update script to avoid duplicate policy in the extended model: vxlan.policy.groups and vxlan.policy.policies.

Duplicate appears because we removed switch name in the policy description.

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Remove duplicate in the extended data model for the following keys:
* vxlan.policy.policies
* vxlan.policy.groups

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [x] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
