### PR TITLE
update jinja template to support GRT, when vrf: default is used.

### DIFF
--- a/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_ebgp.j2
+++ b/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_ebgp.j2
@@ -2,102 +2,91 @@
 ! DO NOT EDIT MANUALLY
 !
 !
-{% if switch_item.bgp_peers %}
+{% macro vrf_lite_ebgp_vrf_config(item, switch_item, defaults) %}
+
+{% if switch_item.router_id %}
+  router-id {{ switch_item.router_id }}
+{% endif %}
+{% if switch_item.bgp.best_path_as_path_relax %}
+  bestpath as-path multipath-relax
+{% elif switch_item.bgp.best_path_as_path_relax is not defined and (item.bgp.best_path_as_path_relax | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.best_path_as_path_relax)) %}
+  bestpath as-path multipath-relax
+{% endif %}
+{% if (switch_item.bgp.graceful_restart is defined and switch_item.bgp.graceful_restart == false) or (item.bgp.graceful_restart is defined and item.bgp.graceful_restart == false) %}
+  no graceful-restart
+{% endif %}
+{% if switch_item.bgp.graceful_restart_helper %}
+  graceful-restart-helper
+{% elif switch_item.bgp.graceful_restart_helper is not defined and (item.bgp.graceful_restart_helper | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.graceful_restart_helper)) %}
+  graceful-restart-helper
+{% endif %}
+{% if switch_item.bgp.local_as %}
+  local-as {{ switch_item.bgp.local_as }}
+{% elif item.bgp.local_as %}
+  local-as {{ item.bgp.local_as }}
+{% endif %}
+{% set address_family = {'address_family_v4': false, 'address_family_v6': false } %}
+{% if switch_item.bgp_peers is defined %}
   {% for peer in switch_item.bgp_peers %}
-    {% if peer.bfd.enabled | default(defaults.vxlan.overlay_extensions.vrf_lites.switches.bgp_peers.bfd.enabled) %}
-feature bfd
+    {% if "address_family_ipv4_unicast" in peer %}
+      {% set _ = address_family.update({'address_family_v4': true}) %}
+    {% elif "address_family_ipv6_unicast" in peer %}
+      {% set _ = address_family.update({'address_family_v6': true}) %}
     {% endif %}
   {% endfor %}
-!
 {% endif %}
-!
-router bgp {{ MD_Extended.vxlan.global.bgp_asn }}
-  vrf {{ item.vrf }}
-  {% if switch_item.router_id %}
-    router-id {{ switch_item.router_id }}
+{% if switch_item.bgp.address_family_ipv4_unicast or address_family["address_family_v4"] is true %}
+  address-family ipv4 unicast
+  {% if (switch_item.bgp.address_family_ipv4_unicast.ebgp_distance or switch_item.bgp.address_family_ipv4_unicast.ibgp_distance or switch_item.bgp.address_family_ipv4_unicast.local_distance) %}
+    distance {{ switch_item.bgp.address_family_ipv4_unicast.ebgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.ebgp_distance)  }} {{ switch_item.bgp.address_family_ipv4_unicast.ibgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.ibgp_distance)  }} {{ switch_item.bgp.address_family_ipv4_unicast.local_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.local_distance) }}
   {% endif %}
-  {% if switch_item.bgp.best_path_as_path_relax %}
-    bestpath as-path multipath-relax
-  {% elif switch_item.bgp.best_path_as_path_relax is not defined and (item.bgp.best_path_as_path_relax | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.best_path_as_path_relax)) %}
-    bestpath as-path multipath-relax
+  {% if switch_item.bgp.address_family_ipv4_unicast.default_originate | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.default_originate) %}
+    default-information originate
   {% endif %}
-  {% if (switch_item.bgp.graceful_restart is defined and switch_item.bgp.graceful_restart == false) or (item.bgp.graceful_restart is defined and item.bgp.graceful_restart == false) %}
-    no graceful-restart
+  {% if switch_item.bgp.address_family_ipv4_unicast.additional_paths_send | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.additional_paths_send) %}
+    additional-paths send
   {% endif %}
-  {% if switch_item.bgp.graceful_restart_helper %}
-    graceful-restart-helper
-  {% elif switch_item.bgp.graceful_restart_helper is not defined and (item.bgp.graceful_restart_helper | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.graceful_restart_helper)) %}
-    graceful-restart-helper
+  {% if switch_item.bgp.address_family_ipv4_unicast.additional_paths_receive | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.additional_paths_receive) %}
+    additional-paths receive
   {% endif %}
-  {# #}
-  {% if switch_item.bgp.local_as %}
-    local-as {{ switch_item.bgp.local_as }}
-  {% elif item.bgp.local_as %}
-    local-as {{ item.bgp.local_as }}
+  {% if switch_item.bgp.address_family_ipv4_unicast.additional_paths_selection_route_map %}
+    additional-paths selection route-map {{ switch_item.bgp.address_family_ipv4_unicast.additional_paths_selection_route_map }}
   {% endif %}
-  {# Check if address_family is enabled for redistribution #}
-  {% set address_family = {'address_family_v4': false, 'address_family_v6': false } %}
-  {% if switch_item.bgp_peers is defined %}
-    {% for peer in switch_item.bgp_peers %}
-      {% if "address_family_ipv4_unicast" in peer %}
-        {% set _ = address_family.update({'address_family_v4': true}) %}
-      {% elif "address_family_ipv6_unicast" in peer %}
-        {% set _ = address_family.update({'address_family_v6': true}) %}
+  {% if switch_item.redistribution %}
+    {% for switch_redist in switch_item.redistribution %}
+      {% if switch_redist.source == 'static' and switch_redist.route_map_ipv4 %}
+    redistribute static route-map {{ switch_redist.route_map_ipv4 }}
       {% endif %}
     {% endfor %}
   {% endif %}
-  {% if switch_item.bgp.address_family_ipv4_unicast or address_family["address_family_v4"] is true %}
-    address-family ipv4 unicast
-    {% if (switch_item.bgp.address_family_ipv4_unicast.ebgp_distance or switch_item.bgp.address_family_ipv4_unicast.ibgp_distance or switch_item.bgp.address_family_ipv4_unicast.local_distance) %}
-      distance {{ switch_item.bgp.address_family_ipv4_unicast.ebgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.ebgp_distance)  }} {{ switch_item.bgp.address_family_ipv4_unicast.ibgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.ibgp_distance)  }} {{ switch_item.bgp.address_family_ipv4_unicast.local_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.local_distance) }}
-    {% endif %}
-    {% if switch_item.bgp.address_family_ipv4_unicast.default_originate | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.default_originate) %}
-      default-information originate
-    {% endif %}
-    {% if switch_item.bgp.address_family_ipv4_unicast.additional_paths_send | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.additional_paths_send) %}
-      additional-paths send
-    {% endif %}
-    {% if switch_item.bgp.address_family_ipv4_unicast.additional_paths_receive | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv4_unicast.additional_paths_receive) %}
-      additional-paths receive
-    {% endif %}
-    {% if switch_item.bgp.address_family_ipv4_unicast.additional_paths_selection_route_map %}
-      additional-paths selection route-map {{ switch_item.bgp.address_family_ipv4_unicast.additional_paths_selection_route_map }}
-    {% endif %}
-    {% if switch_item.redistribution %}
-      {% for switch_redist in switch_item.redistribution %}
-        {% if switch_redist.source == 'static' and switch_redist.route_map_ipv4 %}
-      redistribute static route-map {{ switch_redist.route_map_ipv4 }}
-        {% endif %}
-      {% endfor %}
-    {% endif %}
 !
+{% endif %}
+{% if switch_item.bgp.address_family_ipv6_unicast or address_family["address_family_v6"] is true %}
+  address-family ipv6 unicast
+  {% if (switch_item.bgp.address_family_ipv6_unicast.ebgp_distance or switch_item.bgp.address_family_ipv6_unicast.ibgp_distance or switch_item.bgp.address_family_ipv6_unicast.local_distance) %}
+    distance {{ switch_item.bgp.address_family_ipv6_unicast.ebgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.ebgp_distance)  }} {{ switch_item.bgp.address_family_ipv6_unicast.ibgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.ibgp_distance)  }} {{ switch_item.bgp.address_family_ipv6_unicast.local_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.local_distance) }}
   {% endif %}
-  {% if switch_item.bgp.address_family_ipv6_unicast or address_family["address_family_v6"] is true %}
-    address-family ipv6 unicast
-    {% if (switch_item.bgp.address_family_ipv6_unicast.ebgp_distance or switch_item.bgp.address_family_ipv6_unicast.ibgp_distance or switch_item.bgp.address_family_ipv6_unicast.local_distance) %}
-      distance {{ switch_item.bgp.address_family_ipv6_unicast.ebgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.ebgp_distance)  }} {{ switch_item.bgp.address_family_ipv6_unicast.ibgp_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.ibgp_distance)  }} {{ switch_item.bgp.address_family_ipv6_unicast.local_distance | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.local_distance) }}
-    {% endif %}
-    {% if switch_item.bgp.address_family_ipv6_unicast.default_originate | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.default_originate) %}
-      default-information originate
-    {% endif %}
-    {% if switch_item.bgp.address_family_ipv6_unicast.additional_paths_send | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.additional_paths_send) %}
-      additional-paths send
-    {% endif %}
-    {% if switch_item.bgp.address_family_ipv6_unicast.additional_paths_receive | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.additional_paths_receive) %}
-      additional-paths receive
-    {% endif %}
-    {% if switch_item.bgp.address_family_ipv6_unicast.additional_paths_selection_route_map %}
-      additional-paths selection route-map {{ switch_item.bgp.address_family_ipv6_unicast.additional_paths_selection_route_map }}
-    {% endif %}
-    {% if switch_item.redistribution %}
-      {% for switch_redist in switch_item.redistribution %}
-        {% if switch_redist.source == 'static' and switch_redist.route_map_ipv6 %}
-      redistribute static route-map {{ switch_redist.route_map_ipv6 }}
-        {% endif %}
-      {% endfor %}
-    {% endif %}
+  {% if switch_item.bgp.address_family_ipv6_unicast.default_originate | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.default_originate) %}
+    default-information originate
+  {% endif %}
+  {% if switch_item.bgp.address_family_ipv6_unicast.additional_paths_send | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.additional_paths_send) %}
+    additional-paths send
+  {% endif %}
+  {% if switch_item.bgp.address_family_ipv6_unicast.additional_paths_receive | default(defaults.vxlan.overlay_extensions.vrf_lites.bgp.address_family_ipv6_unicast.additional_paths_receive) %}
+    additional-paths receive
+  {% endif %}
+  {% if switch_item.bgp.address_family_ipv6_unicast.additional_paths_selection_route_map %}
+    additional-paths selection route-map {{ switch_item.bgp.address_family_ipv6_unicast.additional_paths_selection_route_map }}
+  {% endif %}
+  {% if switch_item.redistribution %}
+    {% for switch_redist in switch_item.redistribution %}
+      {% if switch_redist.source == 'static' and switch_redist.route_map_ipv6 %}
+    redistribute static route-map {{ switch_redist.route_map_ipv6 }}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
 !
-  {% endif %}
+{% endif %}
 {% if switch_item.bgp_peers %}
   {% for peer in switch_item.bgp_peers %}
     neighbor {{ peer.address }}
@@ -192,4 +181,26 @@ router bgp {{ MD_Extended.vxlan.global.bgp_asn }}
       {% endif %}
     {% endif %}
   {% endfor %}
+{% endif %}
+{% endmacro %}
+
+{% if switch_item.bgp_peers %}
+  {% for peer in switch_item.bgp_peers %}
+    {% if peer.bfd.enabled | default(defaults.vxlan.overlay_extensions.vrf_lites.switches.bgp_peers.bfd.enabled) %}
+feature bfd
+    {% endif %}
+  {% endfor %}
+!
+{% endif %}
+!
+
+{% if item.vrf.lower() == "default" %}
+router bgp {{ MD_Extended.vxlan.global.bgp_asn }}
+  {# If GRT #}
+  {{- vrf_lite_ebgp_vrf_config(item, switch_item, defaults) -}}
+{% else %}
+router bgp {{ MD_Extended.vxlan.global.bgp_asn }}
+  vrf {{ item.vrf }}
+  {# If other vrfs #}{# If not GRT #}
+      {{- vrf_lite_ebgp_vrf_config(item, switch_item, defaults) | indent(2)-}}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_ospf.j2
+++ b/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_ospf.j2
@@ -2,6 +2,89 @@
 ! DO NOT EDIT MANUALLY
 !
 !
+{# macro render_ospf_interface to render ospf area part #}
+{% macro render_ospf_area(area, defaults) %}
+  {% if area.id and (area.id != 0 or area.id != '0.0.0.0') %}
+    {% if (area.area_type and area.area_type == 'stub') or (area.area_type is not defined and defaults.vxlan.overlay_extensions.vrf_lites.ospf.areas.area_type == 'stub') %}
+area {{ area.id | ipaddr('address') }} stub
+    {% elif (area.area_type and area.area_type == 'totally_stub') or (area.area_type is not defined and defaults.vxlan.overlay_extensions.vrf_lites.ospf.areas.area_type == 'totally_stub') %}
+area {{ area.id | ipaddr('address') }} stub no-summary
+    {% elif (area.area_type and area.area_type == 'nssa') or (area.area_type is not defined and defaults.vxlan.overlay_extensions.vrf_lites.ospf.areas.area_type == 'nssa') %}
+      {% if area.nssa is not defined %}
+area {{ area.id | ipaddr('address') }} nssa
+      {% else %}
+        {%- set nssa_options = {
+          'no_redistribution': area.nssa.no_redistribution | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.no_redistribution),
+          'no_summary': area.nssa.no_summary | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.no_summary),
+          'default_information_originate': area.nssa.default_information_originate | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.default_information_originate),
+          'translate_always': area.nssa.translate.always | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.translate.always),
+          'translate_supress_fa': area.nssa.translate.supress_fa | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.translate.supress_fa),
+          'translate_never': area.nssa.translate.never | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.translate.never)
+        } -%}
+        {%- set nssa_options_flags = [] -%}
+        {%- set nssa_options_translate = [] -%}
+        {%- set nssa_options_flags_enabled = false -%}
+        {%- set nssa_options_translate_enabled = false -%}
+        {% if nssa_options.no_summary is true %}
+          {%- set _= nssa_options_flags.append("no-summary") -%}
+          {%- set nssa_options_flags_enabled = true -%}
+        {% endif %}
+        {% if nssa_options.no_redistribution is true %}
+          {% set _= nssa_options_flags.append("no-redistribution") -%}
+          {%- set nssa_options_flags_enabled = true -%}
+        {% endif %}
+        {% if nssa_options.default_information_originate is true %}
+          {% set _= nssa_options_flags.append("default-information-originate") %}
+          {% if area.nssa.route_map %}
+            {% set _= nssa_options_flags.append("route-map") %}
+            {% set _= nssa_options_flags.append(area.nssa.route_map) %}
+            {% set nssa_options_flags_enabled = true %}
+          {% endif %}
+        {% endif %}
+        {% if nssa_options.translate_always is true %}
+          {% set _= nssa_options_translate.append("always") %}
+          {% set nssa_options_translate_enabled = true %}
+        {% endif %}
+        {% if nssa_options.translate_supress_fa is true %}
+          {% set _= nssa_options_translate.append("supress-fa") %}
+          {% set nssa_options_translate_enabled = true %}
+        {% endif %}
+        {% if nssa_options.translate_never is true %}
+          {% set _= nssa_options_translate.append("never") %}
+          {% set nssa_options_translate_enabled = true %}
+        {% endif %}
+        {% if nssa_options_flags_enabled is true %}
+area {{ area.id | ipaddr('address') }} nssa {{ nssa_options_flags | join(' ') }}
+        {% endif %}
+        {% if nssa_options_translate_enabled is true %}
+area {{ area.id | ipaddr('address') }} nssa translate type7 {{ nssa_options_translate | join(' ') }}
+        {% endif %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+  {% if area.area_cost is defined and area.area_cost != 1 and area.id != 0 %}
+area {{ area.id | ipaddr('address') }} default-cost {{ area.area_cost }}
+  {% elif area.area_cost is defined and area.area_cost != 1 %}
+area 0.0.0.0 default-cost {{ area.area_cost }}
+  {% endif %}
+  {% if area.default_information_originate is defined %}
+    {% if area.default_information_originate.always is not defined %}
+      {% set default_information_originate_always = defaults.vxlan.overlay_extensions.vrf_lites.ospf.default_information_originate.always %}
+    {% else %}
+      {% set default_information_originate_always = area.default_information_originate.always %}
+    {% endif %}
+    {% if (default_information_originate_always is true and area.default_information_originate.route_map is defined) %}
+default-information originate always route-map {{ area.default_information_originate.route_map }}
+    {% elif default_information_originate_always is true and area.default_information_originate.route_map is not defined %}
+default-information originate always
+    {% elif default_information_originate_always is false and area.default_information_originate.route_map is defined %}
+default-information originate route-map {{ area.default_information_originate.route_map }}
+    {% else %}
+default-information originate
+    {% endif %}
+  {% endif %}
+{% endmacro %}
+
 feature ospf
 {% set redistribute = {} %}
 {% set feature = {} %}
@@ -21,96 +104,51 @@ feature bfd
 {% endif %}
 !
 router ospf {{ item.ospf['process'] }}
+{# GRT #}
+{% if item.vrf.lower() == "default" %}
+{% if switch_item['router_id'] %}
+  router-id {{ switch_item['router_id'] }}
+{% endif %}
+{% if item.ospf.areas is defined and item.ospf.areas %}
+{% for area in item.ospf.areas %}
+  {{- render_ospf_area(area, defaults) -}}
+{% endfor %}
+{% endif %}
+  {% if (item.ospf.distance and item.ospf.distance != 110) or (item.ospf.distance is not defined and defaults.vxlan.overlay_extensions.vrf_lites.ospf.distance != 110) %}
+  distance {{ item.ospf.distance }}
+  {% endif %}
+  {# Redistribution configuration #}
+  {% if switch_item.redistribution %}
+    {% for switch_redist in switch_item.redistribution %}
+      {% if switch_redist.source == 'direct' and switch_redist.route_map_ipv4 %}
+  redistribute direct route-map {{ switch_redist.route_map_ipv4 }}
+      {% endif %}
+      {% if switch_redist.source == 'static' and switch_redist.route_map_ipv4 %}
+  redistribute static route-map {{ switch_redist.route_map_ipv4 }}
+      {% endif %}
+      {% if switch_redist.source == 'bgp' and switch_redist.route_map_ipv4 %}
+  redistribute bgp {{ MD_Extended.vxlan.global.bgp_asn }} route-map {{ switch_redist.route_map_ipv4 }}
+      {% endif %}
+      {% if switch_redist.source == 'ospf' and switch_redist.route_map_ipv4 %}
+        {% set _ = redistribute.update({'ospf': switch_redist.route_map_ipv4}) %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{% else %}
+{# Other vrfs #}
   vrf {{ item.vrf }}
     {% if switch_item['router_id'] %}
     router-id {{ switch_item['router_id'] }}
     {% endif %}
     {% if item.ospf.areas %}
       {% for area in item.ospf.areas %}
-        {% if area.id and (area.id != 0 or area.id != '0.0.0.0') %}
-          {% if (area.area_type and area.area_type == 'stub') or (area.area_type is not defined and defaults.vxlan.overlay_extensions.vrf_lites.ospf.areas.area_type == 'stub') %}
-    area {{ area.id | ipaddr('address') }} stub
-          {% elif (area.area_type and area.area_type == 'totally_stub') or (area.area_type is not defined and defaults.vxlan.overlay_extensions.vrf_lites.ospf.areas.area_type == 'totally_stub') %}
-    area {{ area.id | ipaddr('address') }} stub no-summary
-          {% elif (area.area_type and area.area_type == 'nssa') or (area.area_type is not defined and defaults.vxlan.overlay_extensions.vrf_lites.ospf.areas.area_type == 'nssa') %}
-            {% if area.nssa is not defined %}
-    area {{ area.id | ipaddr('address') }} nssa
-            {% else %}
-                {% set nssa_options = {
-                'no_redistribution': area.nssa.no_redistribution | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.no_redistribution),
-                'no_summary': area.nssa.no_summary | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.no_summary),
-                'default_information_originate': area.nssa.default_information_originate | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.default_information_originate),
-                'translate_always': area.nssa.translate.always | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.translate.always),
-                'translate_supress_fa': area.nssa.translate.supress_fa | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.translate.supress_fa),
-                'translate_never': area.nssa.translate.never | default(defaults.vxlan.overlay_extensions.vrf_lites.ospf.nssa.translate.never)
-                } %}
-                {% set nssa_options_flags = [] %}
-                {% set nssa_options_translate = [] %}
-                {% set nssa_options_flags_enabled = false %}
-                {% set nssa_options_translate_enabled = false %}
-              {% if nssa_options.no_summary is true %}
-                {% set _= nssa_options_flags.append("no-summary") %}
-                {% set nssa_options_flags_enabled = true %}
-              {% endif %}
-              {% if nssa_options.no_redistribution is true %}
-                {% set _= nssa_options_flags.append("no-redistribution") %}
-                {% set nssa_options_flags_enabled = true %}
-              {% endif %}
-              {% if nssa_options.default_information_originate is true %}
-                {% set _= nssa_options_flags.append("default-information-originate") %}
-                {% if area.nssa.route_map %}
-                  {% set _= nssa_options_flags.append("route-map") %}
-                  {% set _= nssa_options_flags.append(area.nssa.route_map) %}
-                  {% set nssa_options_flags_enabled = true %}
-                {% endif %}
-              {% endif %}
-              {% if nssa_options.translate_always is true %}
-                {% set _= nssa_options_translate.append("always") %}
-                {% set nssa_options_translate_enabled = true %}
-              {% endif %}
-              {% if nssa_options.translate_supress_fa is true %}
-                {% set _= nssa_options_translate.append("supress-fa") %}
-                {% set nssa_options_translate_enabled = true %}
-              {% endif %}
-              {% if nssa_options.translate_never is true %}
-                {% set _= nssa_options_translate.append("never") %}
-                {% set nssa_options_translate_enabled = true %}
-              {% endif %}
-              {% if nssa_options_flags_enabled is true %}
-    area {{ area.id | ipaddr('address') }} nssa {{ nssa_options_flags | join(' ') }}
-              {% endif %}
-              {% if nssa_options_translate_enabled is true %}
-    area {{ area.id | ipaddr('address') }} nssa translate type7 {{ nssa_options_translate | join(' ') }}
-              {% endif %}
-            {% endif %}
-          {% endif %}
-        {% endif %}
-        {% if area.area_cost is defined and area.area_cost != 1 and area.id != 0 %}
-    area {{ area.id | ipaddr('address') }} default-cost {{ area.area_cost }}
-        {% elif area.area_cost is defined and area.area_cost != 1 %}
-    area 0.0.0.0 default-cost {{ area.area_cost }}
-        {% endif %}
-        {% if area.default_information_originate is defined %}
-          {% if area.default_information_originate.always is not defined %}
-            {% set default_information_originate_always = defaults.vxlan.overlay_extensions.vrf_lites.ospf.default_information_originate.always %}
-          {% else %}
-            {% set default_information_originate_always = area.default_information_originate.always %}
-          {% endif %}
-          {% if (default_information_originate_always is true and area.default_information_originate.route_map is defined) %}
-    default-information originate always route-map {{ area.default_information_originate.route_map }}
-          {% elif default_information_originate_always is true and area.default_information_originate.route_map is not defined %}
-    default-information originate always
-          {% elif default_information_originate_always is false and area.default_information_originate.route_map is defined %}
-    default-information originate route-map {{ area.default_information_originate.route_map }}
-          {% else %}
-    default-information originate
-          {% endif %}
-        {% endif %}
+    {{- render_ospf_area(area, defaults) -}}
       {% endfor %}
     {% endif %}
     {% if (item.ospf.distance and item.ospf.distance != 110) or (item.ospf.distance is not defined and defaults.vxlan.overlay_extensions.vrf_lites.ospf.distance != 110) %}
     distance {{ item.ospf.distance }}
     {% endif %}
