### PR TITLE
normalise interface ndfc_fabric_links.j2

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric_links.j2
+++ b/roles/dtc/common/templates/ndfc_fabric_links.j2
@@ -30,8 +30,8 @@
     dst_interface: "{{ normalize_interface(link.dest_interface) }}"
     template: "{{ link.template }}"
     profile:
-      admin_state: "{{ link.admin_state | default(defaults.vxlan.topology.fabric_links.admin_state | default('up')) }}"
-      mtu: "{{ link.mtu | default(defaults.vxlan.topology.fabric_links.mtu | default(9216)) }}"
+      admin_state: "{{ link.admin_state | default(defaults.vxlan.topology.fabric_links.admin_state) }}"
+      mtu: "{{ link.mtu | default(defaults.vxlan.topology.fabric_links.mtu) }}"
       peer1_description: "{{ link.source_description | default('') }}"
       peer2_description: "{{ link.destination_description | default('') }}"
 {%- endif %}


### PR DESCRIPTION
normalize interface for dcnm_link. This is also used by plugins existing_links_check later.

ND rewrite short interface name to long Ex: Eth to Ethernet.

There is an issue in that case because we try to create an existing link.

```
TASK [cisco.nac_dc_vxlan.create : Manage Fabric Links in Nexus Dashboard] *************************************************************************************************************
Monday 15 September 2025  13:53:18 +0200 (0:00:00.083)       0:02:08.355 ****** 
Monday 15 September 2025  13:53:18 +0200 (0:00:00.083)       0:02:08.355 ****** 
fatal: [nac-ndfc3]: FAILED! => {"changed": false, "msg": {"CHANGED": {"debugs": [{"Managable": {"10.229.42.81": "9Q3CBK6JSNT", "10.229.42.82": "9XANRS8T83Y", "10.229.42.83": "9TYF0I1L7Z5", "netascode-bgw3-1": "9Q3CBK6JSNT", "netascode-leaf3-1": "9XANRS8T83Y", "netascode-leaf3-2": "9TYF0I1L7Z5"}}, {"Monitoring": []}], "deleted": [], "deploy": [], "merged": [{"destinationDevice": "9XANRS8T83Y", "destinationFabric": "nac-ndfc3", "destinationInterface": "E1/1", "destinationSwitchName": "netascode-leaf3-1", "nvPairs": {"ADMIN_STATE": true, "ENABLE_MACSEC": false, "MTU": 9216, "PEER1_CONF": "", "PEER1_DESC": "New Connected1 To Leaf3-1 Ethernet1/1", "PEER2_CONF": "", "PEER2_DESC": "New Connected1 To BGW3-1 Ethernet1/1"}, "sourceDevice": "9Q3CBK6JSNT", "sourceFabric": "nac-ndfc3", "sourceInterface": "Eth1/1", "sourceSwitchName": "netascode-bgw3-1", "templateName": "int_intra_fabric_unnum_link"}, {"destinationDevice": "9TYF0I1L7Z5", "destinationFabric": "nac-ndfc3", "destinationInterface": "Ethernet1/1", "destinationSwitchName": "netascode-leaf3-2", "nvPairs": {"ADMIN_STATE": true, "ENABLE_MACSEC": false, "MTU": 9216, "PEER1_CONF": "", "PEER1_DESC": "New Connected2 To BGW3-1 Ethernet1/3", "PEER2_CONF": "", "PEER2_DESC": "New Connected1 To Leaf3-2 Ethernet1/1"}, "sourceDevice": "9Q3CBK6JSNT", "sourceFabric": "nac-ndfc3", "sourceInterface": "Eth1/3", "sourceSwitchName": "netascode-bgw3-1", "templateName": "int_intra_fabric_unnum_link"}], "modified": [], "query": []}, "DATA": "Invalid JSON response: PTI POLICY-1979400 already associated for the link LINK-UUID-1682150. Edit the link to update.", "MESSAGE": "Internal Server Error", "METHOD": "POST", "REQUEST_PATH": "https://10.60.3.55:443/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/links", "RETURN_CODE": 500}}
```

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco NDFC Version
<!-- Please provide Cisco NDFC version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
