### PR TITLE
Removed a second check_roles call that was not needed 

### DIFF
--- a/roles/validate/tasks/manage_model_files_previous.yml
+++ b/roles/validate/tasks/manage_model_files_previous.yml
@@ -21,12 +21,6 @@
 
 ---
 
-- name: Check Roles
-  cisco.nac_dc_vxlan.common.check_roles:
-    role_list: "{{ ansible_play_role_names }}"
-  register: check_roles
-  delegate_to: localhost
-
 # Check if golden and extended service model data files exist from previous runs
 - name: Stat the Golden Service Model Data
   ansible.builtin.stat: path="{{ role_path }}/files/{{ MD_Extended.vxlan.fabric.name }}_service_model_golden.json"


### PR DESCRIPTION
Second check_roles call was overwriting the check_roles var even when the task was being skipped. Seems like the ansible import_Task still runs the sub playbook tasks

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
