### PR TITLE
ND4.1: Validation of cisco.nd.rest module

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ ansible_connection: ansible.netcommon.httpapi
 ansible_httpapi_port: 443
 ansible_httpapi_use_ssl: true
 ansible_httpapi_validate_certs: false
-ansible_network_os: cisco.dcnm.dcnm
+ansible_network_os: cisco.nd.nd
 # NDFC API Credentials
 ansible_user: "{{ lookup('env', 'ND_USERNAME') }}"
 ansible_password: "{{ lookup('env', 'ND_PASSWORD') }}"

--- a/plugins/action/dtc/fabric_check_sync.py
+++ b/plugins/action/dtc/fabric_check_sync.py
@@ -41,7 +41,7 @@ class ActionModule(ActionBase):
         fabric = self._task.args["fabric"]
 
         ndfc_response = self._execute_module(
-            module_name="cisco.dcnm.dcnm_rest",
+            module_name="cisco.nd.nd_rest",
             module_args={
                 "method": "GET",
                 "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric}/inventory/switchesByFabric",

--- a/plugins/action/dtc/fabrics_config_save.py
+++ b/plugins/action/dtc/fabrics_config_save.py
@@ -43,7 +43,7 @@ class ActionModule(ActionBase):
         for fabric in fabrics:
             display.display(f"Executing config-save on Fabric: {fabric}")
             ndfc_config_save = self._execute_module(
-                module_name="cisco.dcnm.dcnm_rest",
+                module_name="cisco.nd.nd_rest",
                 module_args={
                     "method": "POST",
                     "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric}/config-save",

--- a/plugins/action/dtc/fabrics_deploy.py
+++ b/plugins/action/dtc/fabrics_deploy.py
@@ -43,7 +43,7 @@ class ActionModule(ActionBase):
         for fabric in fabrics:
             display.display(f"Executing config-deploy on Fabric: {fabric}")
             ndfc_deploy = self._execute_module(
-                module_name="cisco.dcnm.dcnm_rest",
+                module_name="cisco.nd.nd_rest",
                 module_args={
                     "method": "POST",
                     "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric}/config-deploy?forceShowRun=false",

--- a/plugins/action/dtc/get_poap_data.py
+++ b/plugins/action/dtc/get_poap_data.py
@@ -149,7 +149,7 @@ class POAPDevice:
         self.refresh_message = None
 
         data = self.execute_module(
-            module_name="cisco.dcnm.dcnm_rest",
+            module_name="cisco.nd.nd_rest",
             module_args={
                 "method": self.poap_get_method,
                 "path": self.poap_get_path

--- a/plugins/action/dtc/manage_child_fabric_networks.py
+++ b/plugins/action/dtc/manage_child_fabric_networks.py
@@ -130,7 +130,7 @@ class ActionModule(ActionBase):
                         #         return results
 
                         ndfc_net = self._execute_module(
-                            module_name="cisco.dcnm.dcnm_rest",
+                            module_name="cisco.nd.nd_rest",
                             module_args={
                                 "method": "GET",
                                 "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{child_fabric}/networks/{network['name']}",
@@ -184,7 +184,7 @@ class ActionModule(ActionBase):
                             rendered_to_nice_json = templar.environment.filters['to_nice_json'](rendered_content)
 
                             ndfc_net_update = self._execute_module(
-                                module_name="cisco.dcnm.dcnm_rest",
+                                module_name="cisco.nd.nd_rest",
                                 module_args={
                                     "method": "PUT",
                                     "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{child_fabric}/networks/{network['name']}",

--- a/plugins/action/dtc/manage_child_fabric_vrfs.py
+++ b/plugins/action/dtc/manage_child_fabric_vrfs.py
@@ -130,7 +130,7 @@ class ActionModule(ActionBase):
                         #         return results
 
                         ndfc_vrf = self._execute_module(
-                            module_name="cisco.dcnm.dcnm_rest",
+                            module_name="cisco.nd.nd_rest",
                             module_args={
                                 "method": "GET",
                                 "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{child_fabric}/vrfs/{vrf['name']}"
@@ -195,7 +195,7 @@ class ActionModule(ActionBase):
                             rendered_to_nice_json = templar.environment.filters['to_nice_json'](rendered_content)
 
                             ndfc_vrf_update = self._execute_module(
-                                module_name="cisco.dcnm.dcnm_rest",
+                                module_name="cisco.nd.nd_rest",
                                 module_args={
                                     "method": "PUT",
                                     "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{child_fabric}/vrfs/{vrf['name']}",

--- a/plugins/action/dtc/manage_child_fabrics.py
+++ b/plugins/action/dtc/manage_child_fabrics.py
@@ -46,7 +46,7 @@ class ActionModule(ActionBase):
             for fabric in child_fabrics:
                 json_data = '{"destFabric":"%s","sourceFabric":"%s"}' % (parent_fabric, fabric)
                 add_fabric_result = self._execute_module(
-                    module_name="cisco.dcnm.dcnm_rest",
+                    module_name="cisco.nd.nd_rest",
                     module_args={
                         "method": "POST",
                         "path": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msdAdd",
@@ -75,7 +75,7 @@ class ActionModule(ActionBase):
             for fabric in child_fabrics:
                 json_data = '{"destFabric":"%s","sourceFabric":"%s"}' % (parent_fabric, fabric)
                 remove_fabric_result = self._execute_module(
-                    module_name="cisco.dcnm.dcnm_rest",
+                    module_name="cisco.nd.nd_rest",
                     module_args={
                         "method": "POST",
                         "path": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msdExit",
@@ -95,7 +95,7 @@ class ActionModule(ActionBase):
         return results
 
 
-#   cisco.dcnm.dcnm_rest:
+#   cisco.nd.nd_rest:
 #     method: POST
 #     path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msdAdd
 #     json_data: '{"destFabric":"nac-msd","sourceFabric":"nac-ndfc1"}'

--- a/plugins/action/dtc/prepare_msite_child_fabrics_data.py
+++ b/plugins/action/dtc/prepare_msite_child_fabrics_data.py
@@ -45,7 +45,7 @@ class ActionModule(ActionBase):
         # This is actaully not an accurrate API endpoint as it returns all fabrics in NDFC, not just the fabrics associated with MSD
         # Therefore, we need to get the fabric associations response and filter out the fabrics that are not associated with the parent fabric (MSD)
         msd_fabric_associations = self._execute_module(
-            module_name="cisco.dcnm.dcnm_rest",
+            module_name="cisco.nd.nd_rest",
             module_args={
                 "method": "GET",
                 "path": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations",

--- a/plugins/action/dtc/prepare_msite_data.py
+++ b/plugins/action/dtc/prepare_msite_data.py
@@ -47,7 +47,7 @@ class ActionModule(ActionBase):
         # This is actaully not an accurrate API endpoint as it returns all fabrics in NDFC, not just the fabrics associated with MSD
         # Therefore, we need to get the fabric associations response and filter out the fabrics that are not associated with the parent fabric (MSD)
         msd_fabric_associations = self._execute_module(
-            module_name="cisco.dcnm.dcnm_rest",
+            module_name="cisco.nd.nd_rest",
             module_args={
                 "method": "GET",
                 "path": "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations",

--- a/plugins/plugin_utils/helper_functions.py
+++ b/plugins/plugin_utils/helper_functions.py
@@ -97,7 +97,7 @@ def ndfc_get_switch_policy(self, task_vars, tmp, switch_serial_number):
         N/A
     """
     policy_data = self._execute_module(
-        module_name="cisco.dcnm.dcnm_rest",
+        module_name="cisco.nd.nd_rest",
         module_args={
             "method": "GET",
             "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/switches/{switch_serial_number}/SWITCH/SWITCH"
@@ -183,7 +183,7 @@ def ndfc_get_fabric_attributes(self, task_vars, tmp, fabric):
         N/A
     """
     fabric_response = self._execute_module(
-        module_name="cisco.dcnm.dcnm_rest",
+        module_name="cisco.nd.nd_rest",
         module_args={
             "method": "GET",
             "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric}",

--- a/roles/dtc/connectivity_check/tasks/main.yml
+++ b/roles/dtc/connectivity_check/tasks/main.yml
@@ -47,7 +47,7 @@
   tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
 
 - name: Get Cisco NDFC Version
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: GET
     path: /appcenter/cisco/ndfc/api/about/version
   register: ndfc_version

--- a/roles/dtc/create/tasks/common/devices_discovery.yml
+++ b/roles/dtc/create/tasks/common/devices_discovery.yml
@@ -82,7 +82,7 @@
     switch_serial_numbers: "{{ md_serial_numbers }}"
     template_name: host_11_1
   register: results
-# do not delegate_to: localhost as this action plugin uses Python to execute cisco.dcnm.dcnm_rest
+# do not delegate_to: localhost as this action plugin uses Python to execute cisco.nd.nd_rest
 
 - name: Join List of Switch Hostname Policy IDs from NDFC
   ansible.builtin.set_fact:
@@ -91,7 +91,7 @@
   delegate_to: localhost
 
 - name: Update Switch Hostname Policy in NDFC
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: PUT
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/{{ policy_ids }}/bulk"
     json_data: "{{ results.policy_update.values() | list | to_json }}"

--- a/roles/dtc/create/tasks/external/devices_discovery.yml
+++ b/roles/dtc/create/tasks/external/devices_discovery.yml
@@ -44,7 +44,7 @@
     switch_serial_numbers: "{{ md_serial_numbers }}"
     template_name: host_11_1
   register: results
-# do not delegate_to: localhost as this action plugin uses Python to execute cisco.dcnm.dcnm_rest
+# do not delegate_to: localhost as this action plugin uses Python to execute cisco.nd.nd_rest
 
 - name: Join List of Switch Hostname Policy IDs from NDFC
   ansible.builtin.set_fact:
@@ -53,7 +53,7 @@
   delegate_to: localhost
 
 - name: Update Switch Hostname Policy in NDFC
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: PUT
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/{{ policy_ids }}/bulk"
     json_data: "{{ results.policy_update.values() | list | to_json }}"

--- a/roles/dtc/create/tasks/external/fabric.yml
+++ b/roles/dtc/create/tasks/external/fabric.yml
@@ -29,14 +29,14 @@
       - "----------------------------------------------------------------"
 
 - name: Check if fabric External {{ MD_Extended.vxlan.fabric.name }} exists in NDFC
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: GET
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}"
   register: get_result
   failed_when: false
 
 - name: Manage fabric External {{ MD_Extended.vxlan.fabric.name }} in NDFC (PUT)
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: PUT
     path: '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/External_Fabric'
     json_data: '{{ fabric_config | to_json }}'
@@ -46,7 +46,7 @@
   register: put_result
 
 - name: Manage fabric External {{ MD_Extended.vxlan.fabric.name }} in NDFC (POST)
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: POST
     path: '/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/External_Fabric'
     json_data: '{{ fabric_config | to_json }}'

--- a/roles/dtc/create/tasks/msd/vrfs_networks.yml
+++ b/roles/dtc/create/tasks/msd/vrfs_networks.yml
@@ -113,7 +113,7 @@
 
 # Check with Matt and Pete on how we want to handle this for MSD
 # - name: Attach VRF Loopbacks per VRF
-#   cisco.dcnm.dcnm_rest:
+#   cisco.nd.nd_rest:
 #     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/fabrics/{{ MD_Extended.vxlan.fabric.name }}/vrfs/attachments"
 #     method: "POST"
 #     json_data: "{{ vars_common_msd.vrf_attach_config | to_json}}"

--- a/roles/dtc/create/tasks/sub_main_vxlan.yml
+++ b/roles/dtc/create/tasks/sub_main_vxlan.yml
@@ -58,7 +58,7 @@
 - name: Config-Save block to propagate vPC changes to the fabric
   block:
     - name: Config-Save for Fabric {{ MD_Extended.vxlan.fabric.name }}
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: POST
         path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-save"
       when: MD_Extended.vxlan.topology.switches | length > 0

--- a/roles/dtc/create/tasks/vxlan/vrfs_networks.yml
+++ b/roles/dtc/create/tasks/vxlan/vrfs_networks.yml
@@ -31,7 +31,7 @@
 - name: Check If Current Fabric Is An Active Multisite Fabric
   block:
     - name: Get Multisite Fabric Associations
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: GET
         path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations
       register: ndfc_msd_fabric_associations
@@ -73,7 +73,7 @@
 # Manage Loopback VRF attachments on NDFC
 # --------------------------------------------------------------------
 - name: Attach Loopbacks to VRFs
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: POST
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/fabrics/{{ MD_Extended.vxlan.fabric.name }}/vrfs/attachments"
     json_data: "{{ vars_common_vxlan.vrf_attach_config | to_json}}"

--- a/roles/dtc/deploy/tasks/sub_main_external.yml
+++ b/roles/dtc/deploy/tasks/sub_main_external.yml
@@ -33,7 +33,7 @@
 - name: Config-Save block
   block:
     - name: Config-Save for Fabric {{ MD_Extended.vxlan.fabric.name }}
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: POST
         path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-save"
       register: config_save
@@ -47,7 +47,7 @@
         msg: "{{ config_save.msg.DATA }}"
 
 - name: Deploy for Fabric {{ MD_Extended.vxlan.fabric.name }}
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: POST
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-deploy?forceShowRun=false"
   vars:

--- a/roles/dtc/deploy/tasks/sub_main_isn.yml
+++ b/roles/dtc/deploy/tasks/sub_main_isn.yml
@@ -33,7 +33,7 @@
 - name: Config-Save block
   block:
     - name: Config-Save for Fabric {{ MD_Extended.vxlan.fabric.name }}
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: POST
         path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-save"
       register: config_save
@@ -48,7 +48,7 @@
         msg: "{{ config_save.msg.DATA }}"
 
 - name: Deploy for Fabric {{ MD_Extended.vxlan.fabric.name }}
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: POST
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-deploy?forceShowRun=false"
   vars:

--- a/roles/dtc/deploy/tasks/sub_main_msd.yml
+++ b/roles/dtc/deploy/tasks/sub_main_msd.yml
@@ -33,7 +33,7 @@
 - name: Config-Save block
   block:
     - name: Config-Save for Fabric {{ MD_Extended.vxlan.fabric.name }}
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: POST
         path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-save"
       register: config_save
@@ -48,7 +48,7 @@
         msg: "{{ config_save.msg.DATA }}"
 
 - name: Deploy for Fabric {{ MD_Extended.vxlan.fabric.name }}
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: POST
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-deploy?forceShowRun=false"
   vars:

--- a/roles/dtc/deploy/tasks/sub_main_vxlan.yml
+++ b/roles/dtc/deploy/tasks/sub_main_vxlan.yml
@@ -33,7 +33,7 @@
 - name: Config-Save block
   block:
     - name: Config-Save for Fabric {{ MD_Extended.vxlan.fabric.name }}
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: POST
         path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-save"
       register: config_save
@@ -47,7 +47,7 @@
         msg: "{{ config_save.msg.DATA }}"
 
 - name: Deploy for Fabric {{ MD_Extended.vxlan.fabric.name }}
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: POST
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-deploy?forceShowRun=false"
   vars:
@@ -67,7 +67,7 @@
 - name: Retrying Config-Save Block
   block:
     - name: Retrying Config-Save for Fabric {{ MD_Extended.vxlan.fabric.name }}
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: POST
         path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-save"
       register: config_save
@@ -83,7 +83,7 @@
         msg: "{{ config_save.msg.DATA }}"
 
 - name: Retrying Deploy for Fabric {{ MD_Extended.vxlan.fabric.name }}
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: POST
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-deploy?forceShowRun=false"
   vars:

--- a/roles/dtc/remove/tasks/common/edge_connections.yml
+++ b/roles/dtc/remove/tasks/common/edge_connections.yml
@@ -42,7 +42,7 @@
       switch_data: "{{ switch_list.response.DATA }}"
       edge_connections: "{{ edge_connections }}"
     register: unmanaged_edge_connections_config
-    # do not delegate_to: localhost as this action plugin uses Python to execute cisco.dcnm.dcnm_rest
+    # do not delegate_to: localhost as this action plugin uses Python to execute cisco.nd.nd_rest
 
   - name: Remove Unmanaged NDFC Edge Connections
     cisco.dcnm.dcnm_policy:

--- a/roles/dtc/remove/tasks/common/interfaces.yml
+++ b/roles/dtc/remove/tasks/common/interfaces.yml
@@ -54,7 +54,7 @@
     - (interface_delete_mode is defined) and (interface_delete_mode is true|bool)
 
 # - name: Config-Save for Fabric {{ MD_Extended.vxlan.fabric.name }} after removing or defaulting interfaces
-#   cisco.dcnm.dcnm_rest:
+#   cisco.nd.nd_rest:
 #     method: POST
 #     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-save"
 #   when:
@@ -63,7 +63,7 @@
 #     - (interface_delete_mode is defined) and (interface_delete_mode is true|bool)
 
 # - name: Deploy for Fabric {{ MD_Extended.vxlan.fabric.name }} after removing or defaulting interfaces
-#   cisco.dcnm.dcnm_rest:
+#   cisco.nd.nd_rest:
 #     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/config-deploy?forceShowRun=false"
 #     method: POST
 #   vars:

--- a/roles/dtc/remove/tasks/common/links.yml
+++ b/roles/dtc/remove/tasks/common/links.yml
@@ -58,7 +58,7 @@
     register: links_to_be_removed
     when: result_links.response is defined
 
-  # do not delegate_to: localhost as this action plugin uses Python to execute cisco.dcnm.dcnm_rest
+  # do not delegate_to: localhost as this action plugin uses Python to execute cisco.nd.nd_rest
   - name: Set not_required_links if result_links.response is not defined
     ansible.builtin.set_fact:
       links_to_be_removed: []

--- a/roles/dtc/remove/tasks/common/policy.yml
+++ b/roles/dtc/remove/tasks/common/policy.yml
@@ -47,7 +47,7 @@
       switch_serial_numbers: "{{ switch_serial_numbers }}"
       model_data: "{{ MD_Extended }}"
     register: unmanaged_policy_config
-    # do not delegate_to: localhost as this action plugin uses Python to execute cisco.dcnm.dcnm_rest
+    # do not delegate_to: localhost as this action plugin uses Python to execute cisco.nd.nd_rest
 
   - name: Remove Unmanaged NDFC Fabric Policy
     cisco.dcnm.dcnm_policy:

--- a/roles/dtc/remove/tasks/sub_main_external.yml
+++ b/roles/dtc/remove/tasks/sub_main_external.yml
@@ -32,7 +32,7 @@
   tags: "{{ nac_tags.remove }}"
 
 - name: Get List of Fabric Switches from NDFC
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: GET
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/inventory/switchesByFabric"
   register: switch_list

--- a/roles/dtc/remove/tasks/sub_main_isn.yml
+++ b/roles/dtc/remove/tasks/sub_main_isn.yml
@@ -32,7 +32,7 @@
   tags: "{{ nac_tags.remove }}"
 
 - name: Get List of Fabric Switches from NDFC
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: GET
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/inventory/switchesByFabric"
   register: switch_list

--- a/roles/dtc/remove/tasks/sub_main_vxlan.yml
+++ b/roles/dtc/remove/tasks/sub_main_vxlan.yml
@@ -32,7 +32,7 @@
   tags: "{{ nac_tags.remove }}"
 
 - name: Get List of Fabric Switches from NDFC
-  cisco.dcnm.dcnm_rest:
+  cisco.nd.nd_rest:
     method: GET
     path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ MD_Extended.vxlan.fabric.name }}/inventory/switchesByFabric"
   register: switch_list

--- a/roles/dtc/remove/tasks/vxlan/networks.yml
+++ b/roles/dtc/remove/tasks/vxlan/networks.yml
@@ -23,7 +23,7 @@
 - name: Check If Current Fabric Is An Active Multisite Fabric
   block:
     - name: Get Multisite Fabric Associations
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: GET
         path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations
       register: ndfc_msd_fabric_associations

--- a/roles/dtc/remove/tasks/vxlan/vrfs.yml
+++ b/roles/dtc/remove/tasks/vxlan/vrfs.yml
@@ -23,7 +23,7 @@
 - name: Check If Current Fabric Is An Active Multisite Fabric
   block:
     - name: Get Multisite Fabric Associations
-      cisco.dcnm.dcnm_rest:
+      cisco.nd.nd_rest:
         method: GET
         path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations
       register: ndfc_msd_fabric_associations

--- a/tests/integration/group_vars/ndfc/examples/main.yml
+++ b/tests/integration/group_vars/ndfc/examples/main.yml
@@ -27,7 +27,7 @@ ansible_connection: ansible.netcommon.httpapi
 ansible_httpapi_port: 443
 ansible_httpapi_use_ssl: true
 ansible_httpapi_validate_certs: false
-ansible_network_os: cisco.dcnm.dcnm
+ansible_network_os: cisco.nd.nd
 # NDFC API Credentials
 ansible_user: admin
 ansible_password: password


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
https://github.com/CiscoDevNet/ansible-dcnm/issues/475

## Related Collection Role : * [ ] cisco.nac_dc_vxlan.validate
<!-- If a new role to the collection, please specify -->
* [- ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element: * [ ] other
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ - ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

The [ND Rest Module](https://github.com/CiscoDevNet/ansible-nd/blob/master/plugins/modules/nd_rest.py) needs to be validated against our [VXLAN as Code](https://github.com/netascode/ansible-dc-vxlan) collection to ensure that everywhere our [DCNM Rest Module](https://github.com/CiscoDevNet/ansible-dcnm/blob/develop/plugins/modules/dcnm_rest.py) is used we can replace it and it works.

Replace all instances of cisco.dcnm.dcnm_rest with cisco.nd.nd_rest
https://github.com/search?q=repo%3Anetascode%2Fansible-dc-vxlan+dcnm_rest&type=code&p=1
Update Ansible collection requirements to include cisco.nd
https://github.com/netascode/ansible-dc-vxlan-example/blob/main/requirements.yaml
Verify end to end workflows using the nd connection plugin
https://github.com/netascode/ansible-dc-vxlan-example/blob/main/requirements.yaml
Replace this line with ansible_network_os: cisco.nd.nd

## Test Notes
<!--- Please provide notes or description of testing -->
Tested with the below playbook
- hosts: nac-fabric1
  any_errors_fatal: true
  gather_facts: no


  tasks:
    - name: Test simple GET request using nd_rest module
      cisco.nd.nd_rest:
        #path: "/api/v1/manage/fabricsSummary"
        #path: "/api/v1/manage/inventory/switches"
        #path: "/appcenter/cisco/ndfc/api/v1/lan-discovery/inventory/modules"
        path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/"
        method: GET
      register: result


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
Nexus Dashboard
Version 4.1.0.156b

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
