### PR TITLE
Added support for multiline freeform on VRF

### DIFF
--- a/roles/dtc/common/templates/ndfc_vrfs/ndfc_attach_vrfs_loopbacks.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/ndfc_attach_vrfs_loopbacks.j2
@@ -22,7 +22,7 @@
         "serialNumber": "{{ switch.serial_number }}",
 {% endif %}
 {% endfor %}
-        "freeformConfig": "{{ attach['freeform_config'] | default('') }}",
+        "freeformConfig": "{{ attach['freeform_config'] | default('') | replace('\n', '\\n') | replace('"', '\\"') }}",
         "extensionValues": "",
         "vlan": "{{ vrf["vlan_id"] }}",
         "deployment": true,


### PR DESCRIPTION
Added support for multiline freeform text. As when cast to JSON the new line wasn't being correctly formatted in the rendered data file

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Issue 442

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [x ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Just needing to replace new lines so that when formatted to JSON in the rendered files, these aren't incorrectly adding new lines in the middle of the entry

## Test Notes
<!--- Please provide notes or description of testing -->
Tested with :

---
vxlan:
  multisite:
    overlay:
      vrfs:
        - name: vrfMGMT
          vrf_id: 50000
          vlan_id: 2000
          max_bgp_paths: 2
          vrf_vlan_name: vrfMGMT_VLAN
          vrf_attach_group: all_vrfMGMT
      vrf_attach_groups:
        - name: all_vrfMGMT
          switches:
            - hostname: SVS-LEAF1
              loopback_id: 120
              loopback_ipv4: 10.34.82.44
              freeform_config: |2-
                vrf context mx_mg_workplace
             - { hostname: SVS-LEAF1, loopback_id: 120, loopback_ipv4: 10.34.82.44, freeform_config: "vrf context mx_mg_workplace\n  ip icmp-errors source-interface loopback120"}

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->
12.2.2

## Checklist

* [ x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x ] Assigned the proper reviewers
