### PR TITLE
Fixed layer2_host_interfacde_mtu typo

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/advanced/dc_vxlan_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/advanced/dc_vxlan_fabric_advanced.j2
@@ -22,7 +22,7 @@
 {% endif %}
   SNMP_SERVER_HOST_TRAP: {{ vxlan.global.snmp_server_host_trap | default(defaults.vxlan.global.snmp_server_host_trap) }}
   FABRIC_MTU: {{ vxlan.underlay.general.intra_fabric_interface_mtu | default(defaults.vxlan.underlay.general.intra_fabric_interface_mtu) }}
-  L2_HOST_INTF_MTU: {{ vxlan.underlay.general.layer2_host_interfacde_mtu | default(defaults.vxlan.underlay.general.layer2_host_interfacde_mtu) }}
+  L2_HOST_INTF_MTU: {{ vxlan.underlay.general.layer2_host_interface_mtu | default(defaults.vxlan.underlay.general.layer2_host_interface_mtu) }}
   HOST_INTF_ADMIN_STATE: {{ vxlan.underlay.general.unshut_host_interfaces | default(defaults.vxlan.underlay.general.unshut_host_interfaces) }}
 {% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=') %}
   STP_ROOT_OPTION: {{ vxlan.global.spanning_tree.root_bridge_protocol | default(defaults.vxlan.global.spanning_tree.root_bridge_protocol) }}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -136,7 +136,7 @@ factory_defaults:
         underlay_routing_protocol_tag: UNDERLAY
         underlay_rp_loopback_id: 254
         intra_fabric_interface_mtu: 9216
-        layer2_host_interfacde_mtu: 9216
+        layer2_host_interface_mtu: 9216
         unshut_host_interfaces: true
       ipv4:
         underlay_routing_loopback_ip_range: 10.2.0.0/22

--- a/tests/integration/host_vars/examples/fabric_empty_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_empty_example/underlay.yaml
@@ -34,7 +34,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: True
     ipv4:
       underlay_routing_loopback_ip_range: 10.2.0.0/22

--- a/tests/integration/host_vars/examples/fabric_full_large_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_large_example/underlay.yaml
@@ -34,7 +34,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: True
     ipv4:
       underlay_routing_loopback_ip_range: 10.2.0.0/22

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_ingress_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_ingress_example/underlay.yaml
@@ -34,7 +34,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: True
     ipv4:
       underlay_routing_loopback_ip_range: 10.2.0.0/22

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_asm_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_asm_example/underlay.yaml
@@ -34,7 +34,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: True
     ipv4:
       underlay_routing_loopback_ip_range: 10.2.0.0/22

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_bidir_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_bidir_example/underlay.yaml
@@ -34,7 +34,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: True
     ipv4:
       underlay_routing_loopback_ip_range: 10.2.0.0/22

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_ingress_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_ingress_example/underlay.yaml
@@ -34,7 +34,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: True
     ipv4:
       underlay_routing_loopback_ip_range: 10.2.0.0/22

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_asm_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_asm_example/underlay.yaml
@@ -34,7 +34,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: True
     ipv4:
       underlay_routing_loopback_ip_range: 10.2.0.0/22

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_bidir_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_bidir_example/underlay.yaml
@@ -34,7 +34,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: True
     ipv4:
       underlay_routing_loopback_ip_range: 10.2.0.0/22


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [X] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [X] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [X] defaults.vxlan
* [ ] other

## Proposed Changes
Replaced layer2_host_interfacde_mtu key with layer2_host_interface_mtu in all applicable files. 


## Test Notes
NA


## Cisco NDFC Version
NA


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
