### PR TITLE
Fixing VLAN ranges on peer-links and description on vPCs

### DIFF
--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
@@ -31,8 +31,6 @@
       {{ switches[peer1].freeform_config | default('') | indent(6, false) }}
     peer2_cmds: |2-
       {{ switches[peer2].freeform_config | default('') | indent(6, false)  }}
-    peer1_description: "{{ switches[peer1].description | default(omit) }}"
-    peer2_description: "{{ switches[peer2].description | default(omit) }}"
     bpdu_guard: {{ switches[peer1].enable_bpdu_guard | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_bpdu_guard)   }}
     disable_lacp_suspend_individual: {{ switches[peer1].disable_lacp_suspend_individual | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.disable_lacp_suspend_individual) }}
     enable_lacp_vpc_convergence: {{ switches[peer1].enable_lacp_vpc_convergence | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_lacp_vpc_convergence) }}
@@ -41,9 +39,13 @@
 {% if switches[peer1].mode == 'trunk' %}
     peer1_allowed_vlans: "{{ convert_ranges(switches[peer1].trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
     peer2_allowed_vlans: "{{ convert_ranges(switches[peer2].trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
+    peer1_description: "{{ switches[peer1].description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.description) }}"
+    peer2_description: "{{ switches[peer2].description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.description) }}"
 {% elif switches[peer1].mode == 'access' %}
     peer1_access_vlan: {{ switches[peer1].access_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan) }}
     peer2_access_vlan: {{ switches[peer2].access_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan)  }}
+    peer1_description: "{{ switches[peer1].description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.description) }}"
+    peer2_description: "{{ switches[peer2].description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.description) }}"
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs_external.j2
+++ b/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs_external.j2
@@ -1,3 +1,5 @@
+{% from 'macros/convert_ranges.j2' import convert_ranges as convert_ranges %}
+
 ---
 # This NDFC vPC Peering config data structure for vPC pairs in External Fabrics is auto-generated
 # DO NOT EDIT MANUALLY
@@ -38,7 +40,7 @@
     PEER2_PCID: {{ peer2_vpc_interface.name | default('') | regex_replace('^(port-channel|po)', '') | default('') }}
     PEER1_MEMBER_INTERFACES: "{{ peer1_vpc_interface.members | default([]) | join(',') }}"
     PEER2_MEMBER_INTERFACES: "{{ peer2_vpc_interface.members | default([]) | join(',') }}"
-    ALLOWED_VLANS: "{{ peer1_vpc_interface.trunk_allowed_vlans | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) }}"
+    ALLOWED_VLANS: "{{ convert_ranges(peer1_vpc_interface.trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans)  | trim }}"
     ADMIN_STATE: {{ peer1_vpc_interface.enabled | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled)}}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #689 and #691


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [X] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
vPC peer-link template has now the correct format for the *allowed_vlans* field: <First VLAN> - <Last VLAN>
VPCs grab the default description if no description is listed on the data model

## Test Notes
Robot test done in lab


## Cisco Nexus Dashboard Version
ND 3.2.2
NDFC 12.2.3.68


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
