### PR TITLE
Added support for VPC pairing on the external fabrics

### DIFF
--- a/roles/dtc/common/tasks/external/ndfc_vpc_peering_pairs.yml
+++ b/roles/dtc/common/tasks/external/ndfc_vpc_peering_pairs.yml
@@ -1,0 +1,94 @@
+# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+
+- name: Initialize changes_detected Var
+  ansible.builtin.set_fact:
+    changes_detected_vpc_peering: false
+  delegate_to: localhost
+
+- name: Set file_name Var
+  ansible.builtin.set_fact:
+    file_name: "ndfc_vpc_peering.yml"
+  delegate_to: localhost
+
+- name: Stat Previous File If It Exists
+  ansible.builtin.stat:
+    path: "{{ path_name }}{{ file_name }}"
+  register: data_file_previous
+  delegate_to: localhost
+
+- name: Backup Previous Data File If It Exists
+  ansible.builtin.copy:
+    src: "{{ path_name }}{{ file_name }}"
+    dest: "{{ path_name }}{{ file_name }}.old"
+  when: data_file_previous.stat.exists
+
+- name: Delete Previous Data File If It Exists
+  ansible.builtin.file:
+    state: absent
+    path: "{{ path_name }}{{ file_name }}"
+  delegate_to: localhost
+  when: data_file_previous.stat.exists
+
+- name: debug MD_Extended.vxlan.topology.vpc_peers
+  ansible.builtin.debug:
+    msg: "{{ MD_Extended.vxlan.topology.vpc_peers }}"
+  when: MD_Extended.vxlan.topology.vpc_peers | length > 0
+  delegate_to: localhost
+
+- name: Build vPC Peering
+  ansible.builtin.template:
+    src: ndfc_vpc/ndfc_vpc_peering_pairs_external.j2
+    dest: "{{ path_name }}{{ file_name }}"
+  delegate_to: localhost
+
+- name: Set vpc_peering Var default
+  ansible.builtin.set_fact:
+    vpc_peering: []
+  delegate_to: localhost
+
+- name: Set link_vpc_peering Var default as not used for external fabric
+  ansible.builtin.set_fact:
+    link_vpc_peering: []
+  delegate_to: localhost
+
+- name: Set vpc_peering Var
+  ansible.builtin.set_fact:
+    vpc_peering: "{{ lookup('file', path_name + file_name) | from_yaml }}"
+  when: MD_Extended.vxlan.topology.vpc_peers | length > 0
+  delegate_to: localhost
+
+- name: Diff Previous and Current Data Files
+  cisco.nac_dc_vxlan.dtc.diff_model_changes:
+    file_name_previous: "{{ path_name }}{{ file_name }}.old"
+    file_name_current: "{{ path_name }}{{ file_name }}"
+  register: file_diff_result
+  delegate_to: localhost
+
+- name: Set File Change Flag Based on File Diff Result
+  ansible.builtin.set_fact:
+    changes_detected_vpc_peering: true
+  delegate_to: localhost
+  when:
+    - file_diff_result.file_data_changed
+    - check_roles['save_previous']

--- a/roles/dtc/common/tasks/sub_main_external.yml
+++ b/roles/dtc/common/tasks/sub_main_external.yml
@@ -53,6 +53,13 @@
   ansible.builtin.import_tasks: common/ndfc_inventory.yml
 
 # --------------------------------------------------------------------
+# Build vPC Peering parameter List From Template
+# --------------------------------------------------------------------
+
+- name: Build vPC Peering Parameters
+  ansible.builtin.import_tasks: external/ndfc_vpc_peering_pairs.yml
+
+# --------------------------------------------------------------------
 # Build NDFC Fabric Access Port-Channel Interfaces List From Template
 # --------------------------------------------------------------------
 
@@ -155,6 +162,7 @@
         changes_detected_sub_interface_routed: "{{ changes_detected_sub_interface_routed }}"
         changes_detected_interfaces: "{{ changes_detected_interfaces }}"
         changes_detected_policy: "{{ changes_detected_policy }}"
+        changes_detected_vpc_peering: "{{ changes_detected_vpc_peering }}"
         fabric_config: "{{ fabric_config }}"
         edge_connections: "{{ edge_connections }}"
         interface_access_po: "{{ interface_access_po }}"
@@ -170,6 +178,7 @@
         policy_config: "{{ policy_config }}"
         sub_interface_routed: "{{ sub_interface_routed }}"
         updated_inv_config: "{{ updated_inv_config }}"
+        vpc_peering: "{{ vpc_peering }}"
 
 - name: Run Diff Flags
   ansible.builtin.debug:
