### PR TITLE
Fix for issue when Port-channel ID != vPC ID #676

### DIFF
--- a/roles/validate/files/rules/common/305_topology_switch_interfaces_vpc.py
+++ b/roles/validate/files/rules/common/305_topology_switch_interfaces_vpc.py
@@ -59,10 +59,11 @@ class Rule:
                         )
                         if port_channel_match:
                             port_channel_id = port_channel_match.group(1)
-           
+
                             if int(port_channel_id) != int(vpc_id):
                                 results.append(
-                                    f"Switch {switch_name} interface {interface_name} uses vPC id {vpc_id} but Port-channel ID {port_channel_id}; these values must match."
+                                    f"Switch {switch_name} interface {interface_name} uses vPC id {vpc_id}"
+                                    "but Port-channel ID {port_channel_id}; these values must match."
                                 )
 
                         # Check if vPC id is referenced by more than 1 Port-channel on the switch


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

When Port-channel ID != vPC ID tests failed #676 

## Related Issue(s)
Fixes https://github.com/netascode/ansible-dc-vxlan/issues/676

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
