### PR TITLE
Fix for "Multi-AS" option.

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
@@ -1,11 +1,11 @@
 {# Auto-generated NDFC eBGP VXLAN EVPN General config data structure for fabric {{ vxlan.fabric.name }} #}
   BGP_AS: "{{ vxlan.global.bgp_asn }}"
+  SUPER_SPINE_BGP_AS: "{{ vxlan.global.ebgp.super_spine_bgp_asn | default(omit) }}"
+  BGP_AS_MODE: "{{ vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) }}"
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Multi-AS' %}
   ALLOW_LEAF_SAME_AS: "{{ vxlan.global.ebgp.leaf_same_bgp_asn | default(defaults.vxlan.global.ebgp.leaf_same_bgp_asn) | lower }}"
 {% endif %}
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Same-Tier-AS' %}
-  SUPER_SPINE_BGP_AS: "{{ vxlan.global.ebgp.super_spine_bgp_asn | default(omit) }}"
-  BGP_AS_MODE: "{{ vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) }}"
   LEAF_BGP_AS: "{{ vxlan.global.ebgp.leaf_bgp_asn | default(omit) }}"
   BORDER_BGP_AS: "{{ vxlan.ebgp_global.border_bgp_asn | default(omit) }}"
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
@@ -1,5 +1,5 @@
 {# Auto-generated NDFC eBGP VXLAN EVPN General config data structure for fabric {{ vxlan.fabric.name }} #}
-  BGP_AS: "{{ vxlan.global.ebgp.spine_bgp_asn }}"
+  BGP_AS: "{{ vxlan.global.bgp_asn }}"
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Multi-AS' %}
   ALLOW_LEAF_SAME_AS: "{{ vxlan.global.ebgp.leaf_same_bgp_asn | default(defaults.vxlan.global.ebgp.leaf_same_bgp_asn) | lower }}"
 {% endif %}
@@ -7,7 +7,7 @@
   SUPER_SPINE_BGP_AS: "{{ vxlan.global.ebgp.super_spine_bgp_asn | default(omit) }}"
   BGP_AS_MODE: "{{ vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) }}"
   LEAF_BGP_AS: "{{ vxlan.global.ebgp.leaf_bgp_asn | default(omit) }}"
-  BORDER_BGP_AS: "{{ vxlan.global.ebgp.border_bgp_asn | default(omit) }}"
+  BORDER_BGP_AS: "{{ vxlan.ebgp_global.border_bgp_asn | default(omit) }}"
 {% endif %}
   UNDERLAY_IS_V6: {{ vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title }}
   STATIC_UNDERLAY_IP_ALLOC: {{ vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | title }}


### PR DESCRIPTION
Fix for "Multi-AS" option. The SUPER_SPINE_BGP_AS and BGP_AS_MODE where under wrong IF statement

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [x] vxlan.fabric
* [x] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
ND 3.2.1i
ND 4.1


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
