### PR TITLE
Fix POAP and PreProvision Workflows

### DIFF
--- a/plugins/action/dtc/get_poap_data.py
+++ b/plugins/action/dtc/get_poap_data.py
@@ -225,9 +225,11 @@ class ActionModule(ActionBase):
         workflow = POAPDevice(params)
         workflow.refresh_discovered()
         workflow.check_poap_supported_switches()
-        workflow.check_preprovision_supported_switches()
+        #
+        # TBD: Don't think we need this
+        # workflow.check_preprovision_supported_switches()
 
-        if workflow.poap_supported_switches and not workflow.preprovision_supported_switches:
+        if workflow.poap_supported_switches:
             workflow.refresh()
 
             if workflow.refresh_succeeded:

--- a/roles/dtc/common/tasks/common/ndfc_inventory_no_bootstrap.yml
+++ b/roles/dtc/common/tasks/common/ndfc_inventory_no_bootstrap.yml
@@ -1,0 +1,80 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+
+- name: Set file_name Var
+  ansible.builtin.set_fact:
+    file_name: "ndfc_inventory_no_bootstrap.yml"
+  delegate_to: localhost
+
+- name: Stat Previous File If It Exists
+  ansible.builtin.stat:
+    path: "{{ path_name }}{{ file_name }}"
+  register: data_file_previous
+  delegate_to: localhost
+
+- name: Backup Previous Data File If It Exists
+  ansible.builtin.copy:
+    src: "{{ path_name }}{{ file_name }}"
+    dest: "{{ path_name }}{{ file_name }}.old"
+  when: data_file_previous.stat.exists
+
+- name: Delete Previous Data File If It Exists
+  ansible.builtin.file:
+    state: absent
+    path: "{{ path_name }}{{ file_name }}"
+  delegate_to: localhost
+  when: data_file_previous.stat.exists
+
+- name: Set Path For Inventory File Lookup
+  ansible.builtin.set_fact:
+    inv_file_path: "{{ path_name }}{{ file_name }}"
+  delegate_to: localhost
+
+- name: Build Fabric Switch Inventory List From Template
+  ansible.builtin.template:
+    src: ndfc_inventory/common/fabric_inventory_no_bootstrap.j2
+    dest: "{{ inv_file_path }}"
+  delegate_to: localhost
+
+- name: Create Empty inv_config Var
+  ansible.builtin.set_fact:
+    inv_config_no_bootstrap: []
+  delegate_to: localhost
+
+- name: Set inv_config Var
+  ansible.builtin.set_fact:
+    inv_config_no_bootstrap: "{{ lookup('file', path_name + file_name) | from_yaml }}"
+  when: (MD_Extended.vxlan.topology.switches | default([])) | length > 0
+  delegate_to: localhost
+
+- name: Retrieve NDFC Device Username and Password from Group Vars and update inv_config
+  cisco.nac_dc_vxlan.common.get_credentials:
+    inv_list: "{{ inv_config_no_bootstrap }}"
+  register: updated_inv_config_no_bootstrap
+  no_log: true
+
+- name: Credential Retrieval Failed
+  ansible.builtin.fail:
+    msg: "{{ updated_inv_config }}"
+  when: updated_inv_config_no_bootstrap['retrieve_failed']
+  delegate_to: localhost

--- a/roles/dtc/common/tasks/sub_main_vxlan.yml
+++ b/roles/dtc/common/tasks/sub_main_vxlan.yml
@@ -52,6 +52,11 @@
 - name: Build NDFC Fabric Switch Inventory List From Template
   ansible.builtin.import_tasks: common/ndfc_inventory.yml
 
+# We need to also build an inventory list without bootstrap settings
+# This will be used for device removal.
+- name: Build NDFC Fabric Switch Inventory List From Template - No Bootstrap
+  ansible.builtin.import_tasks: common/ndfc_inventory_no_bootstrap.yml
+
 # --------------------------------------------------------------------
 # Build vPC Domain ID Resource From Template
 # --------------------------------------------------------------------
@@ -240,6 +245,7 @@
         policy_config: "{{ policy_config }}"
         sub_interface_routed: "{{ sub_interface_routed }}"
         updated_inv_config: "{{ updated_inv_config }}"
+        updated_inv_config_no_bootstrap: "{{ updated_inv_config_no_bootstrap }}"
         vpc_peering: "{{ vpc_peering }}"
         vpc_domain_id_resource: "{{ vpc_domain_id_resource }}"
         vrf_config: "{{ vrf_config }}"

--- a/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory.j2
@@ -12,9 +12,13 @@
   max_hops: 0 # this is the default value as it is not defined into the data model
   role: {{ switch['role'] }}
   preserve_config: false
