### PR TITLE
Add bgp asn rule check for ibgp and external

### DIFF
--- a/plugins/action/common/nac_dc_validate.py
+++ b/plugins/action/common/nac_dc_validate.py
@@ -100,6 +100,7 @@ class ActionModule(ActionBase):
             if 'fabric' in check['keys_found'] and 'fabric' in check['keys_data']:
                 if 'type' in results['data']['vxlan']['fabric']:
                     if results['data']['vxlan']['fabric']['type'] in ('VXLAN_EVPN'):
+                        rules_list.append(f'{rules}common')
                         rules_list.append(f'{rules}ibgp_vxlan/')
                         rules_list.append(f'{rules}common_vxlan')
                     elif results['data']['vxlan']['fabric']['type'] in ('MSD', 'MCF'):
@@ -107,6 +108,7 @@ class ActionModule(ActionBase):
                     elif results['data']['vxlan']['fabric']['type'] in ('ISN'):
                         rules_list.append(f'{rules}isn/')
                     elif results['data']['vxlan']['fabric']['type'] in ('External'):
+                        rules_list.append(f'{rules}common')
                         rules_list.append(f'{rules}external/')
                     elif results['data']['vxlan']['fabric']['type'] in ('eBGP_VXLAN'):
                         rules_list.append(f'{rules}ebgp_vxlan/')

--- a/roles/validate/files/rules/common/200_global_bgp_asn.py
+++ b/roles/validate/files/rules/common/200_global_bgp_asn.py
@@ -1,0 +1,43 @@
+class Rule:
+    id = "200"
+    description = "Verify BGP ASN is defined for iBGP VXLAN and External fabric types."
+    severity = "HIGH"
+
+    @classmethod
+    def match(cls, data):
+        results = []
+
+        fabric_type_map = {
+            "VXLAN_EVPN": "ibgp",
+            "External": "external"
+        }
+
+        fabric_type = None
+        fabric_type = fabric_type_map.get(data["vxlan"]["fabric"].get("type"))
+
+        # If we check keys vxlan.global.{fabric_type}.bgp_asn then this natively checks for this path
+        # as well as the legacy vxlan.global path. Examples:
+        # {'keys_found': ['vxlan', 'global', 'bgp_asn'], 'keys_not_found': ['ibgp'], 'keys_data': ['vxlan', 'global'], 'keys_no_data': ['bgp_asn']}
+        # {'keys_found': ['vxlan', 'global', 'ibgp', 'bgp_asn'], 'keys_not_found': [], 'keys_data': ['vxlan', 'global', 'ibgp'], 'keys_no_data': ['bgp_asn']}
+        check = cls.data_model_key_check(data, ['vxlan', 'global', fabric_type, 'bgp_asn'])
+        if 'bgp_asn' not in check['keys_found']:
+            results.append(f"vxlan.global.{fabric_type}.bgp_asn must be defined in the data model.")
+        elif 'bgp_asn' in check['keys_found'] and 'bgp_asn' in check['keys_no_data']:
+            results.append(f"vxlan.global.{fabric_type}.bgp_asn must have a value defined in the data model.")
+
+        return results
+
+    @classmethod
+    def data_model_key_check(cls, tested_object, keys):
+        dm_key_dict = {'keys_found': [], 'keys_not_found': [], 'keys_data': [], 'keys_no_data': []}
+        for key in keys:
+            if tested_object and key in tested_object:
+                dm_key_dict['keys_found'].append(key)
+                tested_object = tested_object[key]
+                if tested_object:
+                    dm_key_dict['keys_data'].append(key)
+                else:
+                    dm_key_dict['keys_no_data'].append(key)
+            else:
+                dm_key_dict['keys_not_found'].append(key)
+        return dm_key_dict


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
N/A

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [x] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Add a rule to check that bgp_asn is defined for iBGP VXLAN and External fabric types to help with backwards compatibility.

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
