### PR TITLE
adding mtu support for edge_connections

### DIFF
--- a/roles/dtc/common/templates/ndfc_edge_connections.j2
+++ b/roles/dtc/common/templates/ndfc_edge_connections.j2
@@ -17,7 +17,7 @@
           description: {{ 'nace_bgp_peer_template_dci_underlay_jython_' + link.source_device + '_' + link.source_interface + '_' + link.dest_device }}
           name: bgp_peer_template_dci_underlay_jython
           policy_vars:
-            BGP_PASSWORD: "{{ link.bgp_section.bgp_password | default(defaults.vxlan.topology.edge_connections.bgp_section.bgp_password) }}"
+            BGP_PASSWORD: "{{ link.bgp_section.bgp_password | default('') }}"
             BGP_PASSWORD_ENABLE: {{ link.bgp_section.bgp_password_enable | default(defaults.vxlan.topology.edge_connections.bgp_section.bgp_password_enable) }}
             TEMPLATE_NAME: {{ MD_Extended.vxlan.fabric.name + '-' + link.dest_fabric + '-IPV4-EBGP' }}
             NEIGHBOR_ASN: "{{ link.bgp_section.neighbor_asn }}"
@@ -42,7 +42,7 @@
             MTU: {{ link.source_interface_mtu | default(defaults.vxlan.topology.edge_connections.source_interface_mtu) }}
             OVERRIDE_LOCAL_ASN: false
             POLICY_ID: ""
-            ROUTING_TAG: "{{ link.bgp_section.routing_tag | default(defaults.vxlan.topology.edge_connections.bgp_section.routing_tag) }}"
+            ROUTING_TAG: "{{ link.bgp_section.routing_tag | default('') }}"
             SERIAL_NUMBER: ""
             asn: "{{ bgp_asn }}"
             BGP_TEMPLATE_NAME: {{ data_model_extended.vxlan.fabric.name + '-' + link.dest_fabric + '-IPV4-EBGP' }}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -251,9 +251,7 @@ factory_defaults:
         source_interface_mtu: 9216
         source_interface_enabled: true
         bgp_section:
-          bgp_password: ""
           bgp_password_enable: true
-          routing_tag: ""
     underlay:
       general:
         routing_protocol: ospf


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
Fixes #737


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [X] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
A policy "ebgp_underlay_dci_template" used for edge_connection config does support MTU value.
With this PR i want to expose the MTU value and allow it's configuration with edge_connection.
Using "freeform" field of this policy is not feasible, as the policy template assumes default value 9216 for MTU if it's not specified - so an attempt to overwrite it with freeform would generate a conflict


## Test Notes
Tested creation of edge_connection while using:
- default MTU value of 9216
- non-default value 
- skipping the mtu in the yaml files


## Cisco Nexus Dashboard Version
3.2.1


## Checklist
* [X] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
