### PR TITLE
Remove fabric_links reference for External Fabrics. Fix for External Fabric Inventory templates

### DIFF
--- a/roles/dtc/common/tasks/sub_main_external.yml
+++ b/roles/dtc/common/tasks/sub_main_external.yml
@@ -83,7 +83,7 @@
   ansible.builtin.import_tasks: common/ndfc_interface_all.yml
 
 - name: Build NDFC Policy List From Template
-  ansible.builtin.import_tasks: common/ndfc_policy.yml 
+  ansible.builtin.import_tasks: common/ndfc_policy.yml
 
 - name: Edge Connections List From Template
   ansible.builtin.import_tasks: common/ndfc_edge_connections.yml

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
@@ -1,4 +1,4 @@
-{# Auto-generated NDFC DC VXLAN EVPN Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC External Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
   POWER_REDUNDANCY_MODE: ps-redundant
   FEATURE_PTP: {{ vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) }}
 {% if vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/advanced/dc_external_fabric_advanced.j2
@@ -1,8 +1,10 @@
 {# Auto-generated NDFC DC VXLAN EVPN Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
   POWER_REDUNDANCY_MODE: ps-redundant
   FEATURE_PTP: {{ vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) }}
-  PTP_DOMAIN_ID: {{ vxlan.global.ptp.domain_id | default(defaults.vxlan.global.ptp.domain_id) }}
-  PTP_LB_ID: {{ vxlan.global.ptp.lb_id | default(defaults.vxlan.global.ptp.lb_id) }}
+{% if vxlan.global.ptp.enable | default(defaults.vxlan.global.ptp.enable) %}
+  PTP_DOMAIN_ID: {{ vxlan.global.ptp.domain_id }}
+  PTP_LB_ID: {{ vxlan.global.ptp.lb_id }}
+{% endif %}
   ENABLE_NXAPI: {{ vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) }}
 {% if vxlan.global.enable_nxapi_https | default(defaults.vxlan.global.enable_nxapi_https) %}
   NXAPI_HTTPS_PORT: {{ vxlan.global.nxapi_https_port | default(defaults.vxlan.global.nxapi_https_port) }}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
@@ -1,4 +1,4 @@
-{# Auto-generated NDFC DC VXLAN EVPN General config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC VXLAN EVPN Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
   BGP_AS: "{{ vxlan.global.bgp_asn }}"
 
 {% if not (vxlan.global.bootstrap.enable_bootstrap | default(defaults.vxlan.global.bootstrap.enable_bootstrap) | ansible.builtin.bool) %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
@@ -1,4 +1,4 @@
-{# Auto-generated NDFC DC VXLAN EVPN General config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC External General config data structure for fabric {{ vxlan.fabric.name }} #}
   BGP_AS: "{{ vxlan.global.bgp_asn }}"
   IS_READ_ONLY: false
 {# #}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
@@ -1,4 +1,4 @@
-{# Auto-generated NDFC DC VXLAN EVPN Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC External Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
   BGP_AS: "{{ vxlan.global.bgp_asn }}"
 
 {% if not (vxlan.global.bootstrap.enable_bootstrap | default(defaults.vxlan.global.bootstrap.enable_bootstrap) | ansible.builtin.bool) %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
@@ -1,4 +1,4 @@
 {# Auto-generated NDFC DC VXLAN EVPN General config data structure for fabric {{ vxlan.fabric.name }} #}
   BGP_AS: "{{ vxlan.global.bgp_asn }}"
-
+  IS_READ_ONLY: false
 {# #}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
@@ -1,4 +1,4 @@
-{# Auto-generated NDFC DC External Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC External General config data structure for fabric {{ vxlan.fabric.name }} #}
   BGP_AS: "{{ vxlan.global.bgp_asn }}"
 
 {% if not (vxlan.global.bootstrap.enable_bootstrap | default(defaults.vxlan.global.bootstrap.enable_bootstrap) | ansible.builtin.bool) %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_external_fabric/general/dc_external_fabric_general.j2
@@ -1,4 +1,9 @@
-{# Auto-generated NDFC DC External General config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC VXLAN EVPN General config data structure for fabric {{ vxlan.fabric.name }} #}
   BGP_AS: "{{ vxlan.global.bgp_asn }}"
+
+{% if not (vxlan.global.bootstrap.enable_bootstrap | default(defaults.vxlan.global.bootstrap.enable_bootstrap) | ansible.builtin.bool) %}
   IS_READ_ONLY: false
+{% else %}
+  IS_READ_ONLY: ""
+{% endif %}
 {# #}

--- a/roles/dtc/common/templates/ndfc_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory.j2
@@ -16,7 +16,7 @@
 {% elif vxlan.fabric.type == 'External' %}
 
 {# Include NDFC DC External Template #}
-{% include '/ndfc_inventory/common/fabric_inventory.j2' %}
+{% include '/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2' %}
 
-{# Supported fabric types are: DC VXLAN EVPN and ISN #}
+{# Supported fabric types are: DC VXLAN EVPN, ISN and External #}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2
@@ -10,7 +10,7 @@
   password: PLACE_HOLDER_PASSWORD
   max_hops: 0 # this is the default value as it is not defined into the data model
   role: {{ switch['role'] }}
-  preserve_config: false
+  preserve_config: true
 {% if MD_Extended.vxlan.global.bootstrap is defined %}
 {% if MD_Extended.vxlan.global.bootstrap.enable_bootstrap is defined and MD_Extended.vxlan.global.bootstrap.enable_bootstrap %}
 {% if switch.poap is defined and switch.poap.bootstrap %}

--- a/roles/dtc/remove/tasks/sub_main_external.yml
+++ b/roles/dtc/remove/tasks/sub_main_external.yml
@@ -56,12 +56,6 @@
   when:
     - vars_common_external.changes_detected_interfaces
 
-- name: Remove Fabric Links
-  ansible.builtin.import_tasks: common/links.yml
-  tags: "{{ nac_tags.remove_links }}"
-  when:
-    - vars_common_external.changes_detected_fabric_links
-
 # Feature not implemented yet, currently vars_common_external.changes_detected_vpc_peering is not being set so will
 # currently cause an undefined variable error.
 # - name: Remove Fabric vPC Peering


### PR DESCRIPTION
## Related Issue(s)
Fixes #373 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [x] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [x] other

## Proposed Changes
Remove reference to Fabric Links for External Fabrics
Use the correct fabric jinja template for External Fabric and set preserve_config = true

## Test Notes
Deploy Fabric type External with all Roles enabled.
```
  roles:
    - role: cisco.nac_dc_vxlan.dtc.create
      tags: 'role_create'

    - role: cisco.nac_dc_vxlan.dtc.deploy
      tags: 'role_deploy'

    - role: cisco.nac_dc_vxlan.dtc.remove
      tags: 'role_remove'
```
```
---
vxlan:
  fabric:
    name: nac-fabric1-dmz-ext
    type: External
  global:
    bgp_asn: "65005"
```

## Cisco NDFC Version
12.2.3


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers