### PR TITLE
Added Support in External for pre-prov

### DIFF
--- a/roles/dtc/common/templates/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2
@@ -11,8 +11,12 @@
   max_hops: 0 # this is the default value as it is not defined into the data model
   role: {{ switch['role'] }}
   preserve_config: true
+{# ------------------------------ #}
+{# Global Bootstrap Section Start #}
 {% if MD_Extended.vxlan.global.bootstrap is defined %}
 {% if MD_Extended.vxlan.global.bootstrap.enable_bootstrap is defined and MD_Extended.vxlan.global.bootstrap.enable_bootstrap %}
+{#     ------------------------- #}
+{#     Switch POAP Section Start #}
 {% if switch.poap is defined and switch.poap.bootstrap %}
 {% if poap_data[switch['serial_number']] is defined %}
 {% set pdata = poap_data[switch['serial_number']] %}
@@ -24,7 +28,14 @@
       config_data:
         modulesModel: {{ pdata['modulesModel'] }}
         gateway: {{ pdata['gateway'] }}
-{% elif switch['poap']['preprovision'] is defined %}
+{% endif %}
+{% endif %}
+{#     ---------------------------------- #}
+{#     Switch POAP Section End            #}
+{##}
+{#     ---------------------------------- #}
+{#     Switch Pre-Provision Section Start #}
+{% if switch['poap']['preprovision'] is defined %}
   poap:
     - preprovision_serial: {{ switch['poap']['preprovision']['serial_number'] }}
       model: {{  switch['poap']['preprovision']['model'] }}
@@ -34,7 +45,10 @@
         gateway: {{ switch['management']['default_gateway_v4'] | ansible.utils.ipaddr('address') }}/{{ switch['management']['subnet_mask_ipv4'] }}
       hostname: {{ switch['name'] }}
 {% endif %}
+{#     Switch Pre-Provision Section End   #}
+{#     ---------------------------------- #}
 {% endif %}
 {% endif %}
-{% endif %}
+{# Global Bootstrap Section End #}
+{# ---------------------------- #}
 {% endfor %}


### PR DESCRIPTION
Fixed an issue where the poap section was skipped for a pre-prov switch in external.

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
na

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Align the external jinja template with the changes recently made in the vxlan to support pre-provisioned switches. Needed to add some {end if} statments so that the section isn't skipped as pre-prov switches will have bootstrap set to false.

## Test Notes
<!--- Please provide notes or description of testing -->
Sample test data in switche.nac.yaml

---
vxlan:
  topology:
    switches:
      - name: SVS-DC-CORE1
        serial_number: FDO273514Z2
        role: core_router
        management:
          default_gateway_v4: 10.1.120.1
          management_ipv4_address: 10.1.120.100
          subnet_mask_ipv4: 24
        poap:
          bootstrap: false
          preprovision:
            serial_number: FDO273514Z2
            model: N9K-C9364D-GX2A
            version: 10.1(2)
            modulesModel:
              [
                "N9K-X9716D-GX",
                "N9K-X9716D-GX",
                "N9K-X9716D-GX",
                "N9K-X9716D-GX",
                "N9K-X9716D-GX",
                "N9K-X9716D-GX",
                "N9K-X9716D-GX",
                "N9K-X9716D-GX",
                "N9K-C9508-FM-G",
                "N9K-C9508-FM-G",
                "N9K-C9508-FM-G",
                "N9K-C9508-FM-G",
                "N9K-SUP-B+",
                "N9K-SC-A",
                "N9K-SC-A",
              ]
        routing_loopback_id: 0
        vtep_loopback_id: 1

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2.2

## Checklist

* [ x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ x] Assigned the proper reviewers
