### PR TITLE
Adding Config-save task after adding-child-fabrics on MSD and MCFG

### DIFF
--- a/roles/dtc/create/tasks/sub_main_mcfg.yml
+++ b/roles/dtc/create/tasks/sub_main_mcfg.yml
@@ -54,7 +54,7 @@
     - name: Config-Save for MCFG Fabric in Nexus Dashboard
       cisco.dcnm.dcnm_rest:
         method: POST
-        path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{ data_model_extended.vxlan.fabric.name }}/config-save"
+        path: "/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/fabrics/{{ data_model_extended.vxlan.fabric.name }}/config-save"
       when:
         - data_model_extended.vxlan.multisite.child_fabrics | length > 0
       register: config_save
@@ -64,7 +64,8 @@
       ansible.builtin.debug:
         msg: "{{ config_save.msg.DATA }}"
       when:
-        - config_save.msg.RETURN_CODE is defined and config_save.msg.RETURN_CODE == 500
+        - config_save.msg.RETURN_CODE is defined
+        - config_save.msg.RETURN_CODE == 500
 
 - name: Prepare Multisite Data
   cisco.nac_dc_vxlan.dtc.prepare_msite_data:

--- a/roles/dtc/create/tasks/sub_main_msd.yml
+++ b/roles/dtc/create/tasks/sub_main_msd.yml
@@ -65,7 +65,8 @@
       ansible.builtin.debug:
         msg: "{{ config_save.msg.DATA }}"
       when:
-        - config_save.msg.RETURN_CODE is defined and config_save.msg.RETURN_CODE == 500
+        - config_save.msg.RETURN_CODE is defined
+        - config_save.msg.RETURN_CODE == 500
 
 - name: Prepare Multisite Data
   cisco.nac_dc_vxlan.dtc.prepare_msite_data:


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
Fix #699 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [X] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
This change adds a config-save after adding the child fabrics to the MSD/MCFG Fabric


## Test Notes
Tested with a VLAN extended on two sites and with two VLANs, one on each site.


## Cisco Nexus Dashboard Version
ND 4.1
NDFC 3.2


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
