### PR TITLE
Fixes for External fabric and External fabric_links

### DIFF
--- a/roles/dtc/common/tasks/main.yml
+++ b/roles/dtc/common/tasks/main.yml
@@ -69,6 +69,7 @@
     vars_common_external:
         changes_detected_inventory: false
         changes_detected_fabric: false
+        changes_detected_fabric_links: false
         changes_detected_interface_access_po: false
         changes_detected_interface_access: false
         changes_detected_interfaces: false

--- a/roles/dtc/common/tasks/sub_main_external.yml
+++ b/roles/dtc/common/tasks/sub_main_external.yml
@@ -83,7 +83,10 @@
   ansible.builtin.import_tasks: common/ndfc_interface_all.yml
 
 - name: Build NDFC Policy List From Template
-  ansible.builtin.import_tasks: common/ndfc_policy.yml 
+  ansible.builtin.import_tasks: common/ndfc_policy.yml
+
+- name: Build Fabric Links List From Template
+  ansible.builtin.import_tasks: common/ndfc_fabric_links.yml
 
 - name: Edge Connections List From Template
   ansible.builtin.import_tasks: common/ndfc_edge_connections.yml
@@ -95,6 +98,7 @@
   ansible.builtin.set_fact:
     vars_common_external:
         changes_detected_fabric: "{{ changes_detected_fabric }}"
+        changes_detected_fabric_links: "{{ changes_detected_fabric_links }}"
         changes_detected_inventory: "{{ changes_detected_inventory }}"
         changes_detected_edge_connections: "{{ changes_detected_edge_connections }}"
         changes_detected_interface_access_po: "{{ changes_detected_interface_access_po }}"
@@ -108,6 +112,7 @@
         changes_detected_interfaces: "{{ changes_detected_interfaces }}"
         changes_detected_policy: "{{ changes_detected_policy }}"
         fabric_config: "{{ fabric_config }}"
+        fabric_links: "{{ fabric_links }}"
         edge_connections: "{{ edge_connections }}"
         interface_access_po: "{{ interface_access_po }}"
         interface_access: "{{ interface_access }}"
@@ -143,6 +148,7 @@
       - "+     All Interfaces Changes Detected -       [ {{ vars_common_external.changes_detected_interfaces }} ]"
       - "+     ----- All Interfaces -----"
       - "+     Policy Changes Detected -               [ {{ vars_common_external.changes_detected_policy }} ]"
+      - "+     Fabric Links Changes Detected -         [ {{ vars_common_external.changes_detected_fabric_links }} ]"
       - "+     ----- Run Map -----"
       - "+     Run Map Diff Run -                      [ {{ run_map_read_result.diff_run }} ]"
       - "+     Force Run Flag  -                       [ {{ force_run_all }} ]"

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
@@ -1,8 +1,10 @@
 {# Auto-generated NDFC DC VXLAN EVPN Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
   POWER_REDUNDANCY_MODE: ps-redundant
   FEATURE_PTP: {{ vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) }}
-  PTP_DOMAIN_ID: {{ vxlan.global.ptp.domain_id | default(defaults.vxlan.global.ptp.domain_id) }}
-  PTP_LB_ID: {{ vxlan.global.ptp.lb_id | default(defaults.vxlan.global.ptp.lb_id) }}
+{% if vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) %}
+  PTP_DOMAIN_ID: {{ vxlan.global.ptp.domain_id }}
+  PTP_LB_ID: {{ vxlan.global.ptp.lb_id }}
+{% endif %}
   ENABLE_NXAPI: {{ vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) }}
 {% if vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) %}
   NXAPI_HTTPS_PORT: {{ vxlan.global.nxapi_https_port | default(defaults.vxlan.global.nxapi_https_port) }}
@@ -10,7 +12,7 @@
   ENABLE_NXAPI_HTTP: {{ vxlan.global.enable_nxapi_http | default(defaults.vxlan.global.enable_nxapi_http) }}
 {% if vxlan.global.enable_nxapi_http | default(defaults.vxlan.global.enable_nxapi_http) %}
   NXAPI_HTTP_PORT: {{ vxlan.global.nxapi_http_port | default(defaults.vxlan.global.nxapi_http_port) }}
-{% endif %} 
+{% endif %}
   SNMP_SERVER_HOST_TRAP: {{ vxlan.global.snmp_server_host_trap | default(defaults.vxlan.global.snmp_server_host_trap) }}
 {% if vxlan.global.bootstrap is defined and vxlan.global.bootstrap.enable_cdp_mgmt is defined %}
   CDP_ENABLE: {{ vxlan.global.bootstrap.enable_cdp_mgmt }}