@@ -178,6 +187,7 @@
       - "+     Fabric Changes Detected -               [ {{ vars_common_external.changes_detected_fabric }} ]"
       - "+     Inventory Changes Detected -            [ {{ vars_common_external.changes_detected_inventory }} ]"
       - "+     Edge Connections Changes Detected -     [ {{ vars_common_external.changes_detected_edge_connections }} ]"
+      - "+     vPC Peer Changes Detected -             [ {{ vars_common_external.changes_detected_vpc_peering }} ]"
       - "+     ----- Interfaces -----"
       - "+     Interface Access Changes Detected -     [ {{ vars_common_external.changes_detected_interface_access }} ]"
       - "+     Interface Access PO Changes Detected -  [ {{ vars_common_external.changes_detected_interface_access_po }} ]"

--- a/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs_external.j2
+++ b/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs_external.j2
@@ -1,0 +1,31 @@
+---
+# This NDFC vPC Peering config data structure for vPC pairs is auto-generated
+# DO NOT EDIT MANUALLY
+#
+{% if MD_Extended.vxlan.topology.vpc_peers is defined and MD_Extended.vxlan.topology.vpc_peers is not none %}
+{% for vpc_peers_pair in MD_Extended.vxlan.topology.vpc_peers %}
+- peerOneId: {{ vpc_peers_pair.peer1_mgmt_ip_address }}
+  peerTwoId: {{ vpc_peers_pair.peer2_mgmt_ip_address }}
+  templateName: "vpc_pair"
+  profile:
+    ADMIN_STATE: {{ vpc_peers_pair.enabled }}
+    ALLOWED_VLANS: "{{ vpc_peers_pair.trunk_allowed_vlans }}"
+    DOMAIN_ID: {{ vpc_peers_pair.domain_id }}
+    FABRIC_NAME: {{ MD_Extended.vxlan.fabric.name }}
+    KEEP_ALIVE_HOLD_TIMEOUT: {{ vpc_peers_pair.keepalive_holdout_time | default(defaults.vxlan.topology.vpc_peers.keepalive_holdout_time) }}
+    KEEP_ALIVE_VRF: {{ vpc_peers_pair.keepalive_vrfname }}
+    PC_MODE: {{ vpc_peers_pair.port_channel_mode | default(defaults.vxlan.topology.vpc_peers.port_channel_mode) }}
+    PEER1_DOMAIN_CONF: "{{ vpc_peers_pair.peer1_domain_conf | default('') }}"
+    PEER1_KEEP_ALIVE_LOCAL_IP: {{ vpc_peers_pair.peer1_keepalive_ipv4 }}
+    PEER1_PO_CONF: "{{ vpc_peers_pair.peer1_po_channel_conf | default('') }}"
+    PEER1_PO_DESC: "{{ vpc_peers_pair.peer1_po_channel_desc | default('') }}"
+    PEER2_DOMAIN_CONF: "{{ vpc_peers_pair.peer2_domain_conf | default('') }}"
+    PEER2_KEEP_ALIVE_LOCAL_IP: {{ vpc_peers_pair.peer2_keepalive_ipv4 }}
+    PEER2_PO_CONF: "{{ vpc_peers_pair.peer2_po_channel_conf | default('') }}"
+    PEER2_PO_DESC: "{{ vpc_peers_pair.peer2_po_channel_desc | default('') }}"
+    PEER1_PCID: {{ vpc_peers_pair.peer1_port_channel_id | default(defaults.vxlan.topology.vpc_peers.peer1_port_channel_id) }}
+    PEER2_PCID: {{ vpc_peers_pair.peer2_port_channel_id | default(defaults.vxlan.topology.vpc_peers.peer2_port_channel_id) }}
+    PEER1_MEMBER_INTERFACES: "{{ vpc_peers_pair.peer1_member_interfaces | default('') }}"
+    PEER2_MEMBER_INTERFACES: "{{ vpc_peers_pair.peer1_member_interfaces | default('') }}"
+{% endfor %}
+{% endif %}

--- a/roles/dtc/create/tasks/common/vpc_peering.yml
+++ b/roles/dtc/create/tasks/common/vpc_peering.yml
@@ -51,7 +51,9 @@
     state: merged
     fabric: "{{ MD_Extended.vxlan.fabric.name }}"
     config: "{{ vars_common_vxlan.vpc_domain_id_resource }}"
-  when: vars_common_vxlan.vpc_domain_id_resource | length > 0
+  when:
+    - vars_common_vxlan.vpc_domain_id_resource is defined
+    - vars_common_vxlan.vpc_domain_id_resource | length > 0
 
 # --------------------------------------------------------------------
 # Manage Intra Fabric Links Configuration on NDFC (prepare links for vpc peering)

