### PR TITLE
Fix For Loading Yaml File Content and Inline Hashes

### DIFF
--- a/roles/dtc/common/templates/ndfc_policy.j2
+++ b/roles/dtc/common/templates/ndfc_policy.j2
@@ -36,7 +36,9 @@
 {% endfor %}
 {% elif policy_match.filename is defined and policy_match.filename and (".yaml" in policy_match.filename or ".yml" in policy_match.filename) %}
 {% set raw_yaml_content = lookup('ansible.builtin.file', policy_match.filename) %}
-{% set cleaned_yaml_content = raw_yaml_content | replace('---\n', '') | regex_replace('\.\.\.\s*$', '') %}
+{% set cleaned_yaml_content = raw_yaml_content.lstrip('---\n') %}
+{% set cleaned_yaml_content = cleaned_yaml_content.rstrip('...\n') %}
+{% set cleaned_yaml_content = cleaned_yaml_content.rstrip('...') %}
             {{ cleaned_yaml_content | indent(12) | trim }}
 {% elif policy_match.filename is defined and policy_match.filename and ".cfg" in policy_match.filename %}
             CONF: |-

--- a/roles/dtc/common/templates/ndfc_policy.j2
+++ b/roles/dtc/common/templates/ndfc_policy.j2
@@ -31,11 +31,13 @@
             {{ key }}: |-
               {{ value | indent(14) }}
 {% else %}
-              {{ key }}: {{ value | to_nice_yaml(indent=2) | indent(10) | trim }}
+              {{ key }}: {{ value | indent(12) | trim }}
 {% endif %}
 {% endfor %}
 {% elif policy_match.filename is defined and policy_match.filename and (".yaml" in policy_match.filename or ".yml" in policy_match.filename) %}
-            {{ lookup("ansible.builtin.file", policy_match.filename) | indent(12) }}
+{% set raw_yaml_content = lookup('ansible.builtin.file', policy_match.filename) %}
+{% set cleaned_yaml_content = raw_yaml_content | replace('---\n', '') | regex_replace('\.\.\.\s*$', '') %}
+            {{ cleaned_yaml_content | indent(12) | trim }}
 {% elif policy_match.filename is defined and policy_match.filename and ".cfg" in policy_match.filename %}
             CONF: |-
               {{ lookup("ansible.builtin.file", policy_match.filename) | indent(14) | trim }}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Resolves #270 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [ ] vxlan.overlay_extensions
* [x] vxlan.policy
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
The proposed changes strips the --- and ... of YAML files.
Additionally, the usage of Ansible's ```to_nice_yaml``` is removed as it's unnecessary.

## Test Notes
<!--- Please provide notes or description of testing -->
Tested with .cfg, .yml, and inline data.
Can discuss in standup.

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2.2

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
