### PR TITLE
fix: correct arp_supress typo to arp_suppress

### DIFF
--- a/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
@@ -31,7 +31,7 @@
   secondary_ip_gw4: {{ net['secondary_ip_addresses'][3]['ip_address'] }}
 {% endif %}
 {% endif %}
-  arp_suppress: {{ net['arp_suppress'] | default(defaults.vxlan.overlay.networks.arp_supress) }}
+  arp_suppress: {{ net['arp_suppress'] | default(defaults.vxlan.overlay.networks.arp_suppress) }}
   dhcp_loopback_id: {{ net['dhcp_loopback_id'] | default(omit) }}
 {% if net.dhcp_servers is defined %}
 {% if net.dhcp_servers | length == 1 %}

--- a/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
@@ -32,7 +32,7 @@
   secondary_ip_gw4: {{ net['secondary_ip_addresses'][3]['ip_address'] }}
 {% endif %}
 {% endif %}
-  arp_suppress: {{ net['arp_suppress'] | default(defaults.vxlan.overlay.networks.arp_supress) }}
+  arp_suppress: {{ net['arp_suppress'] | default(defaults.vxlan.overlay.networks.arp_suppress) }}
   gw_ipv6_subnet: {{ net['gw_ipv6_address'] | default(omit) }}
   int_desc: {{ net['int_desc'] | default(defaults.vxlan.overlay.networks.net_description) }}
   mtu_l3intf: {{ net['mtu_l3intf'] | default(defaults.vxlan.overlay.networks.mtu_l3intf) }}

--- a/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
@@ -32,7 +32,7 @@
   secondary_ip_gw4: {{ net['secondary_ip_addresses'][3]['ip_address'] }}
 {% endif %}
 {% endif %}
-  arp_suppress: {{ net['arp_suppress'] | default(defaults.vxlan.multisite.overlay.networks.arp_supress) }}
+  arp_suppress: {{ net['arp_suppress'] | default(defaults.vxlan.multisite.overlay.networks.arp_suppress) }}
   gw_ipv6_subnet: {{ net['gw_ipv6_address'] | default(omit) }}
   int_desc: {{ net['int_desc'] | default(defaults.vxlan.multisite.overlay.networks.net_description) }}
   mtu_l3intf: {{ net['mtu_l3intf'] | default(defaults.vxlan.multisite.overlay.networks.mtu_l3intf) }}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -339,7 +339,7 @@ factory_defaults:
       networks:
         net_description: "Configured by Ansible NetAsCode"
         is_l2_only: false
-        arp_supress: false
+        arp_suppress: false
         l3gw_on_border: false
         mtu_l3intf: 9216
         multicast_group_address: 239.1.1.1
@@ -487,7 +487,7 @@ factory_defaults:
         networks:
           net_description: "Configured by Ansible NetAsCode"
           is_l2_only: false
-          arp_supress: false
+          arp_suppress: false
           l3gw_on_border: false
           mtu_l3intf: 9216
           multicast_group_address: 239.1.1.1


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->
Fixes #708 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Fixed typo in 4 files (5 occurrences):
- roles/validate/files/defaults.yml (2 occurrences)
- roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
- roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
- roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2

Aligns defaults and Jinja2 templates with schema which uses correct spelling 'arp_suppress'. No breaking changes as users already use correct spelling in their data models.

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
