### PR TITLE
PTP fix 371

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
@@ -1,8 +1,10 @@
 {# Auto-generated NDFC DC VXLAN EVPN Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
   POWER_REDUNDANCY_MODE: ps-redundant
   FEATURE_PTP: {{ vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) }}
+{% if vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) %}
   PTP_DOMAIN_ID: {{ vxlan.global.ptp.domain_id | default(defaults.vxlan.global.ptp.domain_id) }}
   PTP_LB_ID: {{ vxlan.global.ptp.lb_id | default(defaults.vxlan.global.ptp.lb_id) }}
+{% endif %}
   ENABLE_NXAPI: {{ vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) }}
 {% if vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) %}
   NXAPI_HTTPS_PORT: {{ vxlan.global.nxapi_https_port | default(defaults.vxlan.global.nxapi_https_port) }}
@@ -10,7 +12,7 @@
   ENABLE_NXAPI_HTTP: {{ vxlan.global.enable_nxapi_http | default(defaults.vxlan.global.enable_nxapi_http) }}
 {% if vxlan.global.enable_nxapi_http | default(defaults.vxlan.global.enable_nxapi_http) %}
   NXAPI_HTTP_PORT: {{ vxlan.global.nxapi_http_port | default(defaults.vxlan.global.nxapi_http_port) }}
-{% endif %} 
+{% endif %}
   SNMP_SERVER_HOST_TRAP: {{ vxlan.global.snmp_server_host_trap | default(defaults.vxlan.global.snmp_server_host_trap) }}
 {% if vxlan.global.bootstrap is defined and vxlan.global.bootstrap.enable_cdp_mgmt is defined %}
   CDP_ENABLE: {{ vxlan.global.bootstrap.enable_cdp_mgmt }}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
@@ -2,8 +2,8 @@
   POWER_REDUNDANCY_MODE: ps-redundant
   FEATURE_PTP: {{ vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) }}
 {% if vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) %}
-  PTP_DOMAIN_ID: {{ vxlan.global.ptp.domain_id | default(defaults.vxlan.global.ptp.domain_id) }}
-  PTP_LB_ID: {{ vxlan.global.ptp.lb_id | default(defaults.vxlan.global.ptp.lb_id) }}
+  PTP_DOMAIN_ID: {{ vxlan.global.ptp.domain_id }}
+  PTP_LB_ID: {{ vxlan.global.ptp.lb_id }}
 {% endif %}
   ENABLE_NXAPI: {{ vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) }}
 {% if vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) %}


### PR DESCRIPTION
Update so that if PTP is not passed in to external fabric creation there is no issue creating the fabric

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ X] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Add support so that if PTP is not passed into fabric, there is no error

## Test Notes
<!--- Please provide notes or description of testing -->
Tested by creating an external fabric without any PTP settings

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2.2

## Checklist

* [ x] Latest commit is rebased from develop with merge conflicts resolved
* [ x] New or updates to documentation has been made accordingly
* [ x] Assigned the proper reviewers
