### PR TITLE
Enforce BGP AS to a string

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
@@ -1,4 +1,4 @@
 {# Auto-generated NDFC DC VXLAN EVPN General config data structure for fabric {{ vxlan.fabric.name }} #}
-  BGP_AS: {{ vxlan.global.bgp_asn }}
+  BGP_AS: "{{ vxlan.global.bgp_asn }}"
 
 {# #}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/general/dc_vxlan_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/general/dc_vxlan_fabric_general.j2
@@ -1,5 +1,5 @@
 {# Auto-generated NDFC DC VXLAN EVPN General config data structure for fabric {{ vxlan.fabric.name }} #}
-  BGP_AS: {{ vxlan.global.bgp_asn }}
+  BGP_AS: "{{ vxlan.global.bgp_asn }}"
   UNDERLAY_IS_V6: {{ (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) }}
 {% if (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title) == 'True' %}
   USE_LINK_LOCAL: {{ vxlan.underlay.ipv6.enable_ipv6_link_local_address | default(defaults.vxlan.underlay.ipv6.enable_ipv6_link_local_address | title) }}

--- a/roles/dtc/common/templates/ndfc_fabric/isn_fabric/general/isn_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/isn_fabric/general/isn_fabric_general.j2
@@ -1,4 +1,4 @@
 {# Auto-generated NDFC ISN General config data structure for fabric {{ vxlan.fabric.name }} #}
-  BGP_AS: {{ vxlan.multisite.isn.bgp_asn }}
+  BGP_AS: "{{ vxlan.multisite.isn.bgp_asn }}"
   IS_READ_ONLY: false
 {# #}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

Fix issue for AS Dot.
Avoid using AS like this 65000.1, which is recognized as a float. Adding double quotes when rendering the template will enforce the value as a string.

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [x] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