--- a/roles/dtc/create/tasks/sub_main_external.yml
+++ b/roles/dtc/create/tasks/sub_main_external.yml
@@ -48,6 +48,13 @@
     - vars_common_external.changes_detected_inventory
   tags: "{{ nac_tags.create_switches }}"
 
+- name: Manage NDFC External VPC Peering
+  ansible.builtin.import_tasks: common/vpc_peering.yml
+  when:
+    - MD_Extended.vxlan.topology.vpc_peers | length > 0
+    - vars_common_external.changes_detected_vpc_peering
+  tags: "{{ nac_tags.create_vpc_peers }}"
+
 - name: Manage NDFC Fabric Inter Links
   ansible.builtin.import_tasks: common/edge_connections.yml
   when:

--- a/roles/dtc/remove/tasks/common/vpc_peers.yml
+++ b/roles/dtc/remove/tasks/common/vpc_peers.yml
@@ -20,6 +20,20 @@
 # SPDX-License-Identifier: MIT
 ---
 
+- name: Choose vars_common Based On Fabric Type
+  ansible.builtin.set_fact:
+    vars_common_local: "{{ vars_common_vxlan }}"
+  when: MD_Extended.vxlan.fabric.type == "VXLAN_EVPN"
+- ansible.builtin.set_fact:
+    vars_common_local: "{{ vars_common_msd }}"
+  when: MD_Extended.vxlan.fabric.type == "MSD"
+- ansible.builtin.set_fact:
+    vars_common_local: "{{ vars_common_isn }}"
+  when: MD_Extended.vxlan.fabric.type == "ISN"
+- ansible.builtin.set_fact:
+    vars_common_local: "{{ vars_common_external }}"
+  when: MD_Extended.vxlan.fabric.type == "External"
+
 - ansible.builtin.debug: msg="Removing Unmanaged vPC Peering. This could take several minutes..."
   when:
     - switch_list.response.DATA | length > 0
@@ -30,7 +44,7 @@
     src_fabric: "{{ MD_Extended.vxlan.fabric.name }}"
     deploy: true
     state: overridden
-    config: "{{ vars_common_vxlan.vpc_peering }}"
+    config: "{{ vars_common_local.vpc_peering }}"
   vars:
       ansible_command_timeout: 1000
       ansible_connect_timeout: 1000

--- a/roles/dtc/remove/tasks/sub_main_external.yml
+++ b/roles/dtc/remove/tasks/sub_main_external.yml
@@ -56,13 +56,11 @@
   when:
     - vars_common_external.changes_detected_interfaces
 
-# Feature not implemented yet, currently vars_common_external.changes_detected_vpc_peering is not being set so will
-# currently cause an undefined variable error.
-# - name: Remove Fabric vPC Peering
-#   ansible.builtin.import_tasks: common/vpc_peers.yml
-#   tags: "{{ nac_tags.remove_vpc_peers }}"
-#   when:
-#     - vars_common_external.changes_detected_vpc_peering
+- name: Remove Fabric vPC Peering
+  ansible.builtin.import_tasks: common/vpc_peers.yml
+  tags: "{{ nac_tags.remove_vpc_peers }}"
+  when:
+    - vars_common_external.changes_detected_vpc_peering
 
 - name: Remove Fabric Switches
   ansible.builtin.import_tasks: common/switches.yml

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -156,6 +156,10 @@ factory_defaults:
           bootstrap: false
       vpc_peers:
         domain_id: 1
+        keepalive_holdout_time: 3
+        port_channel_mode: active
+        peer1_port_channel_id: 500
+        peer2_port_channel_id: 500
       fabric_links:
         mtu: 9216
         admin_state: true


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

[https://github.com/netascode/ansible-dc-vxlan/issues/407](url)

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Adding support for the VPC pairing in the external fabric that requires multiple new input paramaters

## Test Notes
<!--- Please provide notes or description of testing -->

Completed testing on an external fabric with a broad sample of inputs:
---
vxlan:
  topology:
    vpc_peers:
      - peer1: SVS-DC-SL1
        peer2: SVS-DC-SL2
        enabled: true
        trunk_allowed_vlans: all
        domain_id: 11
        keepalive_vrfname: management
        port_channel_mode: active
        peer1_keepalive_ipv4: 10.1.150.100
        peer2_keepalive_ipv4: 10.1.150.101
        peer1_po_channel_desc: "SVS-DC-SL1 to SVS-DC-SL2"
        peer2_po_channel_desc: "SVS-DC-SL2 to SVS-DC-SL1"
        peer1_member_interfaces: "eth1/15,eth1/16"
        peer2_member_interfaces: "eth1/15,eth1/16"

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->

12.2.2

## Checklist

* [ x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x ] Assigned the proper reviewers
