### PR TITLE
add template at fabric level

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/advanced/dc_vxlan_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/advanced/dc_vxlan_fabric_advanced.j2
@@ -38,3 +38,19 @@
   STP_BRIDGE_PRIORITY: {{ vxlan.global.spanning_tree.bridge_priority | default(defaults.vxlan.global.spanning_tree.bridge_priority) }}
 {% endif %}
 {% endif %}
+{% if vxlan.underlay.general.leaf_freeform is defined %}
+  EXTRA_CONF_LEAF: |
+    {{ vxlan.underlay.general.leaf_freeform | indent(4) }}
+{% endif%}
+{% if vxlan.underlay.general.spine_freeform is defined %}
+  EXTRA_CONF_SPINE: |
+    {{ vxlan.underlay.general.spine_freeform | indent(4) }}
+{% endif%}
+{% if vxlan.underlay.general.tor_freeform is defined %}
+  EXTRA_CONF_TOR: |
+    {{ vxlan.underlay.general.tor_freeform | indent(4) }}
+{% endif%}
+{% if vxlan.underlay.general.intra_fabric_link is defined %}
+  EXTRA_CONF_INTRA_LINKS: |
+    {{ vxlan.underlay.general.intra_fabric_link | indent(4) }}
+{% endif%}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/bootstrap/dc_vxlan_fabric_bootstrap.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/bootstrap/dc_vxlan_fabric_bootstrap.j2
@@ -14,6 +14,10 @@
   BOOTSTRAP_MULTISUBNET: "{{ vxlan.global.bootstrap.dhcp_v4.multi_subnet_scope }}"
 {% endif %}
 {% endif %}
-{% endif %}  
+{% endif %}
+{% endif %}
+{% if vxlan.underlay.general.bootstrap_freeform is defined %}
+  BOOTSTRAP_CONF: |
+    {{ vxlan.underlay.general.bootstrap_freeform | indent(4) }}
 {% endif %}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/manageability/dc_vxlan_fabric_manageability.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/manageability/dc_vxlan_fabric_manageability.j2
@@ -55,3 +55,11 @@
   SYSLOG_SEV: {{ syslog_server_sevs | join(',') | default(omit) }}
 {% endif %}
 {% endif %}
+{% if vxlan.underlay.general.aaa_freeform is defined %}
+  AAA_SERVER_CONF: |
+    {{ vxlan.underlay.general.aaa_freeform | indent(4) }}
+{% endif%}
+{% if vxlan.underlay.general.banner_freeform is defined %}
+  BANNER: |
+    {{ vxlan.underlay.general.banner_freeform | indent(4) }}
+{% endif%}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
@@ -65,3 +65,11 @@
 {% endif %}
 {% endif %}
 {% endif %}
+{% if vxlan.underlay.bgp.ibgp_rr_peer_template is defined %}
+  IBGP_PEER_TEMPLATE: |2
+    {{ vxlan.underlay.bgp.ibgp_rr_peer_template | indent(4, false) }}
+{% endif %}
+{% if vxlan.underlay.bgp.ibgp_peer_template is defined %}
+  IBGP_PEER_TEMPLATE_LEAF: |2
+    {{ vxlan.underlay.bgp.ibgp_peer_template | indent(4, false) }}
+{% endif %}


### PR DESCRIPTION
Add support for the following template:

* EXTRA_CONF_INTRA_LINKS
* EXTRA_CONF_LEAF
* EXTRA_CONF_SPINE
* EXTRA_CONF_TOR
* AAA_SERVER_CONF
* BANNER
* IBGP_PEER_TEMPLATE
* IBGP_PEER_TEMPLATE_LEAF
* BOOTSTRAP_CONF

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [x] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Add support for template at the fabric level:

* EXTRA_CONF_INTRA_LINKS
* EXTRA_CONF_LEAF
* EXTRA_CONF_SPINE
* EXTRA_CONF_TOR
* AAA_SERVER_CONF
* BANNER
* IBGP_PEER_TEMPLATE
* IBGP_PEER_TEMPLATE_LEAF
* BOOTSTRAP_CONF

## Test Notes
<!--- Please provide notes or description of testing -->

Data source example:
```
---
vxlan:
  underlay:
    general:
      # template peer must have two whitespace
      ibgp_rr_peer_template: |2
          template peer iBGP-Peer-Template
            bfd
            remote-as 65000.3
            password 3 9125d59c18a9b015
            update-source loopback0
            address-family l2vpn evpn
              send-community
              send-community extended
      ibgp_peer_template: |2
          template peer VTEP-Peer-Template
            bfd
            remote-as 65000.3
            password 3 9125d59c18a9b015
            update-source loopback0
            address-family l2vpn evpn
              send-community
              send-community extended
      intra_fabric_link: |
        no bfd echo
        bfd interval 250 min_rx 250 multiplier 3
        bfd authentication Keyed-SHA1 key-id 1 hex-key 636973636F
      leaf_freeform: |
        as-format asdot
        fabric forwarding dup-host-ip-addr-detection 50 180
        l2rib dup-host-mac-detection 50 180
      spine_freeform: |
        as-format asdot
      banner_freeform: |
        _
        ***************************************************************************
        *                       My Fabric                                        *
        ***************************************************************************
        _
      aaa_freeform: |
        feature tacacs+
        tacacs-server host 1.1.1.1 key 7 "fewhg" timeout 2
        tacacs-server host 1.1.1.2 key 7 "fewhg" timeout 2
        tacacs-server host 1.1.1.1 test idle-time 2
        tacacs-server host 1.1.1.2 test idle-time 2
        aaa group server tacacs+ TACACS-GRP
            server 1.1.1.1
            server 1.1.1.2
            deadtime 1
            use-vrf management
            source-interface mgmt0
        aaa authentication login default group TACACS-GRP local
        aaa authentication login console local
        aaa authorization config-commands default group TACACS-GRP local
        aaa authorization commands default group TACACS-GRP local
        aaa accounting default group TACACS-GRP
        login on-success log
```

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
