### PR TITLE
Change template to accept VRF definition without vlan_id

### DIFF
--- a/roles/dtc/common/templates/ndfc_vrfs/ndfc_attach_vrfs_loopbacks.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/ndfc_attach_vrfs_loopbacks.j2
@@ -24,7 +24,9 @@
 {% endfor %}
         "freeformConfig": "{{ attach['freeform_config'] | default('') | replace('\n', '\\n') | replace('"', '\\"') }}",
         "extensionValues": "",
+{% if vrf['vlan_id'] is defined %}
         "vlan": "{{ vrf["vlan_id"] }}",
+{% endif %}
         "deployment": true,
         "instanceValues": "{\"loopbackId\": \"{{ attach['loopback_id'] | default('')}}\", \"loopbackIpAddress\": \"{{ attach['loopback_ipv4'] | default('') }}\", \"loopbackIpV6Address\":\"{{ attach['loopback_ipv6'] | default('') }}\"}"
       }{% if not loop.last %},{% endif %}


### PR DESCRIPTION

## Related Issue(s)
Solves Issue #454 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [X] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Adding condition to omit vlan assignment if the vlan_id key is empty


## Test Notes
Tested with VRF combinations with and without vlan_id


## Cisco NDFC Version
12.2.3


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
