### PR TITLE
Network ports is no longer a mandatory parameter

### DIFF
--- a/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
@@ -76,7 +76,9 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
+{% endif %}
 {% endfor %}
   deploy: false
 {% endif %}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [x] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

This updates the jinja2 template to no longer require ports after the following PR has been merged in the base collection.

https://github.com/CiscoDevNet/ansible-dcnm/pull/427

## Test Notes
<!--- Please provide notes or description of testing -->

Tested with and without ports defined in the data model and using the base collection that has the module change.

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->

Version 3.2.2f

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
