### PR TITLE
Update github templates to add quick copy option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     id: ansible-version
     attributes:
       label: Ansible Version
-      description: Please provide your Ansible version used when encountering this issue by grabbing ```ansible --version```
+      description: Please provide your Ansible version used when encountering this issue from ```ansible --version```
       placeholder: ansible --version
       render: shell
     validations:
@@ -32,7 +32,7 @@ body:
     id: ansible-collection-versions
     attributes:
       label: Ansible Collection Versions
-      description: Please provide your Ansible Collection versions used when encountering this issue
+      description: Please provide your Ansible Collection versions used when encountering this issue from ```ansible-galaxy collection list```
       placeholder: ansible-galaxy collection list
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     id: ansible-version
     attributes:
       label: Ansible Version
-      description: Please provide your Ansible version used when encountering this issue
+      description: Please provide your Ansible version used when encountering this issue by grabbing ```ansible --version```
       placeholder: ansible --version
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     id: ansible-version
     attributes:
       label: Ansible Version
-      description: Please provide your Ansible version used when encountering this issue from ```ansible --version```
+      description: Please provide your Ansible version used when encountering this issue using ```ansible --version```
       placeholder: ansible --version
       render: shell
     validations:
@@ -32,7 +32,7 @@ body:
     id: ansible-collection-versions
     attributes:
       label: Ansible Collection Versions
-      description: Please provide your Ansible Collection versions used when encountering this issue from ```ansible-galaxy collection list```
+      description: Please provide your Ansible Collection versions used when encountering this issue using ```ansible-galaxy collection list```
       placeholder: ansible-galaxy collection list
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -78,7 +78,7 @@ body:
     id: ansible-version
     attributes:
       label: Ansible Version
-      description: Please provide your Ansible version used when encountering this issue
+      description: Please provide your Ansible version used when encountering this issue from ```ansible --version```
       placeholder: ansible --version
       render: shell
     validations:
@@ -88,7 +88,7 @@ body:
     id: ansible-collection-versions
     attributes:
       label: Ansible Collection Versions
-      description: Please provide your Ansible Collection versions used when encountering this issue
+      description: Please provide your Ansible Collection versions used when encountering this issue from ```ansible-galaxy collection list```
       placeholder: ansible-galaxy collection list
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -78,7 +78,7 @@ body:
     id: ansible-version
     attributes:
       label: Ansible Version
-      description: Please provide your Ansible version used when encountering this issue from ```ansible --version```
+      description: Please provide your Ansible version used when encountering this issue using ```ansible --version```
       placeholder: ansible --version
       render: shell
     validations:
@@ -88,7 +88,7 @@ body:
     id: ansible-collection-versions
     attributes:
       label: Ansible Collection Versions
-      description: Please provide your Ansible Collection versions used when encountering this issue from ```ansible-galaxy collection list```
+      description: Please provide your Ansible Collection versions used when encountering this issue using ```ansible-galaxy collection list```
       placeholder: ansible-galaxy collection list
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -117,7 +117,7 @@ body:
     id: ansible-collection-versions
     attributes:
       label: Ansible Collection Versions
-      description: Please provide your Ansible Collection versions used when encountering this issue from ```ansible-galaxy collection list```
+      description: Please provide your Ansible Collection versions if this requires some new collection or updated version from ```ansible-galaxy collection list```
       placeholder: ansible-galaxy collection list
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -97,7 +97,7 @@ body:
     id: ansible-version
     attributes:
       label: Ansible Version
-      description: Please provide your Ansible version used when encountering this issue
+      description: Please provide your Ansible version used when encountering this issue from ```ansible --version```
       placeholder: ansible --version
       render: shell
     validations:
@@ -107,7 +107,7 @@ body:
     id: ansible-collection-versions
     attributes:
       label: Ansible Collection Versions
-      description: Please provide your Ansible Collection versions used when encountering this issue
+      description: Please provide your Ansible Collection versions used when encountering this issue from ```ansible-galaxy collection list```
       placeholder: ansible-galaxy collection list
       render: shell
     validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -35,6 +35,16 @@ body:
       required: true
 
   - type: textarea
+    id: new-feature
+    attributes:
+      label: "New feature description:"
+      description: Please provide input on the new feature required
+      placeholder: New feature description
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
     id: new-feature-role
     attributes:
       label: Would this be a new feature requiring a new role?
@@ -97,7 +107,7 @@ body:
     id: ansible-version
     attributes:
       label: Ansible Version
-      description: Please provide your Ansible version used when encountering this issue from ```ansible --version```
+      description: Please provide your Ansible version used if this requires some new feature from Ansible using ```ansible --version```
       placeholder: ansible --version
       render: shell
     validations:
@@ -117,7 +127,7 @@ body:
     id: ndfc-version
     attributes:
       label: Cisco NDFC Version
-      description: Please provide your Cisco NDFC version used when encountering this issue
+      description: Please provide your Cisco NDFC version being used
       render: shell
     validations:
       required: false
@@ -126,7 +136,7 @@ body:
     id: nxos-version
     attributes:
       label: Cisco NX-OS Version
-      description: Please provide your Cisco NX-OS version used when encountering this issue
+      description: Please provide your Cisco NX-OS version being used
       render: shell
     validations:
       required: false


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
N/A

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Updated sentence under ansible version and ansible collection sections so that users can quickly copy and then paste ```ansible --version``` or ```ansible-galaxy collection list``` into their terminals or setups.

## Test Notes
<!--- Please provide notes or description of testing -->
N/A

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
N/A

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
