### PR TITLE
Expose mcast address back to child fabric in msd

### DIFF
--- a/plugins/action/dtc/manage_child_fabric_networks.py
+++ b/plugins/action/dtc/manage_child_fabric_networks.py
@@ -127,7 +127,8 @@ class ActionModule(ActionBase):
                         (ndfc_net_template_config['loopbackId'] != network.get('dhcp_loopback_id', "")) or
                         (ndfc_net_template_config['ENABLE_NETFLOW'] != str(network.get('netflow_enable', False)).lower()) or
                         (ndfc_net_template_config['VLAN_NETFLOW_MONITOR'] != network.get('vlan_netflow_monitor', "")) or
-                        (ndfc_net_template_config['trmEnabled'] != str(network.get('trm_enable', False)).lower())
+                        (ndfc_net_template_config['trmEnabled'] != str(network.get('trm_enable', False)).lower()) or
+                        (ndfc_net_template_config['mcastGroup'] != network.get('multicast_group_address'))
                     ):
                         results['child_fabrics_changed'].append(child_fabric)
 

--- a/roles/dtc/common/templates/ndfc_networks/msd_fabric/child_fabric/msd_child_fabric_network.j2
+++ b/roles/dtc/common/templates/ndfc_networks/msd_fabric/child_fabric/msd_child_fabric_network.j2
@@ -18,7 +18,7 @@
         "mtu": ndfc.mtu,
         "isLayer2Only": ndfc.isLayer2Only,
         "suppressArp": ndfc.suppressArp,
-        "mcastGroup": ndfc.mcastGroup,
+        "mcastGroup": dm.multicast_group_address | default(ndfc.mcastGroup),
         "tag": ndfc.tag,
         "secondaryGW1": ndfc.secondaryGW1,
         "secondaryGW2": ndfc.secondaryGW2,


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Resolves #294 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [x] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Exposes mcast address for an L2VNI back to child fabrics as expected.

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2.2

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
