### PR TITLE
Fix Remove role issue with vPC Fabric Peering 

### DIFF
--- a/roles/dtc/common/tasks/common/ndfc_vpc_fabric_peering_links.yml
+++ b/roles/dtc/common/tasks/common/ndfc_vpc_fabric_peering_links.yml
@@ -64,7 +64,10 @@
 - name: Set link_vpc_peering Var
   ansible.builtin.set_fact:
     link_vpc_peering: "{{ lookup('file', path_name + file_name) | from_yaml }}"
-  when: MD_Extended.vxlan.topology.vpc_peers | length > 0
+  when:
+    - MD_Extended.vxlan.topology.vpc_peers | length > 0
+    - MD_Extended.vxlan.topology.vpc_peers | selectattr('peer1_peerlink_interfaces', 'defined') | list | length > 0 or
+      MD_Extended.vxlan.topology.vpc_peers | selectattr('peer2_peerlink_interfaces', 'defined') | list | length > 0
   delegate_to: localhost
 
 - name: Diff Previous and Current Data Files


### PR DESCRIPTION
add condition to set link_vpc_peering

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

#445 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Add condition to set `link_vpc_peering` only when peerlink interfaces are defined.

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
