### PR TITLE
Support of per-switch credentials

### DIFF
--- a/plugins/action/common/get_credentials.py
+++ b/plugins/action/common/get_credentials.py
@@ -55,10 +55,9 @@ class ActionModule(ActionBase):
         updated_inv_list = []
         for device in inv_list:
             updated_inv_list.append(copy.deepcopy(device))
-
         for new_device in updated_inv_list:
-            new_device['user_name'] = username
-            new_device['password'] = password
+            if new_device.get('user_name') == 'PLACE_HOLDER_USERNAME': new_device['user_name'] = username
+            if new_device.get('password') == 'PLACE_HOLDER_PASSWORD': new_device['password'] = password
 
         results['updated_inv_list'] = updated_inv_list
         return results

--- a/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory.j2
@@ -6,9 +6,17 @@
 {% elif switch.management.management_ipv6_address is defined %}
 - seed_ip: {{ switch['management']['management_ipv6_address'] }}
 {% endif %}
-  auth_proto: {{ MD['vxlan']['global']['auth_proto'] | default(defaults.vxlan.global.auth_proto) }}
+{% if switch['management']['username'] is defined %}
+  user_name: {{ switch['management']['username'] }}
+{% else %}
   user_name: PLACE_HOLDER_USERNAME
+{% endif %}
+{% if switch['management']['password'] is defined %}
+  password: {{ switch['management']['password'] }}
+{% else %}
   password: PLACE_HOLDER_PASSWORD
+{% endif %}
+  auth_proto: {{ MD['vxlan']['global']['auth_proto'] | default(defaults.vxlan.global.auth_proto) }}
   max_hops: 0 # this is the default value as it is not defined into the data model
   role: {{ switch['role'] }}
   preserve_config: false


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->
The proposal to support “per-switch credentials” requires new ‘username’ and “password” fields in the data model.


## Related Issue(s)
#457 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [x] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
Example topology yaml:
```yaml
---
vxlan:
 topology:
   switches:
     - name: eBGP_SPINE_21
       serial_number: 99FYP2OV1NS
       role: spine
       management:
         default_gateway_v4: 198.18.133.1
         management_ipv4_address: 198.18.133.21
         username: admin
         password: admin123
       routing_loopback_id: 0
       vtep_loopback_id: 1
     - name: eBGP_LEAF23
       serial_number: 9M81OZOOCWM
       role: leaf
       management:
         default_gateway_v4: 198.18.133.1
         management_ipv4_address: 198.18.133.23
       routing_loopback_id: 0
       vtep_loopback_id: 1
```

## Cisco NDFC Version
ND 3.2.1i

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
