### PR TITLE
fix for fabric_loopback deployments

### DIFF
--- a/roles/dtc/common/tasks/common/ndfc_interface_loopback.yml
+++ b/roles/dtc/common/tasks/common/ndfc_interface_loopback.yml
@@ -66,7 +66,10 @@
 - name: Set int_loopback_config Var
   ansible.builtin.set_fact:
     int_loopback_config: "{{ lookup('file', path_name + file_name) | from_yaml }}"
-  when: MD_Extended.vxlan.topology.interfaces.modes.loopback.count > 0
+  when: >
+    (MD_Extended.vxlan.topology.interfaces.modes.loopback.count > 0) or
+    (MD_Extended.vxlan.topology.interfaces.modes.fabric_loopback.count > 0) or
+    (MD_Extended.vxlan.topology.interfaces.modes.mpls_loopback.count > 0)
   delegate_to: localhost
 
 - name: Diff Previous and Current Data Files

--- a/roles/dtc/common/tasks/external/ndfc_interface_loopback.yml
+++ b/roles/dtc/common/tasks/external/ndfc_interface_loopback.yml
@@ -66,7 +66,10 @@
 - name: Set int_loopback_config Var
   ansible.builtin.set_fact:
     int_loopback_config: "{{ lookup('file', path_name + file_name) | from_yaml }}"
-  when: MD_Extended.vxlan.topology.interfaces.modes.loopback.count > 0
+  when: >
+    (MD_Extended.vxlan.topology.interfaces.modes.loopback.count > 0) or
+    (MD_Extended.vxlan.topology.interfaces.modes.fabric_loopback.count > 0) or
+    (MD_Extended.vxlan.topology.interfaces.modes.mpls_loopback.count > 0)
   delegate_to: localhost
 
 - name: Diff Previous and Current Data Files

--- a/roles/dtc/create/tasks/common/interfaces.yml
+++ b/roles/dtc/create/tasks/common/interfaces.yml
@@ -142,7 +142,10 @@
     fabric: "{{ MD_Extended.vxlan.fabric.name }}"
     state: replaced
     config: "{{ vars_common_local.int_loopback_config }}"
-  when: MD_Extended.vxlan.topology.interfaces.modes.loopback.count > 0
+  when: >
+    (MD_Extended.vxlan.topology.interfaces.modes.loopback.count > 0) or
+    (MD_Extended.vxlan.topology.interfaces.modes.fabric_loopback.count > 0) or
+    (MD_Extended.vxlan.topology.interfaces.modes.mpls_loopback.count > 0)
 
 # ----------------------------------------------------------------------
 # Manage Interface Dot1q Configuration in Nexus Dashboard

--- a/roles/dtc/create/tasks/external/interfaces.yml
+++ b/roles/dtc/create/tasks/external/interfaces.yml
@@ -114,7 +114,10 @@
     fabric: "{{ MD_Extended.vxlan.fabric.name }}"
     state: replaced
     config: "{{ vars_common_external.int_loopback_config }}"
-  when: MD_Extended.vxlan.topology.interfaces.modes.loopback.count > 0
+  when: >
+    (MD_Extended.vxlan.topology.interfaces.modes.loopback.count > 0) or
+    (MD_Extended.vxlan.topology.interfaces.modes.fabric_loopback.count > 0) or
+    (MD_Extended.vxlan.topology.interfaces.modes.mpls_loopback.count > 0)
 
 # ----------------------------------------------------------------------
 # Manage Interface vPC Configuration in Nexus Dashboard


### PR DESCRIPTION
## Related Issue(s)
Fixes #566 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Setting of the int_loopback_config variable was only dependant on the presence of the "regular" loopback interfaces and was not taking into consideration "special" loopbacks: "fabric" and "mpls".
I just added a conditional checks to include those loopback types as well.


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