+{# ------------------------------ #}
+{# Global Bootstrap Section Start #}
 {% if MD_Extended.vxlan.global.bootstrap is defined %}
-{% if MD_Extended.vxlan.global.bootstrap.enable_bootstrap is defined and MD_Extended.vxlan.global.bootstrap.enable_bootstrap %}
-{% if switch.poap is defined and switch.poap.bootstrap %}
+{% if MD_Extended.vxlan.global.bootstrap.enable_bootstrap | default(defaults.vxlan.global.enable_bootstrap) | ansible.builtin.bool %}
+{#     ------------------------- #}
+{#     Switch POAP Section Start #}
+{% if switch.poap is defined and (switch.poap.bootstrap | default(defaults.vxlan.topology.switches.poap.bootstrap) | ansible.builtin.bool) %}
 {% if poap_data[switch['serial_number']] is defined %}
 {% set pdata = poap_data[switch['serial_number']] %}
   poap:
@@ -25,7 +29,15 @@
       config_data:
         modulesModel: {{ pdata['modulesModel'] }}
         gateway: {{ pdata['gateway'] }}
-{% elif switch['poap']['preprovision'] is defined %}
+{% endif %}
+{% endif %}
+{#     ---------------------------------- #}
+{#     Switch POAP Section End            #}
+{##}
+{#     ---------------------------------- #}
+{#     Switch Pre-Provision Section Start #}
+{% if switch['poap']['preprovision'] is defined %}
+{% if switch['serial_number'] == switch['poap']['preprovision']['serial_number'] %}
   poap:
     - preprovision_serial: {{ switch['poap']['preprovision']['serial_number'] }}
       model: {{  switch['poap']['preprovision']['model'] }}
@@ -34,8 +46,16 @@
         modulesModel: {{ switch['poap']['preprovision']['modulesModel'] }}
         gateway: {{ switch['management']['default_gateway_v4'] | ansible.utils.ipaddr('address') }}/{{ switch['management']['subnet_mask_ipv4'] }}
       hostname: {{ switch['name'] }}
+{% else %}
+  poap:
+    - serial_number: {{ switch['serial_number'] }}
+      preprovision_serial: {{ switch['poap']['preprovision']['serial_number'] }}
 {% endif %}
 {% endif %}
+{#     Switch Pre-Provision Section End   #}
+{#     ---------------------------------- #}
 {% endif %}
 {% endif %}
-{% endfor %}
+{# Global Bootstrap Section End #}
+{# ---------------------------- #}
+{% endfor %} 

--- a/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory_no_bootstrap.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory_no_bootstrap.j2
@@ -1,0 +1,15 @@
+{# Auto-generated NDFC DC VXLAN EVPN Inventory config data structure for fabric {{ vxlan.fabric.name }} #}
+{% set poap_data = poap_data['poap_data'] %}
+{% for switch in MD_Extended.vxlan.topology.switches %}
+{% if switch.management.management_ipv4_address is defined %}
+- seed_ip: {{ switch['management']['management_ipv4_address'] }}
+{% elif switch.management.management_ipv6_address is defined %}
+- seed_ip: {{ switch['management']['management_ipv6_address'] }}
+{% endif %}
+  auth_proto: {{ MD['vxlan']['global']['auth_proto'] | default(defaults.vxlan.global.auth_proto) }}
+  user_name: PLACE_HOLDER_USERNAME
+  password: PLACE_HOLDER_PASSWORD
+  max_hops: 0 # this is the default value as it is not defined into the data model
+  role: {{ switch['role'] }}
+  preserve_config: false
+{% endfor %}

--- a/roles/dtc/create/tasks/common/devices_discovery.yml
+++ b/roles/dtc/create/tasks/common/devices_discovery.yml
@@ -54,15 +54,22 @@
     config: "{{ vars_common_vxlan.underlay_ip_address }}"
   when: MD_Extended.vxlan.underlay.general.manual_underlay_allocation is defined and MD_Extended.vxlan.underlay.general.manual_underlay_allocation == True
 
-- name: Config-Save block
-  block:
-    - name: Config-Save for Fabric {{ MD_Extended.vxlan.fabric.name }}
-      cisco.dcnm.dcnm_rest:
-        method: POST
-        path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-save"
-      register: config_save
-      when: >
-        (MD_Extended.vxlan.topology.switches is defined and MD_Extended.vxlan.topology.switches | length > 0)
+# With the addition of the Allocate Underlay IP Address change above we
+# cannot call cisco.dcnm.dcnm_inventory with save: true until after
+# cisco.dcnm.dcnm_resource_manager is called.  This is why we call it
+# again here with save: true to maintain the previous workflow.
+- name: Call Inventory Module Again with Save set to True
+  cisco.dcnm.dcnm_inventory:
+    fabric: "{{ MD_Extended.vxlan.fabric.name }}"
+    config: "{{ vars_common_local.updated_inv_config['updated_inv_list'] }}"
+    deploy: false
+    save: true
+    state: merged
+  vars:
+    ansible_command_timeout: 3000
+    ansible_connect_timeout: 3000
+  when:
+    - MD_Extended.vxlan.topology.switches | length > 0
 
 - name: Create List of Switch Serial Numbers from Data Model
   ansible.builtin.set_fact:

--- a/roles/dtc/remove/tasks/common/switches.yml
+++ b/roles/dtc/remove/tasks/common/switches.yml
@@ -41,7 +41,7 @@
 - name: Remove Unmanaged NDFC Fabric Devices
   cisco.dcnm.dcnm_inventory:
     fabric: "{{ MD_Extended.vxlan.fabric.name }}"
-    config: "{{ vars_common_local.updated_inv_config['updated_inv_list'] }}"
+    config: "{{ vars_common_local.updated_inv_config_no_bootstrap['updated_inv_list'] }}"
     deploy: true
     save: true
     state: overridden

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -152,6 +152,8 @@ factory_defaults:
           topology_switch_loopback_interface:
             description: "NetAsCode Loopback Interface"
             enabled: true
+        poap:
+          bootstrap: false
       vpc_peers:
         domain_id: 1
       fabric_links:


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [x] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [x] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

This update allows devices to be discovered using discovery mode, poap and pre-provision workflows.  Previously the solution did not allow both poap and pre-provision in the same datafile.

Note:
* The `poap.boostrap` setting under the device is only used for POAP mode without pre-provision first.  It is not used by a pre-provision or pre-provision + POAP workflow.

## Test Notes
<!--- Please provide notes or description of testing -->

The following data model was used for testing these changes:

```yaml
---

vxlan:
  topology:
    switches:
      - name: staging-leaf1
        serial_number: 9MGBD4LHN0O
        role: leaf
        management:
          management_ipv4_address: 10.15.9.12
          default_gateway_v4: 10.15.9.1

      - name: staging-leaf2
        serial_number: 9APUPKODH2Y
        role: leaf
        management:
          management_ipv4_address: 10.15.9.13
          default_gateway_v4: 10.15.9.1

      - name: staging-leaf3
        serial_number: 9BC3LNYBKZM
        role: border
        management:
          management_ipv4_address: 10.15.9.14
          default_gateway_v4: 10.15.9.1
        poap:
          # Bootstrap must be true to discover a device
          # that is in POAP mode.
          bootstrap: true

      - name: prod-leaf1
        # -------------------------------------------
        # Temporary Fake Serial Number
        # (Must Match SN under poap.preprovision)
        serial_number: 550K4YPFFFF
        # -------------------------------------------
        # Real device SN that needs to replace the
        # fake SN above when the device is available.
        #
        # serial_number: 96QBK4NUWK4
        # -------------------------------------------
        role: leaf
        management:
          management_ipv4_address: 10.15.9.19
          default_gateway_v4: 10.15.9.1
          subnet_mask_ipv4: 24
        poap:
          preprovision:
            model: N9K-C9300v
            # Matches fake serial number above
            serial_number: 550K4YPFFFF
            version: 15.5(2)
            modulesModel: [N9K-X9364v, N9K-vSUP]
```

**TestCase 1:**

State Before Running the Playbook
* staging-leaf1 and staging-leaf2 are reachable using the IP address
* staging-leaf3 and prod-leaf1 are in POAP mode

State After Running the Playbook
`ansible-playbook -i hosts.stage.yml vxlan.yml --tags cr_manage_switches`
* staging-leaf1 and staging-leaf2 are discovered and added to the fabric
* staging-leaf3 is discovered using POAP since `poap.boostrap` is `true`
* prod-leaf1 is pre-provisioned but stays in POAP mode since the `device serial_number` and `poap.preprovision.serial_number` match and they are using the `fake temporary serial_number`.

Rerun is idempotent

**TestCase 2:**

State Before Running the Playbook
* staging-leaf1, staging-leaf2 and staging-leaf3 are discovered and added to the fabric
* prod-leaf1 is pre-provisioned but still in POAP mode

Update the data model to change out the fake SN with the real SN for `prod-leaf1 `

```yaml
---

vxlan:
  topology:
    switches:
      - name: prod-leaf1
        # -------------------------------------------
        # Temporary Fake Serial Number
        # (Must Match SN under poap.preprovision)
        # serial_number: 550K4YPFFFF
        # -------------------------------------------
        # Real device SN that needs to replace the
        # fake SN above when the device is available.
        #
        serial_number: 96QBK4NUWK4
        # -------------------------------------------
        role: leaf
        management:
          management_ipv4_address: 10.15.9.19
          default_gateway_v4: 10.15.9.1
          subnet_mask_ipv4: 24
        poap:
          preprovision:
            model: N9K-C9300v
            # Matches fake serial number above
            serial_number: 550K4YPFFFF
            version: 15.5(2)
            modulesModel: [N9K-X9364v, N9K-vSUP]
```

This will trigger POAP for prod-leaf1

State After Running the Playbook
`ansible-playbook -i hosts.stage.yml vxlan.yml --tags cr_manage_switches`

* All devices are added to the fabric

Rerun is idempotent

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->

**TestCase 3:**

State Before Running the Playbook
* staging-leaf1, staging-leaf2, staging-leaf3 and prod-leaf1 are discovered and added to the fabric

Update the data model to comment out all switches and run the remove role

`ansible-playbook -i hosts.stage.yml vxlan.yml --tags rr_manage_switches`

All switches are removed properly


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
