### PR TITLE
fix: validation to work with inventory in different directory than playbook

### DIFF
--- a/roles/validate/tasks/sub_main.yml
+++ b/roles/validate/tasks/sub_main.yml
@@ -69,7 +69,7 @@
     rules: "{{ rules_path }}"
   register: data_model
   vars:
-    data_path: "{{ playbook_dir }}/host_vars/{{ inventory_hostname }}"
+    data_path: "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}"
     rules_path: "{{ role_path }}/files/rules/"
   delegate_to: localhost
 
@@ -79,7 +79,7 @@
     mdata: "{{ data_path }}"
     rules: "{{ enhanced_rules_path }}"
   vars:
-    data_path: "{{ playbook_dir }}/host_vars/{{ inventory_hostname }}"
+    data_path: "{{ inventory_dir }}/host_vars/{{ inventory_hostname }}"
   when: enhanced_rules_path is defined and enhanced_rules_path
   delegate_to: localhost
 


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #678 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Make the data folder lookup relative to the `inventory_dir` rather than the `playbook_dir`.
This enables using the same playbook with multiple inventories / fabrics  (e.g. when using with vxlan multi-site we have at least 3 inventories - site1, site2 and msite)


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->

Tested against ND 4.1.1g

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
