### PR TITLE
Fix msd without child

### DIFF
--- a/roles/dtc/common/templates/ndfc_bgw_anycast_vip.j2
+++ b/roles/dtc/common/templates/ndfc_bgw_anycast_vip.j2
@@ -4,6 +4,7 @@
 
 {% set anycast_lo_id = vxlan.multisite.vtep_loopback_id | default(defaults.vxlan.multisite.vtep_loopback_id) %}
 
+{% if vxlan.multisite.child_fabrics is defined and vxlan.multisite.child_fabrics is iterable %}
 {% for fabric in vxlan.multisite.child_fabrics %}
 {% if fabric.bgw_anycast_vip_ipv4 is defined %}
 - entity_name: "{{ fabric.name }}"
@@ -13,3 +14,4 @@
   resource: "{{ fabric.bgw_anycast_vip_ipv4 }}"
 {% endif %}
 {% endfor %}
+{% endif %}

--- a/roles/dtc/deploy/tasks/sub_main_msd.yml
+++ b/roles/dtc/deploy/tasks/sub_main_msd.yml
@@ -55,8 +55,13 @@
       ansible_command_timeout: 3000
       ansible_connect_timeout: 3000
   when: >
-    (MD_Extended.vxlan.fabric.type == 'ISN' and (MD_Extended.vxlan.topology.switches is defined and MD_Extended.vxlan.topology.switches | length > 0)) or
-    MD_Extended.vxlan.fabric.type == 'MSD'
+      (MD_Extended.vxlan.fabric.type == 'ISN' and
+       MD_Extended.vxlan.topology.switches is defined and
+       MD_Extended.vxlan.topology.switches | length > 0)
+      or
+      (MD_Extended.vxlan.fabric.type == 'MSD' and
+       MD_Extended.vxlan.topology.child_fabrics is defined and
+       MD_Extended.vxlan.topology.child_fabrics | length > 0)
   # TODO: Need to add logic to only deploy if changes are made
 
 - name: Config-Save For Child Fabrics

--- a/roles/dtc/deploy/tasks/sub_main_msd.yml
+++ b/roles/dtc/deploy/tasks/sub_main_msd.yml
@@ -55,10 +55,6 @@
       ansible_command_timeout: 3000
       ansible_connect_timeout: 3000
   when: >
-      (MD_Extended.vxlan.fabric.type == 'ISN' and
-       MD_Extended.vxlan.topology.switches is defined and
-       MD_Extended.vxlan.topology.switches | length > 0)
-      or
       (MD_Extended.vxlan.fabric.type == 'MSD' and
        MD_Extended.vxlan.topology.child_fabrics is defined and
        MD_Extended.vxlan.topology.child_fabrics | length > 0)

--- a/roles/dtc/remove/tasks/msd/networks.yml
+++ b/roles/dtc/remove/tasks/msd/networks.yml
@@ -70,7 +70,6 @@
     - multisite_network_delete_mode is defined
     - multisite_network_delete_mode is true | bool
     - vars_common_msd.changes_detected_networks
-    - MD_Extended.vxlan.topology.switches is defined and MD_Extended.vxlan.topology.switches | length > 0
     - MD_Extended.vxlan.multisite.child_fabrics is defined and MD_Extended.vxlan.multisite.child_fabrics | length > 0
 
 - ansible.builtin.debug:

--- a/roles/dtc/remove/tasks/msd/networks.yml
+++ b/roles/dtc/remove/tasks/msd/networks.yml
@@ -70,6 +70,8 @@
     - multisite_network_delete_mode is defined
     - multisite_network_delete_mode is true | bool
     - vars_common_msd.changes_detected_networks
+    - MD_Extended.vxlan.topology.switches is defined and MD_Extended.vxlan.topology.switches | length > 0
+    - MD_Extended.vxlan.multisite.child_fabrics is defined and MD_Extended.vxlan.multisite.child_fabrics | length > 0
 
 - ansible.builtin.debug:
     msg:

--- a/roles/dtc/remove/tasks/msd/vrfs.yml
+++ b/roles/dtc/remove/tasks/msd/vrfs.yml
@@ -70,6 +70,8 @@
     - multisite_vrf_delete_mode is defined
     - multisite_vrf_delete_mode is true | bool
     - vars_common_msd.changes_detected_vrfs
+    - MD_Extended.vxlan.topology.switches is defined and MD_Extended.vxlan.topology.switches | length > 0
+    - MD_Extended.vxlan.multisite.child_fabrics is defined and MD_Extended.vxlan.multisite.child_fabrics | length > 0
 
 - ansible.builtin.debug:
     msg:

--- a/roles/dtc/remove/tasks/msd/vrfs.yml
+++ b/roles/dtc/remove/tasks/msd/vrfs.yml
@@ -70,7 +70,6 @@
     - multisite_vrf_delete_mode is defined
     - multisite_vrf_delete_mode is true | bool
     - vars_common_msd.changes_detected_vrfs
-    - MD_Extended.vxlan.topology.switches is defined and MD_Extended.vxlan.topology.switches | length > 0
     - MD_Extended.vxlan.multisite.child_fabrics is defined and MD_Extended.vxlan.multisite.child_fabrics | length > 0
 
 - ansible.builtin.debug:


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

Fix #468 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [x] cisco.nac_dc_vxlan.dtc.deploy
* [x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [x] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Add condition to skip deploy, when there are not switches or child_fabrics. Same for remove role with Network and VRF

dcnm_network and dcnm_vrf, cannot query.

msg": "Fabric `fabric` missing on DCNM or does not have any switches",

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
