### PR TITLE
update PR template to include keyword usage for Related Issue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,7 @@
 
 ## Related Issue(s)
 <!--- Please link the relevant issue(s) -->
+<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->
 
 
 ## Related Collection Role


### PR DESCRIPTION
Github PR template update.
Updating PR template to show the keywords to link issues as found in https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
