### PR TITLE
Fix for #589

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/ebgp_vxlan_fabric_base.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/ebgp_vxlan_fabric_base.j2
@@ -32,6 +32,3 @@
 
 {# Include NDFC eBGP VXLAN EVPN Flow Monitor Template #}
 {% include '/ndfc_fabric/ebgp_vxlan_fabric/flow_monitor/ebgp_vxlan_fabric_flow_monitor.j2' %}
-
-{# Include NDFC eBGP VXLAN EVPN Config Backup Template #}
-{% include '/ndfc_fabric/ebgp_vxlan_fabric/config_backup/ebgp_vxlan_fabric_config_backup.j2' %}


### PR DESCRIPTION
The config backup is not in use, the file ebgp_vxlan_fabric_config_backup.j2 has been removed.

## Related Issue(s)
#589 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
