### PR TITLE
Update solution to use meta: end_host

### DIFF
--- a/roles/validate/tasks/manage_model_files_current.yml
+++ b/roles/validate/tasks/manage_model_files_current.yml
@@ -74,7 +74,7 @@
   delegate_to: localhost
 
 - name: No Model Changes Detected
-  ansible.builtin.meta: end_play
+  ansible.builtin.meta: end_host
   when:
     - check_roles['save_previous']
     - smd_golden_diff.diff_lines | length == 0


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [x] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

This update changes our solution to use `meta: end_host` instead of `meta: end_play` to allow the diff run framework to continue running for fabrics that have changes and only skip fabrics that have no changes when targeting multiple fabrics in parallel.

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
