### PR TITLE
Adding qos policies to routed interface templates

### DIFF
--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_po_routed.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_po_routed.j2
@@ -31,6 +31,11 @@
     speed: {{ interface['speed'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.speed) }}
     pc_mode: "{{ interface['pc_mode'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.pc_mode) }}"
     members: {{ interface['members'] | default(omit) }}
+    enable_qos: {{ interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_qos) | lower }}
+{% if interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_qos) %}
+    qos_policy: {{ interface['qos_policy'] | default("") }}
+    queuing_policy: {{ interface['queuing_policy'] | default("") }}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_po_routed.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_po_routed.j2
@@ -31,8 +31,8 @@
     speed: {{ interface['speed'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.speed) }}
     pc_mode: "{{ interface['pc_mode'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.pc_mode) }}"
     members: {{ interface['members'] | default(omit) }}
-    enable_qos: {{ interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_qos) | lower }}
-{% if interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_qos) %}
+    enable_qos: {{ interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.enable_qos) | lower }}
+{% if interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.enable_qos) %}
     qos_policy: {{ interface['qos_policy'] | default("") }}
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_routed.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_routed.j2
@@ -34,6 +34,11 @@
     int_vrf: {{ interface['vrf'] | default(omit) }}
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.mtu) }}
     speed: {{ interface['speed'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.speed) }}
+    enable_qos: {{ interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_qos) | lower }}
+{% if interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_qos) %}
+    qos_policy: {{ interface['qos_policy'] | default("") }}
+    queuing_policy: {{ interface['queuing_policy'] | default("") }}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_routed.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_routed.j2
@@ -34,8 +34,8 @@
     int_vrf: {{ interface['vrf'] | default(omit) }}
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.mtu) }}
     speed: {{ interface['speed'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.speed) }}
-    enable_qos: {{ interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_qos) | lower }}
-{% if interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_qos) %}
+    enable_qos: {{ interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.enable_qos) | lower }}
+{% if interface['enable_qos'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.enable_qos) %}
     qos_policy: {{ interface['qos_policy'] | default("") }}
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -197,8 +197,8 @@ factory_defaults:
             enable_lacp_vpc_convergence: false
             lacp_port_priority: 32768
             lacp_rate: normal
-            monitor: false
             enable_qos: false
+            monitor: false
           topology_switch_trunk_po_interface:
             description: "NetAsCode Trunk PO Interface"
             mtu: jumbo
@@ -215,8 +215,8 @@ factory_defaults:
             enable_lacp_vpc_convergence: false
             lacp_port_priority: 32768
             lacp_rate: normal
-            monitor: false
             enable_qos: false
+            monitor: false
           topology_switch_dot1q_interface:
             description: "NetAsCode Dot1q Interface"
             mtu: jumbo
@@ -232,6 +232,7 @@ factory_defaults:
             mtu: 9216
             speed: auto
             enabled: true
+            enable_qos: false
           topology_switch_routed_sub_interface:
             description: "NetAsCode Routed Sub Interface"
             mtu: 9216
@@ -243,6 +244,7 @@ factory_defaults:
             speed: auto
             enabled: true
             pc_mode: active
+            enable_qos: false
           topology_switch_loopback_interface:
             description: "NetAsCode Loopback Interface"
             enabled: true


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
Fixes #750 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [X] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Adding qos and queuing policies under routed ports (port-channel and interface, subinterfaces is not supported on the base collection)


## Test Notes
Tested on iBGP VXLAN


## Cisco Nexus Dashboard Version
4.1


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
