### PR TITLE
Update role_names to ansible_play_role_names

### DIFF
--- a/roles/validate/tasks/manage_model_files_previous.yml
+++ b/roles/validate/tasks/manage_model_files_previous.yml
@@ -21,9 +21,9 @@
 
 ---
 
-- name: "Check Roles"
+- name: Check Roles
   cisco.nac_dc_vxlan.common.check_roles:
-    role_list: "{{ role_names }}"
+    role_list: "{{ ansible_play_role_names }}"
   register: check_roles
   delegate_to: localhost
 

--- a/roles/validate/tasks/sub_main.yml
+++ b/roles/validate/tasks/sub_main.yml
@@ -119,7 +119,7 @@
 
 - name: Check Roles
   cisco.nac_dc_vxlan.common.check_roles:
-    role_list: "{{ role_names }}"
+    role_list: "{{ ansible_play_role_names }}"
   register: check_roles
   delegate_to: localhost
 


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Resolves #272 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay_services
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] defaults.vxlan
* [x] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Update role_names to ansible_play_role_names as role_names is deprecated.
See [here](https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#term-role_names).
ansible_play_role_names was introduced back in 2.9 or before.

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
