### PR TITLE
Support for VRF route_target formats of xx:xx

### DIFF
--- a/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_vrfs.j2
@@ -26,12 +26,12 @@
   bgp_password: {{ vrf['bgp_password'] | default(omit) }}
   bgp_password_encryption_type: {{ vrf['bgp_password_encryption_type'] | default(omit) }}
   disable_rt_auto: {{ vrf['disable_rt_auto'] | default(defaults.vxlan.overlay.vrfs.disable_rt_auto) }}
-  export_evpn_rt: {{ vrf['export_evpn_rt'] | default(omit) }}
-  export_mvpn_rt: {{ vrf['export_mvpn_rt'] | default(omit) }}
-  export_vpn_rt: {{ vrf['export_vpn_rt'] | default(omit) }}
-  import_evpn_rt: {{ vrf['import_evpn_rt'] | default(omit) }}
-  import_mvpn_rt: {{ vrf['import_mvpn_rt'] | default(omit) }}
-  import_vpn_rt: {{ vrf['import_vpn_rt'] | default(omit) }}
+  export_evpn_rt: "{{ vrf['export_evpn_rt'] | default(omit) }}"
+  export_mvpn_rt: "{{ vrf['export_mvpn_rt'] | default(omit) }}"
+  export_vpn_rt: "{{ vrf['export_vpn_rt'] | default(omit) }}"
+  import_evpn_rt: "{{ vrf['import_evpn_rt'] | default(omit) }}"
+  import_mvpn_rt: "{{ vrf['import_mvpn_rt'] | default(omit) }}"
+  import_vpn_rt: "{{ vrf['import_vpn_rt'] | default(omit) }}"
   netflow_enable: {{ vrf['netflow_enable'] | default(defaults.vxlan.overlay.vrfs.netflow_enable) }}
 {% if vrf['netflow_enable'] is defined and vrf['netflow_enable'] | ansible.builtin.bool %}
   nf_monitor: {{ vrf['netflow_monitor'] }}

--- a/roles/dtc/common/templates/ndfc_vrfs/mcfg_fabric/mcfg_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/mcfg_fabric/mcfg_fabric_vrfs.j2
@@ -21,10 +21,10 @@
   max_ibgp_paths: {{ vrf['max_ibgp_paths'] | default(defaults.vxlan.multisite.overlay.vrfs.max_ibgp_paths) }}
   ipv6_linklocal_enable: {{ vrf['ipv6_linklocal_enable'] | default(defaults.vxlan.multisite.overlay.vrfs.ipv6_linklocal_enable) }}
   disable_rt_auto: {{ vrf['disable_rt_auto'] | default(defaults.vxlan.multisite.overlay.vrfs.disable_rt_auto) }}
-  export_evpn_rt: {{ vrf['export_evpn_rt'] | default(omit) }}
-  export_vpn_rt: {{ vrf['export_vpn_rt'] | default(omit) }}
-  import_evpn_rt: {{ vrf['import_evpn_rt'] | default(omit) }}
-  import_vpn_rt: {{ vrf['import_vpn_rt'] | default(omit) }}
+  export_evpn_rt: "{{ vrf['export_evpn_rt'] | default(omit) }}"
+  export_vpn_rt: "{{ vrf['export_vpn_rt'] | default(omit) }}"
+  import_evpn_rt: "{{ vrf['import_evpn_rt'] | default(omit) }}"
+  import_vpn_rt: "{{ vrf['import_vpn_rt'] | default(omit) }}"
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.multisite.overlay.vrfs.redist_direct_routemap) }}
 {% if (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) %}
   v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.multisite.overlay.vrfs.ipv6_redist_direct_routemap) }}

--- a/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_vrfs.j2
@@ -21,10 +21,10 @@
   max_ibgp_paths: {{ vrf['max_ibgp_paths'] | default(defaults.vxlan.multisite.overlay.vrfs.max_ibgp_paths) }}
   ipv6_linklocal_enable: {{ vrf['ipv6_linklocal_enable'] | default(defaults.vxlan.multisite.overlay.vrfs.ipv6_linklocal_enable) }}
   disable_rt_auto: {{ vrf['disable_rt_auto'] | default(defaults.vxlan.multisite.overlay.vrfs.disable_rt_auto) }}
-  export_evpn_rt: {{ vrf['export_evpn_rt'] | default(omit) }}
-  export_vpn_rt: {{ vrf['export_vpn_rt'] | default(omit) }}
-  import_evpn_rt: {{ vrf['import_evpn_rt'] | default(omit) }}
-  import_vpn_rt: {{ vrf['import_vpn_rt'] | default(omit) }}
+  export_evpn_rt: "{{ vrf['export_evpn_rt'] | default(omit) }}"
+  export_vpn_rt: "{{ vrf['export_vpn_rt'] | default(omit) }}"
+  import_evpn_rt: "{{ vrf['import_evpn_rt'] | default(omit) }}"
+  import_vpn_rt: "{{ vrf['import_vpn_rt'] | default(omit) }}"
   redist_direct_rmap: {{ vrf['redist_direct_routemap'] | default(defaults.vxlan.multisite.overlay.vrfs.redist_direct_routemap) }}
 {% if (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=')) %}
   v6_redist_direct_rmap: {{ vrf['ipv6_redist_direct_routemap'] | default(defaults.vxlan.multisite.overlay.vrfs.ipv6_redist_direct_routemap) }}


### PR DESCRIPTION
Currently YAML conversion is happening in the framework rendering when the inuput of the _rt fields in VRF is of a time like format i.e. xx:xx the yaml parses it as a base 60 number

If you pass into the VRF config:

export_evpn_rt: 11:11,
import_evpn_rt: 12:12

It gets applied to NDFC as 

"export_evpn_rt": 732,
"import_evpn_rt": 671.

## Related Issue(s)
not raised


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [x ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Quoting the jinja template fields for _rt so that it treats it like a string and doesn't convert to base 60 int.

## Test Notes
<!--- Please provide notes or description of testing -->
Changed the jinja to a quoted string and the rendered data is now of the correct format and updated in NDFC

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->
3.2

## Checklist

* [ x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [x ] Assigned the proper reviewers
