### PR TITLE
Fix for vpc interfaces being created on non-leaf roles

### DIFF
--- a/plugins/action/common/prepare_plugins/prep_106_topology_vpc_interfaces.py
+++ b/plugins/action/common/prepare_plugins/prep_106_topology_vpc_interfaces.py
@@ -60,6 +60,12 @@ class PreparePlugin:
                                             model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')] = model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')].get(switch.get('name'), {})  # noqa: E501
                                             # Assign interface to vxlan.topology.interfaces.vpc_interfaces.<peer1>___<peer2>.<vpc_id>.<switch_name>
                                             model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')] = interface  # noqa: E501
+
+                                            if switch.get('management').get('management_ipv4_address'):
+                                                model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')].update({'mgmt_ip_address': switch.get('management').get('management_ipv4_address')})
+                                            elif switch.get('management').get('management_ipv6_address'):
+                                                model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')].update({'mgmt_ip_address': switch.get('management').get('management_ipv6_address')})
+    
         # Update model_extended with updated model_data
         self.kwargs['results']['model_extended'] = model_data
         return self.kwargs['results']

--- a/plugins/action/common/prepare_plugins/prep_106_topology_vpc_interfaces.py
+++ b/plugins/action/common/prepare_plugins/prep_106_topology_vpc_interfaces.py
@@ -62,10 +62,10 @@ class PreparePlugin:
                                             model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')] = interface  # noqa: E501
 
                                             if switch.get('management').get('management_ipv4_address'):
-                                                model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')].update({'mgmt_ip_address': switch.get('management').get('management_ipv4_address')})
+                                                model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')].update({'mgmt_ip_address': switch.get('management').get('management_ipv4_address')})  # noqa: E501
                                             elif switch.get('management').get('management_ipv6_address'):
-                                                model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')].update({'mgmt_ip_address': switch.get('management').get('management_ipv6_address')})
-    
+                                                model_data['vxlan']['topology']['interfaces']['vpc_interfaces'][vpc_peer.get('peer1') + "___" + vpc_peer.get('peer2')][interface.get('vpc_id')][switch.get('name')].update({'mgmt_ip_address': switch.get('management').get('management_ipv6_address')})  # noqa: E501
+
         # Update model_extended with updated model_data
         self.kwargs['results']['model_extended'] = model_data
         return self.kwargs['results']

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
@@ -12,17 +12,9 @@
 {% set peer2 = switch_names[1] %}
 - name: vpc{{ vpc_id }}
   type: vpc
-  switch: 
-{% if MD_Extended.vxlan.topology.leaf[peer1].management_ipv4_address is defined %}
-    - {{ MD_Extended.vxlan.topology.leaf[peer1].management_ipv4_address }}
-{% elif MD_Extended.vxlan.topology.leaf[peer1].management_ipv6_address is defined %}
-    - {{ MD_Extended.vxlan.topology.leaf[peer1].management_ipv6_address }}
-{% endif %}
-{% if MD_Extended.vxlan.topology.leaf[peer2].management_ipv4_address is defined %}
-    - {{ MD_Extended.vxlan.topology.leaf[peer2].management_ipv4_address }}
-{% elif MD_Extended.vxlan.topology.leaf[peer2].management_ipv6_address is defined %}
-    - {{ MD_Extended.vxlan.topology.leaf[peer2].management_ipv6_address }}
-{% endif %}
+  switch:
+    - {{ switches[peer1]['mgmt_ip_address'] }}
+    - {{ switches[peer2]['mgmt_ip_address'] }}
   deploy: false
   profile:
     admin_state: {{ switches[peer1].enabled | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled) }}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Resolves #311 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
This change maps the mgmt ip address into the vpc interfaces data for lookup later in the templating.
The templating is refactored to use the mgmt ip address lookup vs hardcoded leaf role.

## Test Notes
<!--- Please provide notes or description of testing -->
Tested create and removal of vpc interface.

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2.2

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
