### PR TITLE
Update isn_fabric_advanced.j2 add all NXAPI parameters and update defaults

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/isn_fabric/advanced/isn_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/isn_fabric/advanced/isn_fabric_advanced.j2
@@ -7,4 +7,6 @@
   AAA_REMOTE_IP_ENABLED: false
   INBAND_MGMT: false
   FEATURE_PTP: false
+  ENABLE_NXAPI: {{ vxlan.global.enable_nxapi | default(defaults.vxlan.global.enable_nxapi) }}
+  ENABLE_NXAPI_HTTP: {{ vxlan.global.enable_nxapi_http | default(defaults.vxlan.global.enable_nxapi_http ) }}
 {# #}

--- a/roles/dtc/common/templates/ndfc_fabric/isn_fabric/advanced/isn_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/isn_fabric/advanced/isn_fabric_advanced.j2
@@ -7,6 +7,8 @@
   AAA_REMOTE_IP_ENABLED: false
   INBAND_MGMT: false
   FEATURE_PTP: false
-  ENABLE_NXAPI: {{ vxlan.global.enable_nxapi | default(defaults.vxlan.global.enable_nxapi) }}
+  ENABLE_NXAPI: {{ vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) }}
+  NXAPI_HTTPS_PORT: {{ vxlan.global.nxapi_https_port | default(defaults.vxlan.global.nxapi_https_port ) }}
   ENABLE_NXAPI_HTTP: {{ vxlan.global.enable_nxapi_http | default(defaults.vxlan.global.enable_nxapi_http ) }}
+  NXAPI_HTTP_PORT: {{ vxlan.global.nxapi_http_port | default(defaults.vxlan.global.nxapi_http_port ) }}
 {# #}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -294,9 +294,6 @@ factory_defaults:
       ipv6_vtep_loopback_range: fd00::a10:0/120
       overlay_dci:
         deployment_method: Direct_To_BGWS
-        route_server:
-          redistribute_direct: false
-          ip_tag: 54321
         ipv4_dci_subnet_range: 10.10.1.0/24
         ipv4_dci_subnet_mask: 30
         ipv6_dci_subnet_range: fd00::a11:0/120

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -27,8 +27,8 @@ factory_defaults:
       anycast_gateway_mac: 20:20:00:00:00:aa
       auth_proto: MD5
       enable_nxapi_http: false
-      enable_nxapi_https: true
       nxapi_http_port: 80
+      enable_nxapi_https: true
       nxapi_https_port: 443
       vpc:
         peer_link_vlan: 3600

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -26,6 +26,10 @@ factory_defaults:
       route_reflectors: 2
       anycast_gateway_mac: 20:20:00:00:00:aa
       auth_proto: MD5
+      enable_nxapi_http: false
+      enable_nxapi_https: true
+      nxapi_http_port: 80
+      nxapi_https_port: 443
       vpc:
         peer_link_vlan: 3600
         peer_keep_alive: management
@@ -290,6 +294,9 @@ factory_defaults:
       ipv6_vtep_loopback_range: fd00::a10:0/120
       overlay_dci:
         deployment_method: Direct_To_BGWS
+        route_server:
+          redistribute_direct: false
+          ip_tag: 54321
         ipv4_dci_subnet_range: 10.10.1.0/24
         ipv4_dci_subnet_mask: 30
         ipv6_dci_subnet_range: fd00::a11:0/120


### PR DESCRIPTION
Add ENABLE_NXAPI and ENABLE_NXAPI_HTTP for isn fabric

## Related Issue(s)
Resolves #303 


## Related Collection Role
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
* [x] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Added the following parameters to isn_fabric_advanced.j2
```
   ENABLE_NXAPI: {{ vxlan.global.enable_nxapi | default(defaults.vxlan.global.enable_nxapi) }}
   ENABLE_NXAPI_HTTP: {{ vxlan.global.enable_nxapi_http | default(defaults.vxlan.global.enable_nxapi_http ) }}
```

## Test Notes


## Cisco NDFC Version
12.2.2


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
