### PR TITLE
Fix for Policy Bannerdelimiter

### DIFF
--- a/roles/dtc/common/templates/ndfc_policy.j2
+++ b/roles/dtc/common/templates/ndfc_policy.j2
@@ -33,6 +33,8 @@
 {% elif key == "BANNER" %}
             {{ key }}: |
               {{ value | indent(14) }}
+{% elif key == "BANNERDELIMITER" %}
+            {{ key }}: "{{ value }}"
 {% elif key in ["asn", "BGP_AS", "BGP_ASN", "NEIGHBOR_ASN"] %}
             {{ key }}: "{{ value | string | indent(12) | trim }}"
 {% elif value is iterable and '\n' in value %}


### PR DESCRIPTION
## Related Issue(s)
Fixes #355 


## Related Collection Role
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [x] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Add double-quotes to input for DANNERDELIMITER
```
{% elif key == "BANNERDELIMITER" %}
            {{ key }}: "{{ value }}"
```

## Test Notes
All tests successful. No errors. Successfully deployed fabric with banner policy.


## Cisco NDFC Version
12.2


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
