### PR TITLE
Fix for ANYCAST_RP_IP_RANGE on ND 3.1 for eBGP fabrics

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -9,68 +9,99 @@
 {% set ndfc_ge_12_4_1 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>') %}
   ENABLE_EVPN: true
   OVERLAY_MODE: {{ vxlan.global.ebgp.overlay_mode | default(defaults.vxlan.global.ebgp.overlay_mode) }}
+{# IF: NDFC between 12.2.2 and 12.4.0 START #}
 {% if ndfc_ge_12_2_2 and ndfc_lt_12_4_1 %}
   ALLOW_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_mvpn_vri_id_range | default(defaults.vxlan.global.ebgp.enable_mvpn_vri_id_range) }}
-  {% elif ndfc_ge_12_4_1 %}
+{% elif ndfc_ge_12_4_1 %}
   ENABLE_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_l3_vni_no_vlan | default(defaults.vxlan.global.ebgp.enable_l3_vni_no_vlan) }}
-  {% endif %}
+{% endif %}
+{# IF: NDFC between 12.2.2 and 12.4.0 END #}
   ANYCAST_GW_MAC: {{ vxlan.global.ebgp.anycast_gateway_mac | default(defaults.vxlan.global.ebgp.anycast_gateway_mac) }}
   ADVERTISE_PIP_BGP: {{ (vxlan.global.ebgp.vpc.advertise_pip | default(defaults.vxlan.global.ebgp.vpc.advertise_pip) | title) }}
+{# IF: Multisite SITE_ID START #}
 {% if vxlan.global.ebgp.multisite_site_id is defined %}
   SITE_ID: {{ vxlan.global.ebgp.multisite_site_id | default(vxlan.global.ebgp.spine_bgp_asn) }}
 {% endif %}
+{# IF: Multisite SITE_ID END #}
   ANYCAST_BGW_ADVERTISE_PIP: {{ vxlan.global.ebgp.vpc.advertise_pip_border_gateway | default(defaults.vxlan.global.ebgp.vpc.advertise_pip_border_gateway) }}
+{# IF: Advertise PIP toggle START #}
 {% if not (vxlan.global.ebgp.vpc.advertise_pip | default(defaults.vxlan.global.ebgp.vpc.advertise_pip) | ansible.builtin.bool) %}
   ADVERTISE_PIP_ON_BORDER: {{ vxlan.global.ebgp.vpc.advertise_pip_border_only | default(defaults.vxlan.global.ebgp.vpc.advertise_pip_border_only) | title }}
 {% endif %}
+{# IF: Advertise PIP toggle END #}
   REPLICATION_MODE: {{ replication_mode }}
+{# IF: Manual underlay disabled START #}
 {% if not manual_underlay %}
+{# IF: IPv4 underlay START #}
 {% if not ipv6_underlay %}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
 {% else %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
 {% endif %}
+{# IF: IPv4 underlay END #}
 {% endif %}
+{# IF: Manual underlay disabled END #}
+{# IF: Replication mode multicast START #}
 {% if replication_mode == 'Multicast' %}
   RP_LB_ID: {{ vxlan.underlay.multicast.underlay_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_rp_loopback_id) }}
   RP_COUNT: "{{ rp_count }}"
   RP_MODE: {{ rp_mode }}
   ENABLE_TRM: {{ vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | title }}
+  {# IF: NDFC >= 12.2.2 START #}
 {% if ndfc_ge_12_2_2 %}
   ENABLE_TRMv6: {{ vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | title }}
 {% endif %}
+  {# IF: NDFC >= 12.2.2 END #}
+  {# IF: IPv4 multicast START #}
 {% if not ipv6_underlay %}
+  {# IF: Manual underlay disabled (IPv4 multicast) START #}
 {% if not manual_underlay %}
   ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
 {% endif %}
+  {# IF: Manual underlay disabled (IPv4 multicast) END #}
   MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv4.group_subnet | default(defaults.vxlan.underlay.multicast.ipv4.group_subnet) }}
 {# {% if (vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | ansible.builtin.bool) %} #}
 {#   L3VNI_MCAST_GROUP: {{ vxlan.underlay.multicast.ipv4.trm_default_group | default(defaults.vxlan.underlay.multicast.ipv4.trm_default_group) }} #}
 {# {% endif %} #}
+  {# IF: TRMv6 group START #}
 {% if ndfc_ge_12_2_2 and (vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | ansible.builtin.bool) %}
   L3VNI_IPv6_MCAST_GROUP: "{{ vxlan.underlay.multicast.ipv6.trmv6_default_group | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_default_group) }}"
 {% endif %}
+  {# IF: TRMv6 group END #}
+  {# IF: RP mode bidir START #}
 {% if rp_mode == 'bidir' %}
   PHANTOM_RP_LB_ID1: {{ vxlan.underlay.multicast.underlay_primary_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_primary_rp_loopback_id) }}
   PHANTOM_RP_LB_ID2: {{ vxlan.underlay.multicast.underlay_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_backup_rp_loopback_id) }}
+    {# IF: RP count equals 4 START #}
 {% if rp_count == 4 %}
   PHANTOM_RP_LB_ID3: {{ vxlan.underlay.multicast.underlay_second_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_second_backup_rp_loopback_id) }}
   PHANTOM_RP_LB_ID4: {{ vxlan.underlay.multicast.underlay_third_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_third_backup_rp_loopback_id) }}
 {% endif %}
+    {# IF: RP count equals 4 END #}
 {% endif %}
+  {# IF: RP mode bidir END #}
 {% else %}
+  {# IF: IPv6 multicast START #}
 {% if not manual_underlay %}
   IPv6_ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv6.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_rp_loopback_ip_range) }}
 {% endif %}
   IPv6_MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv6.group_subnet | default(defaults.vxlan.underlay.multicast.ipv6.group_subnet) }}
+  {# IF: IPv6 multicast END #}
 {% endif %}
+  {# IF: IPv4 multicast END #}
 {% endif %}
+{# IF: Replication mode multicast END #}
+{# IF: L2 VNI start defined START #}
 {% if vxlan.global.ebgp.layer2_vni_range.from is defined %}
 {% set l2_vni_start = vxlan.global.ebgp.layer2_vni_range.from %}
+  {# IF: L2 VNI end defined START #}
 {% if vxlan.global.ebgp.layer2_vni_range.to is defined %}
 {% set l2_vni_end = vxlan.global.ebgp.layer2_vni_range.to %}
 {% endif %}
+  {# IF: L2 VNI end defined END #}
 {% endif %}
+{# IF: L2 VNI start defined END #}
+{# IF: L2 VNI range derive START #}
 {% if l2_vni_start is defined and l2_vni_end is not defined %}
 {% set l2_vni_range = l2_vni_start %}
 {% elif l2_vni_start is defined and l2_vni_end is defined %}
@@ -78,13 +109,19 @@
 {% else %}
 {% set l2_vni_range = defaults.vxlan.global.ebgp.layer2_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vni_range.to %}
 {% endif %}
+{# IF: L2 VNI range derive END #}
   L2_SEGMENT_ID_RANGE: {{ l2_vni_range }}
+{# IF: L3 VNI start defined START #}
 {% if vxlan.global.ebgp.layer3_vni_range.from is defined %}
 {% set l3_vni_start = vxlan.global.ebgp.layer3_vni_range.from %}
+  {# IF: L3 VNI end defined START #}
 {% if vxlan.global.ebgp.layer3_vni_range.to is defined %}
 {% set l3_vni_end = vxlan.global.ebgp.layer3_vni_range.to %}
 {% endif %}
+  {# IF: L3 VNI end defined END #}
 {% endif %}
+{# IF: L3 VNI start defined END #}
+{# IF: L3 VNI range derive START #}
 {% if l3_vni_start is defined and l3_vni_end is not defined %}
 {% set l3_vni_range = l3_vni_start %}
 {% elif l3_vni_start is defined and l3_vni_end is defined %}
@@ -92,13 +129,19 @@
 {% else %}
 {% set l3_vni_range = defaults.vxlan.global.ebgp.layer3_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vni_range.to %}
 {% endif %}
+{# IF: L3 VNI range derive END #}
   L3_PARTITION_ID_RANGE: {{ l3_vni_range }}
+{# IF: L2 VLAN start defined START #}
 {% if vxlan.global.ebgp.layer2_vlan_range.from is defined %}
 {% set l2_vlan_start = vxlan.global.ebgp.layer2_vlan_range.from %}
+  {# IF: L2 VLAN end defined START #}
 {% if vxlan.global.ebgp.layer2_vlan_range.to is defined %}
 {% set l2_vlan_end = vxlan.global.ebgp.layer2_vlan_range.to %}
 {% endif %}
+  {# IF: L2 VLAN end defined END #}
 {% endif %}
+{# IF: L2 VLAN start defined END #}
+{# IF: L2 VLAN range derive START #}
 {% if l2_vlan_start is defined and l2_vlan_end is not defined %}
 {% set l2_vlan_range = l2_vlan_start %}
 {% elif l2_vlan_start is defined and l2_vlan_end is defined %}
@@ -106,13 +149,19 @@
 {% else %}
 {% set l2_vlan_range = defaults.vxlan.global.ebgp.layer2_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vlan_range.to %}
 {% endif %}
+{# IF: L2 VLAN range derive END #}
   NETWORK_VLAN_RANGE: {{ l2_vlan_range }}
+{# IF: L3 VLAN start defined START #}
 {% if vxlan.global.ebgp.layer3_vlan_range.from is defined %}
 {% set l3_vlan_start = vxlan.global.ebgp.layer3_vlan_range.from %}
+  {# IF: L3 VLAN end defined START #}
 {% if vxlan.global.ebgp.layer3_vlan_range.to is defined %}
 {% set l3_vlan_end = vxlan.global.ebgp.layer3_vlan_range.to %}
 {% endif %}
+  {# IF: L3 VLAN end defined END #}
 {% endif %}
+{# IF: L3 VLAN start defined END #}
+{# IF: L3 VLAN range derive START #}
 {% if l3_vlan_start is defined and l3_vlan_end is not defined %}
 {% set l3_vlan_range = l3_vlan_start %}
 {% elif l3_vlan_start is defined and l3_vlan_end is defined %}
@@ -120,4 +169,5 @@
 {% else %}
 {% set l3_vlan_range = defaults.vxlan.global.ebgp.layer3_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vlan_range.to %}
 {% endif %}
+{# IF: L3 VLAN range derive END #}
   VRF_VLAN_RANGE: {{ l3_vlan_range }}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -1,19 +1,10 @@
 {# Auto-generated NDFC eBGP VXLAN EVPN config data structure for fabric {{ vxlan.fabric.name }} #}
-{% set manual_underlay = (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation)) %}
-{% set ipv6_underlay = (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay)) %}
-{% set replication_mode = (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) %}
-{% set rp_mode = vxlan.underlay.multicast.rp_mode | default(defaults.vxlan.underlay.multicast.rp_mode) %}
-{% set rp_count = vxlan.underlay.multicast.rendezvous_points | default(defaults.vxlan.underlay.multicast.rendezvous_points) %}
-{% set ndfc_ge_12_2_2 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=') %}
-{% set ndfc_lt_12_4_1 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '<') %}
-{% set ndfc_ge_12_4_1 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>') %}
   ENABLE_EVPN: true
   OVERLAY_MODE: {{ vxlan.global.ebgp.overlay_mode | default(defaults.vxlan.global.ebgp.overlay_mode) }}
-{% if ndfc_ge_12_2_2 and ndfc_lt_12_4_1 %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=') and ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '<') %}
   ALLOW_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_mvpn_vri_id_range | default(defaults.vxlan.global.ebgp.enable_mvpn_vri_id_range) }}
-{% elif ndfc_ge_12_4_1 %}
-  ENABLE_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_l3_vni_no_vlan | default(defaults.vxlan.global.ebgp.enable_l3_vni_no_vlan) }}
 {% endif %}
+  ENABLE_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_l3_vni_no_vlan | default(defaults.vxlan.global.ebgp.enable_l3_vni_no_vlan) }}
   ANYCAST_GW_MAC: {{ vxlan.global.ebgp.anycast_gateway_mac | default(defaults.vxlan.global.ebgp.anycast_gateway_mac) }}
   ADVERTISE_PIP_BGP: {{ (vxlan.global.ebgp.vpc.advertise_pip | default(defaults.vxlan.global.ebgp.vpc.advertise_pip) | title) }}
 {% if vxlan.global.ebgp.multisite_site_id is defined %}
@@ -23,98 +14,107 @@
 {% if not (vxlan.global.ebgp.vpc.advertise_pip | default(defaults.vxlan.global.ebgp.vpc.advertise_pip) | ansible.builtin.bool) %}
   ADVERTISE_PIP_ON_BORDER: {{ vxlan.global.ebgp.vpc.advertise_pip_border_only | default(defaults.vxlan.global.ebgp.vpc.advertise_pip_border_only) | title }}
 {% endif %}
-  REPLICATION_MODE: {{ replication_mode }}
-{% if not manual_underlay %}
-{% if not ipv6_underlay %}
+  REPLICATION_MODE: {{ vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title }}
+{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
+{% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
-{% else %}
+{% if (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
 {% endif %}
 {% endif %}
-{% if replication_mode == 'Multicast' %}
+{% endif %}
+{% if ( ((ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.1', '<=')) and
+        (not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool))) or
+        (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) ) %}
+{% if (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) == 'Multicast' %}
   RP_LB_ID: {{ vxlan.underlay.multicast.underlay_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_rp_loopback_id) }}
-  RP_COUNT: "{{ rp_count }}"
-  RP_MODE: {{ rp_mode }}
+  RP_COUNT: "{{ vxlan.underlay.multicast.rendezvous_points | default(defaults.vxlan.underlay.multicast.rendezvous_points) }}"
+  RP_MODE: {{ vxlan.underlay.multicast.rp_mode | default(defaults.vxlan.underlay.multicast.rp_mode) }}
   ENABLE_TRM: {{ vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | title }}
-{% if ndfc_ge_12_2_2 %}
+{% if (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) %}
   ENABLE_TRMv6: {{ vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | title }}
 {% endif %}
-{% if not ipv6_underlay %}
-{% if not manual_underlay %}
+{% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
+{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
   ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
 {% endif %}
   MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv4.group_subnet | default(defaults.vxlan.underlay.multicast.ipv4.group_subnet) }}
-{% if ndfc_ge_12_2_2 and (vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | ansible.builtin.bool) %}
+{# {% if (vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | ansible.builtin.bool) %} #}
+{#   L3VNI_MCAST_GROUP: {{ vxlan.underlay.multicast.ipv4.trm_default_group | default(defaults.vxlan.underlay.multicast.ipv4.trm_default_group) }} #}
+{# {% endif %} #}
+{% if ( (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) and
+        (vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | ansible.builtin.bool) ) %}
   L3VNI_IPv6_MCAST_GROUP: "{{ vxlan.underlay.multicast.ipv6.trmv6_default_group | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_default_group) }}"
 {% endif %}
-{% if rp_mode == 'bidir' %}
+{% if vxlan.underlay.multicast.rp_mode | default(defaults.vxlan.underlay.multicast.rp_mode) == 'bidir' %}
   PHANTOM_RP_LB_ID1: {{ vxlan.underlay.multicast.underlay_primary_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_primary_rp_loopback_id) }}
   PHANTOM_RP_LB_ID2: {{ vxlan.underlay.multicast.underlay_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_backup_rp_loopback_id) }}
-{% if rp_count == 4 %}
+{% if vxlan.underlay.multicast.rendezvous_points | default(defaults.vxlan.underlay.multicast.rendezvous_points) == 4 %}
   PHANTOM_RP_LB_ID3: {{ vxlan.underlay.multicast.underlay_second_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_second_backup_rp_loopback_id) }}
   PHANTOM_RP_LB_ID4: {{ vxlan.underlay.multicast.underlay_third_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_third_backup_rp_loopback_id) }}
 {% endif %}
 {% endif %}
-{% else %}
-{% if not manual_underlay %}
+{% elif (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
+{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
   IPv6_ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv6.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_rp_loopback_ip_range) }}
 {% endif %}
   IPv6_MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv6.group_subnet | default(defaults.vxlan.underlay.multicast.ipv6.group_subnet) }}
 {% endif %}
 {% endif %}
-{% if vxlan.global.ebgp.layer2_vni_range.from is defined -%}
-{% set l2_vni_start = vxlan.global.ebgp.layer2_vni_range.from -%}
-{% if vxlan.global.ebgp.layer2_vni_range.to is defined -%}
-{% set l2_vni_end = vxlan.global.ebgp.layer2_vni_range.to -%}
-{% endif -%}
-{% endif -%}
-{% if l2_vni_start is defined and l2_vni_end is not defined -%}
-{% set l2_vni_range = l2_vni_start -%}
-{% elif l2_vni_start is defined and l2_vni_end is defined -%}
-{% set l2_vni_range = l2_vni_start ~ '-' ~ l2_vni_end -%}
-{% else -%}
-{% set l2_vni_range = defaults.vxlan.global.ebgp.layer2_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vni_range.to -%}
+{% endif %}
+{% if vxlan.global.ebgp.layer2_vni_range.from is defined %}
+{% set l2_vni_start = vxlan.global.ebgp.layer2_vni_range.from %}
+{% if vxlan.global.ebgp.layer2_vni_range.to is defined %}
+{% set l2_vni_end = vxlan.global.ebgp.layer2_vni_range.to %}
+{% endif %}
+{% endif %}
+{% if l2_vni_start is defined and l2_vni_end is not defined %}
+{% set l2_vni_range = l2_vni_start %}
+{% elif l2_vni_start is defined and l2_vni_end is defined %}
+{% set l2_vni_range = l2_vni_start ~ '-' ~ l2_vni_end %}
+{% else %}
+{% set l2_vni_range = defaults.vxlan.global.ebgp.layer2_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vni_range.to %}
 {% endif %}
   L2_SEGMENT_ID_RANGE: {{ l2_vni_range }}
-{% if vxlan.global.ebgp.layer3_vni_range.from is defined -%}
-{% set l3_vni_start = vxlan.global.ebgp.layer3_vni_range.from -%}
-{% if vxlan.global.ebgp.layer3_vni_range.to is defined -%}
-{% set l3_vni_end = vxlan.global.ebgp.layer3_vni_range.to -%}
-{% endif -%}
-{% endif -%}
-{% if l3_vni_start is defined and l3_vni_end is not defined -%}
-{% set l3_vni_range = l3_vni_start -%}
-{% elif l3_vni_start is defined and l3_vni_end is defined -%}
-{% set l3_vni_range = l3_vni_start ~ '-' ~ l3_vni_end -%}
-{% else -%}
-{% set l3_vni_range = defaults.vxlan.global.ebgp.layer3_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vni_range.to -%}
+{% if vxlan.global.ebgp.layer3_vni_range.from is defined %}
+{% set l3_vni_start = vxlan.global.ebgp.layer3_vni_range.from %}
+{% if vxlan.global.ebgp.layer3_vni_range.to is defined %}
+{% set l3_vni_end = vxlan.global.ebgp.layer3_vni_range.to %}
+{% endif %}
+{% endif %}
+{% if l3_vni_start is defined and l3_vni_end is not defined %}
+{% set l3_vni_range = l3_vni_start %}
+{% elif l3_vni_start is defined and l3_vni_end is defined %}
+{% set l3_vni_range = l3_vni_start ~ '-' ~ l3_vni_end %}
+{% else %}
+{% set l3_vni_range = defaults.vxlan.global.ebgp.layer3_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vni_range.to %}
 {% endif %}
   L3_PARTITION_ID_RANGE: {{ l3_vni_range }}
-{% if vxlan.global.ebgp.layer2_vlan_range.from is defined -%}
-{% set l2_vlan_start = vxlan.global.ebgp.layer2_vlan_range.from -%}
-{% if vxlan.global.ebgp.layer2_vlan_range.to is defined -%}
-{% set l2_vlan_end = vxlan.global.ebgp.layer2_vlan_range.to -%}
-{% endif -%}
-{% endif -%}
-{% if l2_vlan_start is defined and l2_vlan_end is not defined -%}
-{% set l2_vlan_range = l2_vlan_start -%}
-{% elif l2_vlan_start is defined and l2_vlan_end is defined -%}
-{% set l2_vlan_range = l2_vlan_start ~ '-' ~ l2_vlan_end -%}
-{% else -%}
-{% set l2_vlan_range = defaults.vxlan.global.ebgp.layer2_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vlan_range.to -%}
+{% if vxlan.global.ebgp.layer2_vlan_range.from is defined %}
+{% set l2_vlan_start = vxlan.global.ebgp.layer2_vlan_range.from %}
+{% if vxlan.global.ebgp.layer2_vlan_range.to is defined %}
+{% set l2_vlan_end = vxlan.global.ebgp.layer2_vlan_range.to %}
+{% endif %}
+{% endif %}
+{% if l2_vlan_start is defined and l2_vlan_end is not defined %}
+{% set l2_vlan_range = l2_vlan_start %}
+{% elif l2_vlan_start is defined and l2_vlan_end is defined %}
+{% set l2_vlan_range = l2_vlan_start ~ '-' ~ l2_vlan_end %}
+{% else %}
+{% set l2_vlan_range = defaults.vxlan.global.ebgp.layer2_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vlan_range.to %}
 {% endif %}
   NETWORK_VLAN_RANGE: {{ l2_vlan_range }}
-{% if vxlan.global.ebgp.layer3_vlan_range.from is defined -%}
-{% set l3_vlan_start = vxlan.global.ebgp.layer3_vlan_range.from -%}
-{% if vxlan.global.ebgp.layer3_vlan_range.to is defined -%}
-{% set l3_vlan_end = vxlan.global.ebgp.layer3_vlan_range.to -%}
-{% endif -%}
-{% endif -%}
-{% if l3_vlan_start is defined and l3_vlan_end is not defined -%}
-{% set l3_vlan_range = l3_vlan_start -%}
-{% elif l3_vlan_start is defined and l3_vlan_end is defined -%}
-{% set l3_vlan_range = l3_vlan_start ~ '-' ~ l3_vlan_end -%}
-{% else -%}
-{% set l3_vlan_range = defaults.vxlan.global.ebgp.layer3_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vlan_range.to -%}
+{% if vxlan.global.ebgp.layer3_vlan_range.from is defined %}
+{% set l3_vlan_start = vxlan.global.ebgp.layer3_vlan_range.from %}
+{% if vxlan.global.ebgp.layer3_vlan_range.to is defined %}
+{% set l3_vlan_end = vxlan.global.ebgp.layer3_vlan_range.to %}
+{% endif %}
+{% endif %}
+{% if l3_vlan_start is defined and l3_vlan_end is not defined %}
+{% set l3_vlan_range = l3_vlan_start %}
+{% elif l3_vlan_start is defined and l3_vlan_end is defined %}
+{% set l3_vlan_range = l3_vlan_start ~ '-' ~ l3_vlan_end %}
+{% else %}
+{% set l3_vlan_range = defaults.vxlan.global.ebgp.layer3_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vlan_range.to %}
 {% endif %}
   VRF_VLAN_RANGE: {{ l3_vlan_range }}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -18,6 +18,7 @@
 {% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
+  ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
 {% if (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
 {% endif %}
@@ -35,9 +36,6 @@
   ENABLE_TRMv6: {{ vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | title }}
 {% endif %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
-{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
-  ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
-{% endif %}
   MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv4.group_subnet | default(defaults.vxlan.underlay.multicast.ipv4.group_subnet) }}
 {# {% if (vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | ansible.builtin.bool) %} #}
 {#   L3VNI_MCAST_GROUP: {{ vxlan.underlay.multicast.ipv4.trm_default_group | default(defaults.vxlan.underlay.multicast.ipv4.trm_default_group) }} #}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -1,7 +1,14 @@
 {# Auto-generated NDFC eBGP VXLAN EVPN config data structure for fabric {{ vxlan.fabric.name }} #}
+{% set manual_underlay = (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation)) %}
+{% set ipv6_underlay = (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay)) %}
+{% set replication_mode = (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) %}
+{% set rp_mode = vxlan.underlay.multicast.rp_mode | default(defaults.vxlan.underlay.multicast.rp_mode) %}
+{% set rp_count = vxlan.underlay.multicast.rendezvous_points | default(defaults.vxlan.underlay.multicast.rendezvous_points) %}
+{% set ndfc_ge_12_2_2 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=') %}
+{% set ndfc_lt_12_4_1 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '<') %}
   ENABLE_EVPN: true
   OVERLAY_MODE: {{ vxlan.global.ebgp.overlay_mode | default(defaults.vxlan.global.ebgp.overlay_mode) }}
-{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=') and ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '<') %}
+{% if ndfc_ge_12_2_2 and ndfc_lt_12_4_1 %}
   ALLOW_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_mvpn_vri_id_range | default(defaults.vxlan.global.ebgp.enable_mvpn_vri_id_range) }}
 {% endif %}
   ENABLE_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_l3_vni_no_vlan | default(defaults.vxlan.global.ebgp.enable_l3_vni_no_vlan) }}
@@ -14,50 +21,46 @@
 {% if not (vxlan.global.ebgp.vpc.advertise_pip | default(defaults.vxlan.global.ebgp.vpc.advertise_pip) | ansible.builtin.bool) %}
   ADVERTISE_PIP_ON_BORDER: {{ vxlan.global.ebgp.vpc.advertise_pip_border_only | default(defaults.vxlan.global.ebgp.vpc.advertise_pip_border_only) | title }}
 {% endif %}
-  REPLICATION_MODE: {{ vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title }}
-{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
-{% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
-  ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
+  REPLICATION_MODE: {{ replication_mode }}
+{% if not manual_underlay %}
+{% if not ipv6_underlay %}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
-{% if (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
+{% else %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
 {% endif %}
 {% endif %}
-{% endif %}
-{% if ( ((ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.1', '<=')) and
-        (not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool))) or
-        (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) ) %}
-{% if (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) == 'Multicast' %}
+{% if replication_mode == 'Multicast' %}
   RP_LB_ID: {{ vxlan.underlay.multicast.underlay_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_rp_loopback_id) }}
-  RP_COUNT: "{{ vxlan.underlay.multicast.rendezvous_points | default(defaults.vxlan.underlay.multicast.rendezvous_points) }}"
-  RP_MODE: {{ vxlan.underlay.multicast.rp_mode | default(defaults.vxlan.underlay.multicast.rp_mode) }}
+  RP_COUNT: "{{ rp_count }}"
+  RP_MODE: {{ rp_mode }}
   ENABLE_TRM: {{ vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | title }}
-{% if (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) %}
+{% if ndfc_ge_12_2_2 %}
   ENABLE_TRMv6: {{ vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | title }}
 {% endif %}
-{% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
+{% if not ipv6_underlay %}
+{% if not manual_underlay %}
+  ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
+{% endif %}
   MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv4.group_subnet | default(defaults.vxlan.underlay.multicast.ipv4.group_subnet) }}
 {# {% if (vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | ansible.builtin.bool) %} #}
 {#   L3VNI_MCAST_GROUP: {{ vxlan.underlay.multicast.ipv4.trm_default_group | default(defaults.vxlan.underlay.multicast.ipv4.trm_default_group) }} #}
 {# {% endif %} #}
-{% if ( (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) and
-        (vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | ansible.builtin.bool) ) %}
+{% if ndfc_ge_12_2_2 and (vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | ansible.builtin.bool) %}
   L3VNI_IPv6_MCAST_GROUP: "{{ vxlan.underlay.multicast.ipv6.trmv6_default_group | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_default_group) }}"
 {% endif %}
-{% if vxlan.underlay.multicast.rp_mode | default(defaults.vxlan.underlay.multicast.rp_mode) == 'bidir' %}
+{% if rp_mode == 'bidir' %}
   PHANTOM_RP_LB_ID1: {{ vxlan.underlay.multicast.underlay_primary_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_primary_rp_loopback_id) }}
   PHANTOM_RP_LB_ID2: {{ vxlan.underlay.multicast.underlay_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_backup_rp_loopback_id) }}
-{% if vxlan.underlay.multicast.rendezvous_points | default(defaults.vxlan.underlay.multicast.rendezvous_points) == 4 %}
+{% if rp_count == 4 %}
   PHANTOM_RP_LB_ID3: {{ vxlan.underlay.multicast.underlay_second_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_second_backup_rp_loopback_id) }}
   PHANTOM_RP_LB_ID4: {{ vxlan.underlay.multicast.underlay_third_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_third_backup_rp_loopback_id) }}
 {% endif %}
 {% endif %}
-{% elif (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
-{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
+{% else %}
+{% if not manual_underlay %}
   IPv6_ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv6.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_rp_loopback_ip_range) }}
 {% endif %}
   IPv6_MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv6.group_subnet | default(defaults.vxlan.underlay.multicast.ipv6.group_subnet) }}
-{% endif %}
 {% endif %}
 {% endif %}
 {% if vxlan.global.ebgp.layer2_vni_range.from is defined %}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -18,9 +18,9 @@
 {% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
-{% if (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) == 'Multicast' %}  
+{% if (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) == 'Multicast' %}
   ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
-{% endif %}  
+{% endif %}
 {% if (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -17,6 +17,7 @@
   REPLICATION_MODE: {{ vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title }}
 {% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
+  ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
 {% if (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
@@ -35,9 +36,6 @@
   ENABLE_TRMv6: {{ vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | title }}
 {% endif %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
-{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
-  ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
-{% endif %}
   MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv4.group_subnet | default(defaults.vxlan.underlay.multicast.ipv4.group_subnet) }}
 {# {% if (vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | ansible.builtin.bool) %} #}
 {#   L3VNI_MCAST_GROUP: {{ vxlan.underlay.multicast.ipv4.trm_default_group | default(defaults.vxlan.underlay.multicast.ipv4.trm_default_group) }} #}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -6,12 +6,14 @@
 {% set rp_count = vxlan.underlay.multicast.rendezvous_points | default(defaults.vxlan.underlay.multicast.rendezvous_points) %}
 {% set ndfc_ge_12_2_2 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=') %}
 {% set ndfc_lt_12_4_1 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '<') %}
+{% set ndfc_ge_12_4_1 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>') %}
   ENABLE_EVPN: true
   OVERLAY_MODE: {{ vxlan.global.ebgp.overlay_mode | default(defaults.vxlan.global.ebgp.overlay_mode) }}
 {% if ndfc_ge_12_2_2 and ndfc_lt_12_4_1 %}
   ALLOW_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_mvpn_vri_id_range | default(defaults.vxlan.global.ebgp.enable_mvpn_vri_id_range) }}
-{% endif %}
+  {% elif ndfc_ge_12_4_1 %}
   ENABLE_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_l3_vni_no_vlan | default(defaults.vxlan.global.ebgp.enable_l3_vni_no_vlan) }}
+  {% endif %}
   ANYCAST_GW_MAC: {{ vxlan.global.ebgp.anycast_gateway_mac | default(defaults.vxlan.global.ebgp.anycast_gateway_mac) }}
   ADVERTISE_PIP_BGP: {{ (vxlan.global.ebgp.vpc.advertise_pip | default(defaults.vxlan.global.ebgp.vpc.advertise_pip) | title) }}
 {% if vxlan.global.ebgp.multisite_site_id is defined %}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -9,165 +9,112 @@
 {% set ndfc_ge_12_4_1 = ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>') %}
   ENABLE_EVPN: true
   OVERLAY_MODE: {{ vxlan.global.ebgp.overlay_mode | default(defaults.vxlan.global.ebgp.overlay_mode) }}
-{# IF: NDFC between 12.2.2 and 12.4.0 START #}
 {% if ndfc_ge_12_2_2 and ndfc_lt_12_4_1 %}
   ALLOW_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_mvpn_vri_id_range | default(defaults.vxlan.global.ebgp.enable_mvpn_vri_id_range) }}
 {% elif ndfc_ge_12_4_1 %}
   ENABLE_L3VNI_NO_VLAN:  {{ vxlan.global.ebgp.enable_l3_vni_no_vlan | default(defaults.vxlan.global.ebgp.enable_l3_vni_no_vlan) }}
 {% endif %}
-{# IF: NDFC between 12.2.2 and 12.4.0 END #}
   ANYCAST_GW_MAC: {{ vxlan.global.ebgp.anycast_gateway_mac | default(defaults.vxlan.global.ebgp.anycast_gateway_mac) }}
   ADVERTISE_PIP_BGP: {{ (vxlan.global.ebgp.vpc.advertise_pip | default(defaults.vxlan.global.ebgp.vpc.advertise_pip) | title) }}
-{# IF: Multisite SITE_ID START #}
 {% if vxlan.global.ebgp.multisite_site_id is defined %}
   SITE_ID: {{ vxlan.global.ebgp.multisite_site_id | default(vxlan.global.ebgp.spine_bgp_asn) }}
 {% endif %}
-{# IF: Multisite SITE_ID END #}
   ANYCAST_BGW_ADVERTISE_PIP: {{ vxlan.global.ebgp.vpc.advertise_pip_border_gateway | default(defaults.vxlan.global.ebgp.vpc.advertise_pip_border_gateway) }}
-{# IF: Advertise PIP toggle START #}
 {% if not (vxlan.global.ebgp.vpc.advertise_pip | default(defaults.vxlan.global.ebgp.vpc.advertise_pip) | ansible.builtin.bool) %}
   ADVERTISE_PIP_ON_BORDER: {{ vxlan.global.ebgp.vpc.advertise_pip_border_only | default(defaults.vxlan.global.ebgp.vpc.advertise_pip_border_only) | title }}
 {% endif %}
-{# IF: Advertise PIP toggle END #}
   REPLICATION_MODE: {{ replication_mode }}
-{# IF: Manual underlay disabled START #}
 {% if not manual_underlay %}
-{# IF: IPv4 underlay START #}
 {% if not ipv6_underlay %}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
 {% else %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
 {% endif %}
-{# IF: IPv4 underlay END #}
 {% endif %}
-{# IF: Manual underlay disabled END #}
-{# IF: Replication mode multicast START #}
 {% if replication_mode == 'Multicast' %}
   RP_LB_ID: {{ vxlan.underlay.multicast.underlay_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_rp_loopback_id) }}
   RP_COUNT: "{{ rp_count }}"
   RP_MODE: {{ rp_mode }}
   ENABLE_TRM: {{ vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | title }}
-  {# IF: NDFC >= 12.2.2 START #}
 {% if ndfc_ge_12_2_2 %}
   ENABLE_TRMv6: {{ vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | title }}
 {% endif %}
-  {# IF: NDFC >= 12.2.2 END #}
-  {# IF: IPv4 multicast START #}
 {% if not ipv6_underlay %}
-  {# IF: Manual underlay disabled (IPv4 multicast) START #}
 {% if not manual_underlay %}
   ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
 {% endif %}
-  {# IF: Manual underlay disabled (IPv4 multicast) END #}
   MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv4.group_subnet | default(defaults.vxlan.underlay.multicast.ipv4.group_subnet) }}
-{# {% if (vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | ansible.builtin.bool) %} #}
-{#   L3VNI_MCAST_GROUP: {{ vxlan.underlay.multicast.ipv4.trm_default_group | default(defaults.vxlan.underlay.multicast.ipv4.trm_default_group) }} #}
-{# {% endif %} #}
-  {# IF: TRMv6 group START #}
 {% if ndfc_ge_12_2_2 and (vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | ansible.builtin.bool) %}
   L3VNI_IPv6_MCAST_GROUP: "{{ vxlan.underlay.multicast.ipv6.trmv6_default_group | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_default_group) }}"
 {% endif %}
-  {# IF: TRMv6 group END #}
-  {# IF: RP mode bidir START #}
 {% if rp_mode == 'bidir' %}
   PHANTOM_RP_LB_ID1: {{ vxlan.underlay.multicast.underlay_primary_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_primary_rp_loopback_id) }}
   PHANTOM_RP_LB_ID2: {{ vxlan.underlay.multicast.underlay_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_backup_rp_loopback_id) }}
-    {# IF: RP count equals 4 START #}
 {% if rp_count == 4 %}
   PHANTOM_RP_LB_ID3: {{ vxlan.underlay.multicast.underlay_second_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_second_backup_rp_loopback_id) }}
   PHANTOM_RP_LB_ID4: {{ vxlan.underlay.multicast.underlay_third_backup_rp_loopback_id | default(defaults.vxlan.underlay.multicast.underlay_third_backup_rp_loopback_id) }}
 {% endif %}
-    {# IF: RP count equals 4 END #}
 {% endif %}
-  {# IF: RP mode bidir END #}
 {% else %}
-  {# IF: IPv6 multicast START #}
 {% if not manual_underlay %}
   IPv6_ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv6.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_rp_loopback_ip_range) }}
 {% endif %}
   IPv6_MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv6.group_subnet | default(defaults.vxlan.underlay.multicast.ipv6.group_subnet) }}
-  {# IF: IPv6 multicast END #}
 {% endif %}
-  {# IF: IPv4 multicast END #}
 {% endif %}
-{# IF: Replication mode multicast END #}
-{# IF: L2 VNI start defined START #}
-{% if vxlan.global.ebgp.layer2_vni_range.from is defined %}
-{% set l2_vni_start = vxlan.global.ebgp.layer2_vni_range.from %}
-  {# IF: L2 VNI end defined START #}
-{% if vxlan.global.ebgp.layer2_vni_range.to is defined %}
-{% set l2_vni_end = vxlan.global.ebgp.layer2_vni_range.to %}
+{% if vxlan.global.ebgp.layer2_vni_range.from is defined -%}
+{% set l2_vni_start = vxlan.global.ebgp.layer2_vni_range.from -%}
+{% if vxlan.global.ebgp.layer2_vni_range.to is defined -%}
+{% set l2_vni_end = vxlan.global.ebgp.layer2_vni_range.to -%}
+{% endif -%}
+{% endif -%}
+{% if l2_vni_start is defined and l2_vni_end is not defined -%}
+{% set l2_vni_range = l2_vni_start -%}
+{% elif l2_vni_start is defined and l2_vni_end is defined -%}
+{% set l2_vni_range = l2_vni_start ~ '-' ~ l2_vni_end -%}
+{% else -%}
+{% set l2_vni_range = defaults.vxlan.global.ebgp.layer2_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vni_range.to -%}
 {% endif %}
-  {# IF: L2 VNI end defined END #}
-{% endif %}
-{# IF: L2 VNI start defined END #}
-{# IF: L2 VNI range derive START #}
-{% if l2_vni_start is defined and l2_vni_end is not defined %}
-{% set l2_vni_range = l2_vni_start %}
-{% elif l2_vni_start is defined and l2_vni_end is defined %}
-{% set l2_vni_range = l2_vni_start ~ '-' ~ l2_vni_end %}
-{% else %}
-{% set l2_vni_range = defaults.vxlan.global.ebgp.layer2_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vni_range.to %}
-{% endif %}
-{# IF: L2 VNI range derive END #}
   L2_SEGMENT_ID_RANGE: {{ l2_vni_range }}
-{# IF: L3 VNI start defined START #}
-{% if vxlan.global.ebgp.layer3_vni_range.from is defined %}
-{% set l3_vni_start = vxlan.global.ebgp.layer3_vni_range.from %}
-  {# IF: L3 VNI end defined START #}
-{% if vxlan.global.ebgp.layer3_vni_range.to is defined %}
-{% set l3_vni_end = vxlan.global.ebgp.layer3_vni_range.to %}
+{% if vxlan.global.ebgp.layer3_vni_range.from is defined -%}
+{% set l3_vni_start = vxlan.global.ebgp.layer3_vni_range.from -%}
+{% if vxlan.global.ebgp.layer3_vni_range.to is defined -%}
+{% set l3_vni_end = vxlan.global.ebgp.layer3_vni_range.to -%}
+{% endif -%}
+{% endif -%}
+{% if l3_vni_start is defined and l3_vni_end is not defined -%}
+{% set l3_vni_range = l3_vni_start -%}
+{% elif l3_vni_start is defined and l3_vni_end is defined -%}
+{% set l3_vni_range = l3_vni_start ~ '-' ~ l3_vni_end -%}
+{% else -%}
+{% set l3_vni_range = defaults.vxlan.global.ebgp.layer3_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vni_range.to -%}
 {% endif %}
-  {# IF: L3 VNI end defined END #}
-{% endif %}
-{# IF: L3 VNI start defined END #}
-{# IF: L3 VNI range derive START #}
-{% if l3_vni_start is defined and l3_vni_end is not defined %}
-{% set l3_vni_range = l3_vni_start %}
-{% elif l3_vni_start is defined and l3_vni_end is defined %}
-{% set l3_vni_range = l3_vni_start ~ '-' ~ l3_vni_end %}
-{% else %}
-{% set l3_vni_range = defaults.vxlan.global.ebgp.layer3_vni_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vni_range.to %}
-{% endif %}
-{# IF: L3 VNI range derive END #}
   L3_PARTITION_ID_RANGE: {{ l3_vni_range }}
-{# IF: L2 VLAN start defined START #}
-{% if vxlan.global.ebgp.layer2_vlan_range.from is defined %}
-{% set l2_vlan_start = vxlan.global.ebgp.layer2_vlan_range.from %}
-  {# IF: L2 VLAN end defined START #}
-{% if vxlan.global.ebgp.layer2_vlan_range.to is defined %}
-{% set l2_vlan_end = vxlan.global.ebgp.layer2_vlan_range.to %}
+{% if vxlan.global.ebgp.layer2_vlan_range.from is defined -%}
+{% set l2_vlan_start = vxlan.global.ebgp.layer2_vlan_range.from -%}
+{% if vxlan.global.ebgp.layer2_vlan_range.to is defined -%}
+{% set l2_vlan_end = vxlan.global.ebgp.layer2_vlan_range.to -%}
+{% endif -%}
+{% endif -%}
+{% if l2_vlan_start is defined and l2_vlan_end is not defined -%}
+{% set l2_vlan_range = l2_vlan_start -%}
+{% elif l2_vlan_start is defined and l2_vlan_end is defined -%}
+{% set l2_vlan_range = l2_vlan_start ~ '-' ~ l2_vlan_end -%}
+{% else -%}
+{% set l2_vlan_range = defaults.vxlan.global.ebgp.layer2_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vlan_range.to -%}
 {% endif %}
-  {# IF: L2 VLAN end defined END #}
-{% endif %}
-{# IF: L2 VLAN start defined END #}
-{# IF: L2 VLAN range derive START #}
-{% if l2_vlan_start is defined and l2_vlan_end is not defined %}
-{% set l2_vlan_range = l2_vlan_start %}
-{% elif l2_vlan_start is defined and l2_vlan_end is defined %}
-{% set l2_vlan_range = l2_vlan_start ~ '-' ~ l2_vlan_end %}
-{% else %}
-{% set l2_vlan_range = defaults.vxlan.global.ebgp.layer2_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer2_vlan_range.to %}
-{% endif %}
-{# IF: L2 VLAN range derive END #}
   NETWORK_VLAN_RANGE: {{ l2_vlan_range }}
-{# IF: L3 VLAN start defined START #}
-{% if vxlan.global.ebgp.layer3_vlan_range.from is defined %}
-{% set l3_vlan_start = vxlan.global.ebgp.layer3_vlan_range.from %}
-  {# IF: L3 VLAN end defined START #}
-{% if vxlan.global.ebgp.layer3_vlan_range.to is defined %}
-{% set l3_vlan_end = vxlan.global.ebgp.layer3_vlan_range.to %}
+{% if vxlan.global.ebgp.layer3_vlan_range.from is defined -%}
+{% set l3_vlan_start = vxlan.global.ebgp.layer3_vlan_range.from -%}
+{% if vxlan.global.ebgp.layer3_vlan_range.to is defined -%}
+{% set l3_vlan_end = vxlan.global.ebgp.layer3_vlan_range.to -%}
+{% endif -%}
+{% endif -%}
+{% if l3_vlan_start is defined and l3_vlan_end is not defined -%}
+{% set l3_vlan_range = l3_vlan_start -%}
+{% elif l3_vlan_start is defined and l3_vlan_end is defined -%}
+{% set l3_vlan_range = l3_vlan_start ~ '-' ~ l3_vlan_end -%}
+{% else -%}
+{% set l3_vlan_range = defaults.vxlan.global.ebgp.layer3_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vlan_range.to -%}
 {% endif %}
-  {# IF: L3 VLAN end defined END #}
-{% endif %}
-{# IF: L3 VLAN start defined END #}
-{# IF: L3 VLAN range derive START #}
-{% if l3_vlan_start is defined and l3_vlan_end is not defined %}
-{% set l3_vlan_range = l3_vlan_start %}
-{% elif l3_vlan_start is defined and l3_vlan_end is defined %}
-{% set l3_vlan_range = l3_vlan_start ~ '-' ~ l3_vlan_end %}
-{% else %}
-{% set l3_vlan_range = defaults.vxlan.global.ebgp.layer3_vlan_range.from ~ '-' ~ defaults.vxlan.global.ebgp.layer3_vlan_range.to %}
-{% endif %}
-{# IF: L3 VLAN range derive END #}
   VRF_VLAN_RANGE: {{ l3_vlan_range }}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -18,7 +18,9 @@
 {% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
+{% if (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) == 'Multicast' %}  
   ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
+{% endif %}  
 {% if (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/evpn/ebgp_vxlan_fabric_evpn.j2
@@ -18,15 +18,12 @@
 {% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_vtep_loopback_ip_range) }}
-{% if (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) == 'Multicast' %}
-  ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
-{% endif %}
 {% if (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   LOOPBACK1_IPV6_RANGE: {{ vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range | default(defaults.vxlan.underlay.ipv6.underlay_vtep_loopback_ip_range) }}
 {% endif %}
 {% endif %}
 {% endif %}
-{% if ( ((ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.1', '<=')) and
+{% if ( ((ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '<')) and
         (not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool))) or
         (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) ) %}
 {% if (vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) | title) == 'Multicast' %}
@@ -38,6 +35,9 @@
   ENABLE_TRMv6: {{ vxlan.underlay.multicast.ipv6.trmv6_enable | default(defaults.vxlan.underlay.multicast.ipv6.trmv6_enable) | title }}
 {% endif %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
+{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
+  ANYCAST_RP_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_rp_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_rp_loopback_ip_range) }}
+{% endif %}
   MULTICAST_GROUP_SUBNET: {{ vxlan.underlay.multicast.ipv4.group_subnet | default(defaults.vxlan.underlay.multicast.ipv4.group_subnet) }}
 {# {% if (vxlan.underlay.multicast.ipv4.trm_enable | default(defaults.vxlan.underlay.multicast.ipv4.trm_enable) | ansible.builtin.bool) %} #}
 {#   L3VNI_MCAST_GROUP: {{ vxlan.underlay.multicast.ipv4.trm_default_group | default(defaults.vxlan.underlay.multicast.ipv4.trm_default_group) }} #}


### PR DESCRIPTION
[ND3.1.x] [eBGP fabric] ANYCAST_RP_IP_RANGE is not deploying on NDFC

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
Fixes https://github.com/netascode/ansible-dc-vxlan/issues/688

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
