### PR TITLE
Validate data without removing duplicates

### DIFF
--- a/plugins/action/common/nac_dc_validate.py
+++ b/plugins/action/common/nac_dc_validate.py
@@ -92,7 +92,7 @@ class ActionModule(ActionBase):
         if rules and task_vars['role_path'] in rules:
             # Load in-memory data model using iac-validate
             # Perform the load in this if block to avoid loading the data model multiple times when custom enhanced rules are provided
-            results['data'] = load_yaml_files([mdata])
+            results['data'] = load_yaml_files([mdata], deduplicate=False)
 
             # Introduce common directory to the rules list by default once vrf and network rules are updated
             parent_keys = ['vxlan', 'fabric']
@@ -158,6 +158,7 @@ class ActionModule(ActionBase):
 
         for rules_item in rules_list:
             validator = nac_validate.validator.Validator(schema, rules_item)
+            validator.data = results['data']
             if schema:
                 validator.validate_syntax([mdata])
             if rules_item:


### PR DESCRIPTION
## Related Issue(s)
Fixes #729

## Related Collection Role
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Validate data without the deduplicate function so that validation rules detect even identical duplicates. Fix issue in this collection action plugin, i.e. without changing nac_yaml/yaml.py or nac_validate/validator.py.

1. Call load_yaml_files(input_paths) with deduplicate=False.
2. Inject the pre-loaded data into the Validator instance.

Explanation:

nac_dc_validate.py does not set validator.data before calling validate_semantics(). So validator.data is None, and line 128 in validator.py will call load_yaml_files(input_paths) with the default deduplicate=True. This means deduplicate=False in line 95 of nac_dc_validate.py only affects results['data'], it does not affect the data that rule 304 sees.

Currently the nac_dc_validate.py action plugin does not inject its pre-loaded data into the Validator instance. The Validator.validate_semantics() method loads its own copy via load_yaml_files(input_paths) with deduplicate=True hardcoded. There's no parameter or setter to override this. This could be fix within nac_dc_validate.py (no nac_yaml/nac_validate changes) by pre-loading the data and injecting it into the validator before calling validate_semantics as proposed.


## Test Notes
The following identical duplicate interface is detected by rule 304:
````
---
vxlan:
  topology:
    switches:
      - name: N9Kv-LEAF1
        role: leaf
        serial_number: 9PO5E6ROVPQ
        management:
          management_ipv4_address: 10.0.90.71
          default_gateway_v4: 10.0.90.1
        interfaces:
          - name: Ethernet1/1
            mode: access
            access_vlan: 100
          - name: Ethernet1/1
            mode: access
            access_vlan: 100
````

## Cisco Nexus Dashboard Version
3.2(1i)

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers* [ ] 