+    {# Redistribution configuration #}
     {% if switch_item.redistribution %}
       {% for switch_redist in switch_item.redistribution %}
         {% if switch_redist.source == 'direct' and switch_redist.route_map_ipv4 %}
@@ -127,12 +165,18 @@ router ospf {{ item.ospf['process'] }}
         {% endif %}
       {% endfor %}
     {% endif %}
+{% endif %}
 !
 {% if redistribute['ospf'] %}
 router bgp {{ MD_Extended.vxlan.global.bgp_asn }}
+  {% if item.vrf.lower() == "default" %}
+  address-family ipv4 unicast
+    redistribute ospf {{ item.ospf['process'] }} route-map {{ redistribute['ospf'] }}
+  {% else %}
   vrf {{ item.vrf }}
     address-family ipv4 unicast
       redistribute ospf {{ item.ospf['process'] }} route-map {{ redistribute['ospf'] }}
+  {% endif %}
 !
 {% endif %}
 {% if switch_item.interfaces %}

--- a/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_static.j2
+++ b/roles/dtc/common/templates/ndfc_vrf_lite/ndfc_vrf_lite_static.j2
@@ -2,54 +2,60 @@
 ! DO NOT EDIT MANUALLY
 !
 !
+{% macro render_static_route(static_route, next_hop, address_family) %}
+  {%- set static_option = [] -%}
+  {% if next_hop.track is defined %}
+    {% set _ = static_option.append("track " + next_hop.track | string ) %}
+  {% endif %}
+  {% if next_hop.name is defined %}
+    {%- set _ = static_option.append("name " + next_hop.name ) -%}
+  {% endif %}
+  {% if static_route.route_tag is defined and static_route.route_tag %}
+    {%- set _ = static_option.append("tag " + static_route.route_tag | string ) -%}
+  {% endif %}
+  {% if next_hop.route_preference is defined and next_hop.route_preference != 1 %}
+    {%- set _ = static_option.append(next_hop.route_preference | string ) -%}
+  {% endif %}
+  {% if static_option | length > 0 %}
+{{address_family}} route {{ static_route.prefix }} {{ next_hop.ip }} {{ static_option | join(" ") }}
+  {% else %}
+{{address_family}} route {{ static_route.prefix }} {{ next_hop.ip }}
+  {% endif %}
+{% endmacro %}
+
+{% if item.vrf.lower() == "default" %}
+{% if switch_item.static_routes %}
+  {% if "static_ipv4" in switch_item.static_routes %}
+    {% for static_route in switch_item.static_routes.static_ipv4 %}
+      {%- for next_hop in static_route.next_hops %}
+{{ render_static_route(static_route, next_hop, "ip") }}
+      {%- endfor %}
+    {% endfor %}
+  {% endif %}
+  {% if "static_ipv6" in switch_item.static_routes %}
+    {% for static_route in switch_item.static_routes.static_ipv6 %}
+      {%- for next_hop in static_route.next_hops %}
+{{ render_static_route(static_route, next_hop, "ipv6") }}
+      {%- endfor %}
+    {% endfor %}
+  {% endif %}
+{% endif %}
+{% else %}
 vrf context {{ item.vrf }}
   {% if switch_item.static_routes %}
     {% if "static_ipv4" in switch_item.static_routes %}
       {% for static_route in switch_item.static_routes.static_ipv4 %}
-        {% for next_hop in static_route.next_hops %}
-          {% set static_option = [] %}
-          {% if next_hop.track is defined %}
-          {% set _ = static_option.append("track " + next_hop.track | string )%}
-          {% endif %}
-          {% if next_hop.name is defined %}
-          {% set _ = static_option.append("name " + next_hop.name )%}
-          {% endif %}
-          {% if static_route.route_tag is defined and static_route.route_tag %}
-            {% set _ = static_option.append("tag " + static_route.route_tag | string )%}
-          {% endif %}
-          {% if next_hop.route_preference is defined and next_hop.route_preference != 1 %}
-          {% set _ = static_option.append(next_hop.route_preference | string )%}
-          {% endif %}
-          {% if static_option | length > 0 %}
-  ip route {{ static_route.prefix }} {{ next_hop.ip }} {{ static_option | join(" ") }}
-          {% else %}
-  ip route {{ static_route.prefix }} {{ next_hop.ip }}
-          {% endif %}
-        {% endfor %}
+        {%- for next_hop in static_route.next_hops %}
+  {{ render_static_route(static_route, next_hop, "ip") }}
+        {%- endfor %}
       {% endfor %}
     {% endif %}
     {% if "static_ipv6" in switch_item.static_routes %}
       {% for static_route in switch_item.static_routes.static_ipv6 %}
-        {% for next_hop in static_route.next_hops %}
-          {% set static_option = [] %}
-          {% if next_hop.track is defined %}
-          {% set _ = static_option.append("track " + next_hop.track | string )%}
-          {% endif %}
-          {% if next_hop.name is defined %}
-          {% set _ = static_option.append("name " + next_hop.name )%}
-          {% endif %}
-          {% if static_route.route_tag is defined and static_route.route_tag %}
-            {% set _ = static_option.append("tag " + static_route.route_tag | string )%}
-          {% endif %}
-          {% if next_hop.route_preference is defined and next_hop.route_preference != 1 %}
-          {% set _ = static_option.append(next_hop.route_preference | string )%}
-          {% endif %}
-          {% if static_option | length > 0 %}
-  ipv6 route {{ static_route.prefix }} {{ next_hop.ip }} {{ static_option | join(" ") }}
-          {% else %}
-  ipv6 route {{ static_route.prefix }} {{ next_hop.ip }}
-          {% endif %}
-        {% endfor %}
+      {%- for next_hop in static_route.next_hops %}
+  {{ render_static_route(static_route, next_hop, "ipv6") }}
+      {%- endfor %}
       {% endfor %}
     {% endif %}
   {% endif %}
+{% endif %}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->

Support GRT (vrf default) configuration in VRF-Lite
## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [x] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Update existing template with if condition vrf == "default".

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
