### PR TITLE
Add support for ipv6 route map under vrf

### DIFF
--- a/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
@@ -54,6 +54,7 @@
   underlay_mcast_ip: {{ vrf['underlay_mcast_ip'] | default(omit) }}
 {% endif %}
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.redist_direct_routemap) }}
+  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }}
 {# ------------------------------------------------------ #}
 {# Attach Group Section                                   #}
 {# ------------------------------------------------------ #}

--- a/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
@@ -54,7 +54,7 @@
   underlay_mcast_ip: {{ vrf['underlay_mcast_ip'] | default(omit) }}
 {% endif %}
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.redist_direct_routemap) }}
-  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }}
+{#  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }} #}
 {# ------------------------------------------------------ #}
 {# Attach Group Section                                   #}
 {# ------------------------------------------------------ #}

--- a/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
@@ -54,7 +54,7 @@
   underlay_mcast_ip: {{ vrf['underlay_mcast_ip'] | default(omit) }}
 {% endif %}
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.redist_direct_routemap) }}
-{#  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }} #}
+  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }}
 {# ------------------------------------------------------ #}
 {# Attach Group Section                                   #}
 {# ------------------------------------------------------ #}

--- a/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
@@ -54,7 +54,9 @@
   underlay_mcast_ip: {{ vrf['underlay_mcast_ip'] | default(omit) }}
 {% endif %}
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.redist_direct_routemap) }}
+{% if (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) %}
   v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }}
+{% endif %}
 {# ------------------------------------------------------ #}
 {# Attach Group Section                                   #}
 {# ------------------------------------------------------ #}

--- a/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/child_fabric/3.2/msd_child_fabric_vrf.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/child_fabric/3.2/msd_child_fabric_vrf.j2
@@ -16,7 +16,7 @@
       "mtu": ndfc.mtu,
       "tag": ndfc.tag,
       "vrfRouteMap": ndfc.vrfRouteMap,
-      "v6VrfRouteMap": ndfc.vrfRouteMapV6 if ndfc.vrfRouteMapV6 is defined else "",
+      "v6VrfRouteMap": ndfc.v6VrfRouteMap,
       "maxBgpPaths": ndfc.maxBgpPaths,
       "maxIbgpPaths": ndfc.maxIbgpPaths,
       "ipv6LinkLocalFlag": ndfc.ipv6LinkLocalFlag,

--- a/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/child_fabric/msd_child_fabric_vrf.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/child_fabric/msd_child_fabric_vrf.j2
@@ -16,7 +16,7 @@
       "mtu": ndfc.mtu,
       "tag": ndfc.tag,
       "vrfRouteMap": ndfc.vrfRouteMap,
-      "v6VrfRouteMap": ndfc.vrfRouteMapV6 if ndfc.vrfRouteMapV6 is defined else "",
+      "v6VrfRouteMap": ndfc.v6VrfRouteMap,
       "maxBgpPaths": ndfc.maxBgpPaths,
       "maxIbgpPaths": ndfc.maxIbgpPaths,
       "ipv6LinkLocalFlag": ndfc.ipv6LinkLocalFlag,

--- a/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
@@ -26,7 +26,7 @@
   import_evpn_rt: {{ vrf['import_evpn_rt'] | default(omit) }}
   import_vpn_rt: {{ vrf['import_vpn_rt'] | default(omit) }}
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.redist_direct_routemap) }}
-  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }}
+{#  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }} #}
 {# ------------------------------------------------------ #}
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}

--- a/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
@@ -26,7 +26,9 @@
   import_evpn_rt: {{ vrf['import_evpn_rt'] | default(omit) }}
   import_vpn_rt: {{ vrf['import_vpn_rt'] | default(omit) }}
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.redist_direct_routemap) }}
+{% if (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) %}
   v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }}
+{% endif %}
 {# ------------------------------------------------------ #}
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}

--- a/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
@@ -26,7 +26,7 @@
   import_evpn_rt: {{ vrf['import_evpn_rt'] | default(omit) }}
   import_vpn_rt: {{ vrf['import_vpn_rt'] | default(omit) }}
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.redist_direct_routemap) }}
-{#  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }} #}
+  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }}
 {# ------------------------------------------------------ #}
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}

--- a/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
@@ -26,6 +26,7 @@
   import_evpn_rt: {{ vrf['import_evpn_rt'] | default(omit) }}
   import_vpn_rt: {{ vrf['import_vpn_rt'] | default(omit) }}
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.redist_direct_routemap) }}
+  v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.overlay.vrfs.ipv6_redist_direct_routemap) }}
 {# ------------------------------------------------------ #}
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -247,8 +247,6 @@ factory_defaults:
         max_bgp_paths: 1
         max_ibgp_paths: 2
         ipv6_linklocal_enable: true
-        # Staging ipv6 route-map attribute for later usage after low-level collection adds support.
-        # ipv6_redist_direct_routemap: FABRIC-RMAP-REDIST-SUBNET
         adv_host_routes: false
         adv_default_routes: true
         static_default_route: true
@@ -257,6 +255,7 @@ factory_defaults:
         no_rp: false
         rp_external: false
         redist_direct_routemap: FABRIC-RMAP-REDIST-SUBNET
+        ipv6_redist_direct_routemap: FABRIC-RMAP-REDIST-SUBNET
         trm_enable: false
         trm_bgw_msite: false
         # Staging trmv6 attributes for later usage after low-level collection adds support.


### PR DESCRIPTION
PR is to add support for IPv6 route-map used for redistribution of directly connected routes

## Related Issue(s)
Fixes #540 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [x] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
Tested creation of vrfs with:
- default rm name specified,
- non-default rm name specified,
- rm name skipped in yaml files

I deleted conditional check under "[msd_child_fabric_vrf.j2](https://github.com/netascode/ansible-dc-vxlan/compare/develop...mkilar123:ansible-dc-vxlan:v6_redist_rmap?expand=1#diff-edac9fb9c809991da7f3927463c4bc6bc93416e07154ee5de648a8ab65fcc73c)
The reason is that under a child fabric the name of the route-map is "greyed out" and it always contains the value specified under MSD fabric level, so there is no option for this value to be different 0 - i basically treat the ipv6 route-map the same way as ipv4 one is.

## Cisco NDFC Version
3.2.1i


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
