### PR TITLE
vPC Interface Rule Update to Check Switch is vPC Peer if it has vPC Interface

### DIFF
--- a/roles/validate/files/rules/common/305_topology_switch_interfaces_vpc.py
+++ b/roles/validate/files/rules/common/305_topology_switch_interfaces_vpc.py
@@ -49,7 +49,7 @@ class Rule:
                         if not is_peer:
                             results.append(
                                 f"Switch {switch_name} is not part of a vPC peer group but "
-                                f"has vPC id : {vpc_id} defined on interface {interface_name}."
+                                f"has vPC id {vpc_id} defined on interface {interface_name}."
                             )
                             return results
 


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Add check for switch in vPC peer if it has a vPC interface

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
