### PR TITLE
Fix rule 305 - Not able to create same vpc_id with different vPC pair

### DIFF
--- a/roles/validate/files/rules/vxlan/305_topology_switch_interfaces_vpc.py
+++ b/roles/validate/files/rules/vxlan/305_topology_switch_interfaces_vpc.py
@@ -127,12 +127,8 @@ class Rule:
                     if pair in switch_interfaces:
                         switch_interfaces_pair.update({pair: switch_interfaces[pair]})
 
-                if len(switch_interfaces_pair) > 2:
-                    results.append(
-                        f"vpc_id : {vpc_id} is referenced by more than 2 switches. Switches : {', '.join(switch_interfaces_pair.keys())}"
-                    )
                 # Check if vPC id is only referenced by a single switch but must be referenced by both vPC peer switches
-                elif len(switch_interfaces_pair) > 0 and len(switch_interfaces_pair) < 2:
+                if len(switch_interfaces_pair) > 0 and len(switch_interfaces_pair) < 2:
                     results.append(
                         f"vpc_id : {vpc_id} is only referenced by a single switch {', '.join(switch_interfaces_pair.keys())} "
                         "but must be referenced by both vPC peer switches"

--- a/roles/validate/files/rules/vxlan/305_topology_switch_interfaces_vpc.py
+++ b/roles/validate/files/rules/vxlan/305_topology_switch_interfaces_vpc.py
@@ -118,24 +118,26 @@ class Rule:
                             vpc_interfaces_dict_parameters[vpc_id]["interfaces"][
                                 vpc_id_int
                             ][param] = interface.get(param)
+
         for vpc_id, switch_interfaces in vpc_interfaces_dict.items():
             # Check if vPC id is referenced by more than 2 switches
-            if len(switch_interfaces) > 2:
-                results.append(
-                    f"vpc_id : {vpc_id} is referenced by more than 2 switches. Switches : {', '.join(switch_interfaces.keys())}"
-                )
-            # Check if vPC id is only referenced by a single switch but must be referenced by both vPC peer switches
-            elif len(switch_interfaces) > 0 and len(switch_interfaces) < 2:
-                results.append(
-                    f"vpc_id : {vpc_id} is only referenced by a single switch {', '.join(switch_interfaces.keys())} "
-                    "but must be referenced by both vPC peer switches"
-                )
-            # Check if vPC id is only configured on vPC peers
-            else:
-                if not sorted(list(switch_interfaces.keys())) in vpc_peers_list:
+            for pairs in vpc_peers_list:
+                switch_interfaces_pair = {}
+                for pair in pairs:
+                    if pair in switch_interfaces:
+                        switch_interfaces_pair.update({pair: switch_interfaces[pair]})
+
+                if len(switch_interfaces_pair) > 2:
                     results.append(
-                        f"vpc_id : {vpc_id} can only be configured on vPC peers. Switches : {', '.join(switch_interfaces.keys())} are not vPC peers"
+                        f"vpc_id : {vpc_id} is referenced by more than 2 switches. Switches : {', '.join(switch_interfaces_pair.keys())}"
                     )
+                # Check if vPC id is only referenced by a single switch but must be referenced by both vPC peer switches
+                elif len(switch_interfaces_pair) > 0 and len(switch_interfaces_pair) < 2:
+                    results.append(
+                        f"vpc_id : {vpc_id} is only referenced by a single switch {', '.join(switch_interfaces_pair.keys())} "
+                        "but must be referenced by both vPC peer switches"
+                    )
+
         for vpc_id, interfaces in vpc_interfaces_dict_parameters.items():
             # Check if vPC interfaces have same values for parameters on vpc_params_to_match list
             if len(interfaces["interfaces"]) == 2:


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

Fix #331

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Check vpc_id per pair of switches and across all switches.

## Test Notes
<!--- Please provide notes or description of testing -->

leaf1~leaf2: 
* vpc_id: 100

bleaf1~bleaf2:
* vpc_id: 100
* vpc_id: 101

Data source to test:
```
---
vxlan:
  topology:
    vpc_peers:
      - peer1: netascode-leaf1
        peer2: netascode-leaf2
        peer1_peerlink_interfaces:
          - name: Ethernet1/4
        peer2_peerlink_interfaces:
          - name: Ethernet1/4
        domain_id: 10
        fabric_peering: false
      - peer1: netascode-borderleaf1
        peer2: netascode-borderleaf2
        peer1_peerlink_interfaces:
          - name: Ethernet1/4
        peer2_peerlink_interfaces:
          - name: Ethernet1/4
        domain_id: 20
        fabric_peering: false
    switches:
      - name: netascode-leaf1
        role: leaf
        management:
          default_gateway_v4: 10.229.42.254
          management_ipv4_address: 10.229.42.121
        serial_number: 94WN5222IZ3
        interfaces:
          - name: port-channel100
            mode: access
            enabled: true
            pc_mode: active
            vpc_id: 100  # (VPC Port-channel)
            mtu: jumbo
            speed: auto
            spanning_tree_portfast: true
            enable_bpdu_guard: true
            members:
              - eth1/6
      - name: netascode-leaf2
        role: leaf
        management:
          default_gateway_v4: 10.229.42.254
          management_ipv4_address: 10.229.42.122
        serial_number: 9WOLPXTSUHB
        interfaces:
          - name: port-channel100
            mode: access
            enabled: true
            pc_mode: active
            vpc_id: 100  # (VPC Port-channel)
            mtu: jumbo
            speed: auto
            spanning_tree_portfast: true
            enable_bpdu_guard: true
            members:
              - eth1/6

      - name: netascode-borderleaf1
        role: border
        management:
          default_gateway_v4: 10.229.42.254
          management_ipv4_address: 10.229.42.111
        serial_number: 9JPVU1JTJOS
        interfaces:
          - name: port-channel100
            mode: access
            enabled: true
            pc_mode: active
            vpc_id: 100  # (VPC Port-channel)
            mtu: jumbo
            speed: auto
            spanning_tree_portfast: true
            enable_bpdu_guard: true
            members:
              - eth1/6
          - name: port-channel101
            mode: access
            enabled: true
            pc_mode: active
            vpc_id: 101  # (VPC Port-channel)
            mtu: jumbo
            speed: auto
            spanning_tree_portfast: true
            enable_bpdu_guard: true
            members:
              - eth1/16

      - name: netascode-borderleaf2
        role: border
        management:
          default_gateway_v4: 10.229.42.254
          management_ipv4_address: 10.229.42.112
        serial_number: 91YUI1NIN9D
        interfaces:
          - name: port-channel100
            mode: access
            enabled: true
            pc_mode: active
            vpc_id: 100  # (VPC Port-channel)
            mtu: jumbo
            speed: auto
            spanning_tree_portfast: true
            enable_bpdu_guard: true
            members:
              - eth1/6
          - name: port-channel101
            mode: access
            enabled: true
            pc_mode: active
            vpc_id: 101  # (VPC Port-channel)
            mtu: jumbo
            speed: auto
            spanning_tree_portfast: true
            enable_bpdu_guard: true
            members:
              - eth1/16
```

```
❯ iac-validate -s schemas/schema.yaml -r collections/ansible_collections/cisco/nac_dc_vxlan/roles/validate/files/rules/vxlan/ host_vars/nac-ndfc1/topology_switches.nac-test.yaml -v DEBUG
INFO - Loading schema
INFO - Loading rules
INFO - Validate file: topology_switches.nac-test.yaml
INFO - Loading yaml files from ('host_vars/nac-ndfc1/topology_switches-test.nac.yaml',)
INFO - Verifying rule id 502
INFO - Verifying rule id 403
INFO - Verifying rule id 30
INFO - Verifying rule id 301
INFO - Verifying rule id 305
INFO - Verifying rule id 203
INFO - Verifying rule id 302
INFO - Verifying rule id 304
INFO - Verifying rule id 401
INFO - Verifying rule id 202
INFO - Verifying rule id 402
INFO - Verifying rule id 505
INFO - Verifying rule id 201
INFO - Verifying rule id 303
INFO - Verifying rule id 501
```



## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
