### PR TITLE
Added support for VRF freeform: issue 442

### DIFF
--- a/roles/dtc/common/templates/ndfc_vrfs/ndfc_attach_vrfs_loopbacks.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/ndfc_attach_vrfs_loopbacks.j2
@@ -22,7 +22,7 @@
         "serialNumber": "{{ switch.serial_number }}",
 {% endif %}
 {% endfor %}
-        "freeformConfig": "",
+        "freeformConfig": "{{ attach['freeform_config'] | default('') }}",
         "extensionValues": "",
         "vlan": "{{ vrf["vlan_id"] }}",
         "deployment": true,


### PR DESCRIPTION
Support for VRF freeform to match the NDFC GUI feature. This is different to doing it in policy as this freeform block will be tied to the VRF. So when the VRF is deleted this freeform block will also be deleted rather than having to manage a separate policy. It matches the functionality of the NDFC GUI when editing VRF attachments.

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

[https://github.com/netascode/ansible-dc-vxlan/issues/442]

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ x] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Small update to the jinja for loopback attachment payload to add freeform. Also requires a small update to the data model to add this freeform field under the VRF attachment:

overlay_vrf_attach_group_switch:
  hostname: str()
  loopback_id: int(min=0, max=1023, required=False)
  loopback_ipv4: ip(version=4, required=False)
  loopback_ipv6: ip(version=6, required=False)
  freeform_config: str(required=False)

## Test Notes
<!--- Please provide notes or description of testing -->
VRF test data:

---
vxlan:
  multisite:
    overlay:
      vrfs:
        - name: vrfMGMT
          vrf_id: 50000
          vlan_id: 2000
          max_bgp_paths: 2
          vrf_vlan_name: vrfMGMT_VLAN
          vrf_attach_group: all_vrfMGMT
      vrf_attach_groups:
        - name: all_vrfMGMT
          switches:
            - { hostname: SVS-LEAF1, loopback_id: 120, loopback_ipv4: 10.34.82.44, freeform_config: "  ip icmp-errors source-interface loopback 120" }
            - { hostname: SVS-LEAF2, loopback_id: 120, loopback_ipv4: 10.34.82.45 }

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2.2

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
