### PR TITLE
Added native vlan support to vpc interface

### DIFF
--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
@@ -41,6 +41,8 @@
     peer2_allowed_vlans: "{{ convert_ranges(switches[peer2].trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
     peer1_description: "{{ switches[peer1].description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.description) }}"
     peer2_description: "{{ switches[peer2].description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.description) }}"
+    peer1_native_vlan: "{{ switches[peer1].native_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.native_vlan) }}"
+    peer2_native_vlan: "{{ switches[peer2].native_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.native_vlan) }}"
 {% elif switches[peer1].mode == 'access' %}
     peer1_access_vlan: {{ switches[peer1].access_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan) }}
     peer2_access_vlan: {{ switches[peer2].access_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan)  }}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Adding in support to the VPC interface for trunks so that native vlan can be configured

## Test Notes
<!--- Please provide notes or description of testing -->
Tested with the following input data:

Leaf1:
        interfaces:
          - name: po1005
            mode: trunk
            native_vlan: 20
            vpc_id: 1005
            members:
              - ethernet1/1
            mtu: jumbo
Leaf2:
        interfaces:
          - name: po1005
            mode: trunk
            native_vlan: 20
            vpc_id: 1005
            members:
              - ethernet1/1
            mtu: jumbo
Both Leafs are vpc paired.

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->
3.2

## Checklist

* [x ] Latest commit is rebased from develop with merge conflicts resolved
* [x ] New or updates to documentation has been made accordingly
* [ x] Assigned the proper reviewers
