### PR TITLE
Fix undefined MD_Extended variable in edge_connections template

### DIFF
--- a/roles/dtc/common/templates/ndfc_edge_connections.j2
+++ b/roles/dtc/common/templates/ndfc_edge_connections.j2
@@ -19,7 +19,7 @@
           policy_vars:
             BGP_PASSWORD: "{{ link.bgp_section.bgp_password | default('') }}"
             BGP_PASSWORD_ENABLE: {{ link.bgp_section.bgp_password_enable | default(defaults.vxlan.topology.edge_connections.bgp_section.bgp_password_enable) }}
-            TEMPLATE_NAME: {{ MD_Extended.vxlan.fabric.name + '-' + link.dest_fabric + '-IPV4-EBGP' }}
+            TEMPLATE_NAME: {{ data_model_extended.vxlan.fabric.name + '-' + link.dest_fabric + '-IPV4-EBGP' }}
             NEIGHBOR_ASN: "{{ link.bgp_section.neighbor_asn }}"
             OVERRIDE_LOCAL_ASN: false
             CONF: |2-


### PR DESCRIPTION
## Related Issue(s)
Regression introduced by #646

## Related Collection Role
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [x] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
PR #646 ("adding mtu support for edge_connections") reintroduced the old variable name `MD_Extended` on line 22 of `ndfc_edge_connections.j2`. This variable was renamed to `data_model_extended` in commit 108c81b to comply with ansible-lint `var-naming` rules.

This single stale reference causes deploy failures for edge_connections with BGP (e.g. L3_WAN workflow) because `MD_Extended` is undefined.

The fix replaces `MD_Extended` with `data_model_extended` on the affected line.

## Test Notes
- Verified all other references in the template already use `data_model_extended`
- This is a one-line variable rename fix, no functional change beyond restoring the correct variable name

## Cisco Nexus Dashboard Version
N/A - template variable fix only

## Checklist
* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers