### PR TITLE
Add 'network.attach_groups' and 'vrf.attach_groups' objects to allow more granular switch attachments to overlay networks/vrfs

### DIFF
--- a/plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py
+++ b/plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py
@@ -76,11 +76,17 @@ class PreparePlugin:
                         elif found_switch.get('management').get('management_ipv6_address'):
                             switch['mgmt_ip_address'] = found_switch['management']['management_ipv6_address']
 
-            # Remove network_attach_group from net if the group_name is not defined
+            # Remove network_attach_group or attach_groups from net if the group_name is not defined
             for net in data_model['vxlan']['overlay']['networks']:
                 if 'network_attach_group' in net:
                     if net.get('network_attach_group') not in net_grp_name_list:
                         del net['network_attach_group']
+                elif 'attach_groups' in net:
+                    for grp in net.get('attach_groups'):
+                        if grp not in net_grp_name_list:
+                            net['attach_groups'].remove(grp)
+                    if net.get('attach_groups') == []:
+                        del net['attach_groups']
 
         if data_model['vxlan']['fabric']['type'] in ('MSD', 'MCFG'):
             # Rebuild sm_data['vxlan']['multisite']['overlay']['vrf_attach_groups'] into
@@ -136,11 +142,17 @@ class PreparePlugin:
                     # does not include one of these switches.
                     data_model['vxlan']['multisite']['overlay']['network_attach_switches_list'].append(switch['hostname'])
 
-            # Remove network_attach_group from net if the group_name is not defined
+            # Remove network_attach_group or attach_groups from net if the group_name is not defined
             for net in data_model['vxlan']['multisite']['overlay']['networks']:
                 if 'network_attach_group' in net:
                     if net.get('network_attach_group') not in net_grp_name_list:
                         del net['network_attach_group']
+                elif 'attach_groups' in net:
+                    for grp in net.get('attach_groups'):
+                        if grp not in net_grp_name_list:
+                            net['attach_groups'].remove(grp)
+                    if net.get('attach_groups') == []:
+                        del net['attach_groups']
 
         self.kwargs['results']['model_extended'] = data_model
         return self.kwargs['results']

--- a/plugins/action/dtc/prepare_msite_data.py
+++ b/plugins/action/dtc/prepare_msite_data.py
@@ -130,11 +130,17 @@ class ActionModule(ActionBase):
                 # does not include one of these switches.
                 data_model['vxlan']['multisite']['overlay']['network_attach_switches_list'].append(switch['hostname'])
 
-        # Remove network_attach_group from net if the group_name is not defined
+        # Remove network_attach_group or attach_groups from net if the group_name is not defined
         for net in data_model['vxlan']['multisite']['overlay']['networks']:
             if 'network_attach_group' in net:
                 if net.get('network_attach_group') not in net_grp_name_list:
                     del net['network_attach_group']
+                elif 'attach_groups' in net:
+                    for grp in net.get('attach_groups'):
+                        if grp not in net_grp_name_list:
+                            net['attach_groups'].remove(grp)
+                    if net.get('attach_groups') == []:
+                        del net['attach_groups']
 
         results['overlay_attach_groups'] = data_model['vxlan']['multisite']['overlay']
 

--- a/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
@@ -69,18 +69,27 @@
 {# ------------------------------------------------------ #}
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}
-{% if net['network_attach_group'] is defined %}
-  attach:
 {% if data_model_extended.vxlan.overlay.network_attach_groups_dict is defined and data_model_extended.vxlan.overlay.network_attach_groups_dict %}
 {% set network_attach_groups_dict = data_model_extended.vxlan.overlay.network_attach_groups_dict %}
-{% endif %}
+{% if net['network_attach_group'] is defined %}
+  attach:
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}
 {% endfor %}
+{% elif net['attach_groups'] is defined and net['attach_groups'] | length >= 1 %}
+  attach:
+{% for group in net['attach_groups'] %}
+{% for attach in network_attach_groups_dict[group] %}
+    - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if attach['ports'] is defined %}
+      ports: {{ attach['ports'] }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}
   deploy: false
 {% endif %}
-
 {% endfor %}

--- a/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
@@ -42,17 +42,27 @@
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}
 {# Don't need to attach vrfs if there are no msd_switches #}
-{% if net['network_attach_group'] is defined %}
-  attach:
 {% if data_model_multisite.overlay_attach_groups.network_attach_groups_dict is defined and data_model_multisite.overlay_attach_groups.network_attach_groups_dict %}
 {% set network_attach_groups_dict = data_model_multisite.overlay_attach_groups.network_attach_groups_dict %}
-{% endif %}
+{% if net['network_attach_group'] is defined %}
+  attach:
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}
 {% endfor %}
+{% elif net['attach_groups'] is defined and net['attach_groups'] | length >= 1 %}
+  attach:
+{% for group in net['attach_groups'] %}
+{% for attach in network_attach_groups_dict[group] %}
+    - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if attach['ports'] is defined %}
+      ports: {{ attach['ports'] }}
+{% endif %}
+{% endfor %}
+{% endfor %}
+{% endif %}
   deploy: false
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Related Issue(s)
Fix #437 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [X] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [X] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [X] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [X] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
- Add an `attach_groups` element to `overlay.networks` and `overlay.vrfs`.  This element will allow to attach the network/vrf to multiple `network_attach_groups`/`vrf_attach_groups`. 
- Add the same element to `multisite.overlay.networks` and `multisite.overlay.vrfs`.


## Test Notes
NA


## Cisco Nexus Dashboard Version
- NDFC 12.2
- ND 4.1


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
