### PR TITLE
fix issues to manage new data model

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/ebgp_vxlan_fabric_base.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/ebgp_vxlan_fabric_base.j2
@@ -32,6 +32,3 @@
 
 {# Include NDFC eBGP VXLAN EVPN Flow Monitor Template #}
 {% include '/ndfc_fabric/ebgp_vxlan_fabric/flow_monitor/ebgp_vxlan_fabric_flow_monitor.j2' %}
-
-{# Include NDFC eBGP VXLAN EVPN Config Backup Template #}
-{% include '/ndfc_fabric/ebgp_vxlan_fabric/config_backup/ebgp_vxlan_fabric_config_backup.j2' %}

--- a/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory.j2
@@ -6,7 +6,18 @@
 {% elif switch.management.management_ipv6_address is defined %}
 - seed_ip: {{ switch['management']['management_ipv6_address'] }}
 {% endif %}
-  auth_proto: {{ MD['vxlan']['global']['auth_proto'] | default(defaults.vxlan.global.auth_proto) }}
+{% macro get_auth_proto() %}
+{%- if MD.vxlan.global.ebgp.auth_proto is defined -%}
+{{ MD.vxlan.global.ebgp.auth_proto | default(defaults.vxlan.global.ebgp.auth_proto) }}
+{%- elif MD.vxlan.global.ibgp.auth_proto is defined -%}
+{{ MD.vxlan.global.ibgp.auth_proto | default(defaults.vxlan.global.ibgp.auth_proto) }}
+{%- elif MD.vxlan.global.external.auth_proto is defined -%}
+{{ MD.vxlan.global.external.auth_proto | default(defaults.vxlan.global.external.auth_proto) }}
+{%- else -%}
+{{ MD.vxlan.global.auth_proto | default(defaults.vxlan.global.auth_proto) }}
+{%- endif -%}
+{% endmacro %}
+  auth_proto: {{ get_auth_proto() }}
   user_name: PLACE_HOLDER_USERNAME
   password: PLACE_HOLDER_PASSWORD
   max_hops: 0 # this is the default value as it is not defined into the data model

--- a/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory_no_bootstrap.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/common/fabric_inventory_no_bootstrap.j2
@@ -6,7 +6,18 @@
 {% elif switch.management.management_ipv6_address is defined %}
 - seed_ip: {{ switch['management']['management_ipv6_address'] }}
 {% endif %}
-  auth_proto: {{ MD['vxlan']['global']['auth_proto'] | default(defaults.vxlan.global.auth_proto) }}
+{% macro get_auth_proto() %}
+{%- if MD.vxlan.global.ebgp.auth_proto is defined -%}
+{{ MD.vxlan.global.ebgp.auth_proto | default(defaults.vxlan.global.ebgp.auth_proto) }}
+{%- elif MD.vxlan.global.ibgp.auth_proto is defined -%}
+{{ MD.vxlan.global.ibgp.auth_proto | default(defaults.vxlan.global.ibgp.auth_proto) }}
+{%- elif MD.vxlan.global.external.auth_proto is defined -%}
+{{ MD.vxlan.global.external.auth_proto | default(defaults.vxlan.global.external.auth_proto) }}
+{%- else -%}
+{{ MD.vxlan.global.auth_proto | default(defaults.vxlan.global.auth_proto) }}
+{%- endif -%}
+{% endmacro %}
+  auth_proto: {{ get_auth_proto() }}
   user_name: PLACE_HOLDER_USERNAME
   password: PLACE_HOLDER_PASSWORD
   max_hops: 0 # this is the default value as it is not defined into the data model

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -26,61 +26,118 @@ factory_defaults:
       ebgp:
         bgp_asn_mode: Multi-AS
         leaf_same_bgp_asn: false
+        anycast_gateway_mac: 20:20:00:00:00:aa
+        auth_proto: MD5
+        enable_nxapi_http: false
+        nxapi_http_port: 80
+        enable_nxapi_https: true
+        nxapi_https_port: 443
+        layer2_vni_range:
+          from: 30000
+          to: 49000
+        layer3_vni_range:
+          from: 50000
+          to: 59000
+        layer2_vlan_range:
+          from: 2300
+          to: 2999
+        layer3_vlan_range:
+          from: 2000
+          to: 2299
+        enable_mvpn_vri_id_range: true
+        enable_l3_vni_no_vlan: false
+        vpc:
+          peer_link_vlan: 3600
+          peer_keep_alive: management
+          auto_recovery_time: 360
+          delay_restore_time: 150
+          peer_link_port_channel_id: 500
+          ipv6_nd_sync: true
+          advertise_pip: false
+          advertise_pip_border_only: true
+          domain_id_range: 1-1000
+          fabric_vpc_qos: false
+          fabric_vpc_qos_policy_name: spine_qos_for_fabric_vpc_peering
+        netflow:
+          enable: false
+        ptp:
+          enable: false
+          domain_id: 0
+          lb_id: 0
+        snmp_server_host_trap: true
+        bootstrap:
+          enable_bootstrap: false
+          enable_local_dhcp_server: false
+          enable_cdp_mgmt: false
       ibgp:
+        route_reflectors: 2
+        anycast_gateway_mac: 20:20:00:00:00:aa
+        auth_proto: MD5
+        enable_nxapi_http: false
+        nxapi_http_port: 80
+        enable_nxapi_https: true
+        nxapi_https_port: 443
+        layer2_vni_range:
+          from: 30000
+          to: 49000
+        layer3_vni_range:
+          from: 50000
+          to: 59000
+        layer2_vlan_range:
+          from: 2300
+          to: 2999
+        layer3_vlan_range:
+          from: 2000
+          to: 2299
+        vpc:
+          peer_link_vlan: 3600
+          peer_keep_alive: management
+          auto_recovery_time: 360
+          delay_restore_time: 150
+          peer_link_port_channel_id: 500
+          ipv6_nd_sync: true
+          advertise_pip: false
+          advertise_pip_border_only: true
+          domain_id_range: 1-1000
+          fabric_vpc_qos: false
+          fabric_vpc_qos_policy_name: spine_qos_for_fabric_vpc_peering
+        spanning_tree:
+          root_bridge_protocol: unmanaged
+          vlan_range:
+            - from: 1
+              to: 3967
+          mst_instance_range:
+            - from: 0
+          bridge_priority: 0
+        netflow:
+          enable: false
+        ptp:
+          enable: false
+          domain_id: 0
+          lb_id: 0
+        snmp_server_host_trap: true
+        bootstrap:
+          enable_bootstrap: false
+          enable_local_dhcp_server: false
+          enable_cdp_mgmt: false
         tcam_allocation: true
-      route_reflectors: 2
-      anycast_gateway_mac: 20:20:00:00:00:aa
-      auth_proto: MD5
-      enable_nxapi_http: false
-      nxapi_http_port: 80
-      enable_nxapi_https: true
-      nxapi_https_port: 443
-      layer2_vni_range:
-        from: 30000
-        to: 49000
-      layer3_vni_range:
-        from: 50000
-        to: 59000
-      layer2_vlan_range:
-        from: 2300
-        to: 2999
-      layer3_vlan_range:
-        from: 2000
-        to: 2299
-      enable_mvpn_vri_id_range: true
-      enable_l3_vni_no_vlan: false
-      vpc:
-        peer_link_vlan: 3600
-        peer_keep_alive: management
-        auto_recovery_time: 360
-        delay_restore_time: 150
-        peer_link_port_channel_id: 500
-        ipv6_nd_sync: true
-        advertise_pip: false
-        advertise_pip_border_only: true
-        advertise_pip_border_gateway: false
-        domain_id_range: 1-1000
-        fabric_vpc_qos: false
-        fabric_vpc_qos_policy_name: spine_qos_for_fabric_vpc_peering
-      spanning_tree:
-        root_bridge_protocol: unmanaged
-        vlan_range:
-          - from: 1
-            to: 3967
-        mst_instance_range:
-          - from: 0
-        bridge_priority: 0
-      netflow:
-        enable: false
-      ptp:
-        enable: false
-        domain_id: 0
-        lb_id: 0
-      snmp_server_host_trap: true
-      bootstrap:
-        enable_bootstrap: false
-        enable_local_dhcp_server: false
-        enable_cdp_mgmt: false
+      external:
+        auth_proto: MD5
+        enable_nxapi_http: false
+        nxapi_http_port: 80
+        enable_nxapi_https: true
+        nxapi_https_port: 443
+        netflow:
+          enable: false
+        ptp:
+          enable: false
+          domain_id: 0
+          lb_id: 0
+        snmp_server_host_trap: true
+        bootstrap:
+          enable_bootstrap: false
+          enable_local_dhcp_server: false
+          enable_cdp_mgmt: false
     topology:
       switches:
         routing_loopback_id: 0
@@ -206,7 +263,7 @@ factory_defaults:
         authentication_key_id: 127
       isis:
         level: level-2
-        net_area_number: "0001"
+        net_area_number: 0001
         network_point_to_point: true
         authentication_enable: false
         authentication_key_id: 127
@@ -394,11 +451,19 @@ factory_defaults:
         enable_ebgp_password: false
         enable_trm: false
       isn:
+        auth_proto: MD5
         sub_int_range: 2-511
         enable_nxapi_http: false
         nxapi_http_port: 80
         enable_nxapi_https: true
         nxapi_https_port: 443
+        netflow:
+          enable: false
+        ptp:
+          enable: false
+          domain_id: 0
+          lb_id: 0
+        snmp_server_host_trap: true
         bootstrap:
           enable_bootstrap: false
           enable_local_dhcp_server: false


### PR DESCRIPTION
The PR contains fix for:

- 2 jinja templates to manage new data model for key 'auth_proto'
- updated `roles/validate/files/defaults.yml`
- remove calling `ebgp_vxlan_fabric_config_backup.j2` from `roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/ebgp_vxlan_fabric_base.j2`

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [x] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
