### PR TITLE
Add options to configure LACP attributes for port-channels 

### DIFF
--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
@@ -31,9 +31,9 @@
     access_vlan: {{ interface['access_vlan'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan) }}
     bpdu_guard: {{ interface['enable_bpdu_guard'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_bpdu_guard) }}
     duplex: {{ interface['duplex'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.duplex) }}
-{#    disable_lacp_suspend_individual: {{ interface['disable_lacp_suspend_individual'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.disable_lacp_suspend_individual) }} #}
-{#    lacp_port_priority: {{ interface['lacp_port_priority'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.lacp_port_priority) }} #}
-{#    lacp_rate: {{ interface['lacp_rate'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.lacp_rate) }} #}
+    disable_lacp_suspend_individual: {{ interface['disable_lacp_suspend_individual'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.disable_lacp_suspend_individual) }}
+    lacp_port_priority: {{ interface['lacp_port_priority'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.lacp_port_priority) }}
+    lacp_rate: {{ interface['lacp_rate'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.lacp_rate) }}
 {% if interface['orphan_port'] | default(false) %}
     orphan_port: {{ interface['orphan_port'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.orphan_port) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
@@ -31,6 +31,9 @@
     access_vlan: {{ interface['access_vlan'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan) }}
     bpdu_guard: {{ interface['enable_bpdu_guard'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_bpdu_guard) }}
     duplex: {{ interface['duplex'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.duplex) }}
+{#    disable_lacp_suspend_individual: {{ interface['disable_lacp_suspend_individual'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.disable_lacp_suspend_individual) }} #}
+{#    lacp_port_priority: {{ interface['lacp_port_priority'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.lacp_port_priority) }} #}
+{#    lacp_rate: {{ interface['lacp_rate'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.lacp_rate) }} #}
 {% if interface['orphan_port'] | default(false) %}
     orphan_port: {{ interface['orphan_port'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.orphan_port) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
@@ -32,9 +32,9 @@
     bpdu_guard: {{ interface['enable_bpdu_guard'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_bpdu_guard) }}
     allowed_vlans: "{{ convert_ranges(interface['trunk_allowed_vlans'], defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
     duplex: {{ interface['duplex'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.duplex) }}
-{#    disable_lacp_suspend_individual: {{ interface['disable_lacp_suspend_individual'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.disable_lacp_suspend_individual) }} #}
-{#    lacp_port_priority: {{ interface['lacp_port_priority'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_port_priority) }} #}
-{#    lacp_rate: {{ interface['lacp_rate'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_rate) }} #}
+    disable_lacp_suspend_individual: {{ interface['disable_lacp_suspend_individual'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.disable_lacp_suspend_individual) }}
+    lacp_port_priority: {{ interface['lacp_port_priority'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_port_priority) }}
+    lacp_rate: {{ interface['lacp_rate'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_rate) }}
 {% if interface['orphan_port'] | default(false) %}
     orphan_port: {{ interface['orphan_port'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.orphan_port) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
@@ -32,6 +32,9 @@
     bpdu_guard: {{ interface['enable_bpdu_guard'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_bpdu_guard) }}
     allowed_vlans: "{{ convert_ranges(interface['trunk_allowed_vlans'], defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
     duplex: {{ interface['duplex'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.duplex) }}
+{#    disable_lacp_suspend_individual: {{ interface['disable_lacp_suspend_individual'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.disable_lacp_suspend_individual) }} #}
+{#    lacp_port_priority: {{ interface['lacp_port_priority'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_port_priority) }} #}
+{#    lacp_rate: {{ interface['lacp_rate'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_rate) }} #}
 {% if interface['orphan_port'] | default(false) %}
     orphan_port: {{ interface['orphan_port'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.orphan_port) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
@@ -19,10 +19,6 @@
   profile:
     admin_state: {{ switches[peer1].enabled | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled) }}
     mode: {{ switches[peer1].mode }}
-{#    disable_lacp_suspend_individual: {{ switches[peer1].disable_lacp_suspend_individual | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.disable_lacp_suspend_individual) }} #}
-{#    enable_lacp_vpc_convergence: {{ switches[peer1].enable_lacp_vpc_convergence | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_lacp_vpc_convergence) }} #}
-{#    lacp_port_priority: {{ switches[peer1].lacp_port_priority | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_port_priority) }} #}
-{#    lacp_rate: {{ switches[peer1]lacp_rate | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_rate) }} #}
     peer1_pcid: {{ switches[peer1].name | regex_replace('[^0-9]', '') }}
     peer2_pcid: {{ switches[peer2].name | regex_replace('[^0-9]', '') }}
     port_type_fast: {{ switches[peer1].spanning_tree_portfast | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.spanning_tree_portfast) }}
@@ -38,6 +34,10 @@
     peer1_description: "{{ switches[peer1].description | default(omit) }}"
     peer2_description: "{{ switches[peer2].description | default(omit) }}"
     bpdu_guard: {{ switches[peer1].enable_bpdu_guard | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_bpdu_guard)   }}
+    disable_lacp_suspend_individual: {{ switches[peer1].disable_lacp_suspend_individual | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.disable_lacp_suspend_individual) }}
+    enable_lacp_vpc_convergence: {{ switches[peer1].enable_lacp_vpc_convergence | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_lacp_vpc_convergence) }}    
+    lacp_port_priority: {{ switches[peer1].lacp_port_priority | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_port_priority) }}
+    lacp_rate: {{ switches[peer1].lacp_rate | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_rate) }}
 {% if switches[peer1].mode == 'trunk' %}
     peer1_allowed_vlans: "{{ convert_ranges(switches[peer1].trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
     peer2_allowed_vlans: "{{ convert_ranges(switches[peer2].trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
@@ -19,6 +19,10 @@
   profile:
     admin_state: {{ switches[peer1].enabled | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled) }}
     mode: {{ switches[peer1].mode }}
+{#    disable_lacp_suspend_individual: {{ switches[peer1].disable_lacp_suspend_individual | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.disable_lacp_suspend_individual) }} #}
+{#    enable_lacp_vpc_convergence: {{ switches[peer1].enable_lacp_vpc_convergence | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_lacp_vpc_convergence) }} #}
+{#    lacp_port_priority: {{ switches[peer1].lacp_port_priority | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_port_priority) }} #}
+{#    lacp_rate: {{ switches[peer1]lacp_rate | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.lacp_rate) }} #}
     peer1_pcid: {{ switches[peer1].name | regex_replace('[^0-9]', '') }}
     peer2_pcid: {{ switches[peer2].name | regex_replace('[^0-9]', '') }}
     port_type_fast: {{ switches[peer1].spanning_tree_portfast | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.spanning_tree_portfast) }}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -131,6 +131,10 @@ factory_defaults:
             enable_bpdu_guard: true
             duplex: auto
             orphan_port: false
+            disable_lacp_suspend_individual: false
+            enable_lacp_vpc_convergence: false
+            lacp_port_priority: 32768
+            lacp_rate: normal
           topology_switch_trunk_po_interface:
             description: "NetAsCode Trunk PO Interface"
             mtu: jumbo
@@ -143,6 +147,10 @@ factory_defaults:
             duplex: auto
             orphan_port: false
             native_vlan: ""
+            disable_lacp_suspend_individual: false
+            enable_lacp_vpc_convergence: false
+            lacp_port_priority: 32768
+            lacp_rate: normal
           topology_switch_routed_interface:
             description: "NetAsCode Routed Interface"
             mtu: 9216


### PR DESCRIPTION
Fixes #551 

## Related Issue(s)
This PR is to add support to configure/change following LACP options for port-channels:
-     Enable LACP vPC-convergence (VPC port-channels only)
-     Disable LACP Suspend-individual
-     LACP Port Priority
-     LACP Timer Rate

The changes required changes in the base DCNM module and should be approved after following PRs from base module are merged:
https://github.com/CiscoDevNet/ansible-dcnm/pull/494
https://github.com/CiscoDevNet/ansible-dcnm/pull/495

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Defined four new keys in the schema to accommodate required options:
lacp_port_priority
lacp_rate
disable_lacp_suspend_individual
enable_lacp_vpc_convergence

Will be submitting the PR for internal repo as well to update the schema and defaults files

## Test Notes
Tested creation of 4 types of interfaces:
- access port-channel
- trunk port-channel
- access vpc port-channel
- trunk vpc port-channel
Tried assigning:
- non-default values of each attribute
- default values of each attribute
- skip attributes - rely on defaults 

## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