--- a/roles/dtc/common/templates/ndfc_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory.j2
@@ -16,7 +16,7 @@
 {% elif vxlan.fabric.type == 'External' %}
 
 {# Include NDFC DC External Template #}
-{% include '/ndfc_inventory/common/fabric_inventory.j2' %}
+{% include '/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2' %}
 
-{# Supported fabric types are: DC VXLAN EVPN and ISN #}
+{# Supported fabric types are: DC VXLAN EVPN, ISN, and External #}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2
@@ -1,3 +1,4 @@
+{# Auto-generated NDFC DC External Inventory config data structure for fabric {{ vxlan.fabric.name }} #}
 {% set poap_data = poap_data['poap_data'] %}
 {% for switch in MD_Extended.vxlan.topology.switches %}
 {% if switch.management.management_ipv4_address is defined %}
@@ -10,7 +11,7 @@
   password: PLACE_HOLDER_PASSWORD
   max_hops: 0 # this is the default value as it is not defined into the data model
   role: {{ switch['role'] }}
-  preserve_config: false
+  preserve_config: true
 {% if MD_Extended.vxlan.global.bootstrap is defined %}
 {% if MD_Extended.vxlan.global.bootstrap.enable_bootstrap is defined and MD_Extended.vxlan.global.bootstrap.enable_bootstrap %}
 {% if switch.poap is defined and switch.poap.bootstrap %}
@@ -31,7 +32,7 @@
       version: {{ switch['poap']['preprovision']['version']  }}
       config_data:
         modulesModel: {{ switch['poap']['preprovision']['modulesModel'] }}
-        gateway: {{ switch['management']['default_gateway_v4']  }} 
+        gateway: {{ switch['management']['default_gateway_v4']  }}
       hostname: {{ switch['name'] }}
 {% endif %}
 {% endif %}

--- a/roles/dtc/create/tasks/main.yml
+++ b/roles/dtc/create/tasks/main.yml
@@ -59,7 +59,8 @@
     (vars_common_external.changes_detected_inventory) or
     (vars_common_external.changes_detected_interfaces) or
     (vars_common_external.changes_detected_fabric) or
-    (vars_common_external.changes_detected_interface_access_po) or 
+    (vars_common_external.changes_detected_fabric_links) or
+    (vars_common_external.changes_detected_interface_access_po) or
     (vars_common_external.changes_detected_interface_access) or
     (vars_common_external.changes_detected_interface_loopback) or
     (vars_common_external.changes_detected_interface_po_routed) or

--- a/roles/dtc/create/tasks/sub_main_external.yml
+++ b/roles/dtc/create/tasks/sub_main_external.yml
@@ -62,6 +62,13 @@
     - vars_common_external.changes_detected_interfaces
   tags: "{{ nac_tags.create_interfaces }}"
 
+- name: Manage NDFC External Fabric Intra Links
+  ansible.builtin.import_tasks: common/links.yml
+  when:
+    - MD_Extended.vxlan.topology.fabric_links | length > 0
+    - vars_common_vxlan.changes_detected_fabric_links
+  tags: "{{ nac_tags.create_links }}"
+
 - name: Manage NDFC External Fabric Policies
   ansible.builtin.import_tasks: common/policies.yml
   when:

--- a/roles/dtc/deploy/tasks/main.yml
+++ b/roles/dtc/deploy/tasks/main.yml
@@ -80,6 +80,7 @@
   when: >
     (MD_Extended.vxlan.fabric.type == 'External') and
     (vars_common_external.changes_detected_fabric or
+    vars_common_external.changes_detected_fabric_links or
     vars_common_external.changes_detected_interface_access_po or
     vars_common_external.changes_detected_interface_access or
     vars_common_external.changes_detected_interfaces or

--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -56,7 +56,8 @@
   ansible.builtin.import_tasks: sub_main_external.yml
   when: >
     (MD_Extended.vxlan.fabric.type == 'External') and
-    (vars_common_external.changes_detected_interfaces or
+    (vars_common_external.changes_detected_fabric_links or
+    vars_common_external.changes_detected_interfaces or
     vars_common_external.changes_detected_inventory or
     vars_common_external.changes_detected_policy or
     vars_common_external.changes_detected_edge_connections)


### PR DESCRIPTION
## Related Issue(s)
Fixes #373 


## Related Collection Role
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [x] cisco.nac_dc_vxlan.dtc.deploy
* [x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
* [x] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [x] other

## Proposed Changes
Multiple fixes for External fabrics. 
Add full support for Fabric Links for external.
Use the correct fabric jinja template for External Fabric

## Test Notes
Deploy Fabric type External with all Roles enabled.
```
  roles:
    - role: cisco.nac_dc_vxlan.dtc.create
      tags: 'role_create'

    - role: cisco.nac_dc_vxlan.dtc.deploy
      tags: 'role_deploy'

    - role: cisco.nac_dc_vxlan.dtc.remove
      tags: 'role_remove'
```
```
---
vxlan:
  fabric:
    name: nac-fabric1-dmz-ext
    type: External
  global:
    bgp_asn: "65005"
```

## Cisco NDFC Version
12.2.3


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers