### PR TITLE
Fix for fex

### DIFF
--- a/roles/validate/files/rules/common/310_topology_switch_interface_breakouts.py
+++ b/roles/validate/files/rules/common/310_topology_switch_interface_breakouts.py
@@ -7,7 +7,7 @@ class Rule:
     severity = "HIGH"
 
     # regex pattern: Ethernet[101-199]/1/[1-99]
-    IGNORE_FEX = re.compile(r'^(?:Ethernet)(?:(?:10[1-9]|1[1-9]\d)\/1\/([1-9]|[1-5][0-9])$)', re.IGNORECASE)
+    IGNORE_FEX = re.compile(r'^(?:Ethernet)(?:10[1-9]|1[1-9]\d)/1/(?:[1-9]|[1-5]\d|6[0-4])$', re.IGNORECASE)
 
     @classmethod
     def match(cls, data_model):


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

The current "310" rule checks for breakout interfaces, but the algorithm also matches FEX interfaces (Ethernet[101-199]/1/[1-99]). The proposed solution is to use regex to determine if the interface is a FEX; if it is, then skip processing that interface.


## Related Issue(s)
[#203](https://wwwin-github.cisco.com/netascode/nac-vxlan/issues/203)


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
