### PR TITLE
eBGP ND 4.2 BGP ASN Auto Allocation

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
@@ -4,6 +4,9 @@
   BGP_AS_MODE: "{{ vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) }}"
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Multi-AS' %}
   ALLOW_LEAF_SAME_AS: "{{ vxlan.global.ebgp.leaf_same_bgp_asn | default(defaults.vxlan.global.ebgp.leaf_same_bgp_asn) | lower }}"
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=') %}
+  bgpAsnAutoAllocation: "{{ vxlan.global.ebgp.bgp_asn_auto_allocation | default(defaults.vxlan.global.ebgp.bgp_asn_auto_allocation) | lower }}"
+{% endif %}
 {% endif %}
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Same-Tier-AS' %}
   LEAF_BGP_AS: "{{ vxlan.global.ebgp.leaf_bgp_asn | default(omit) }}"

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -26,6 +26,7 @@ factory_defaults:
       ebgp:
         bgp_asn_mode: Multi-AS
         leaf_same_bgp_asn: false
+        bgp_asn_auto_allocation: true
         anycast_gateway_mac: 20:20:00:00:00:aa
         auth_proto: MD5
         enable_nxapi_http: false


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->
Fixes #749

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [x] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [x] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Add 'bgp_asn_auto_allocation' parameter to support eBGP fabric  ND 4.2.
```
---
vxlan:
  global:
    ebgp:
      bgp_asn_auto_allocation: false
```

## Test Notes
<!--- Please provide notes or description of testing -->
Fabric type: eBGP_VXLAN

ND 3.2
1. bgp_asn_mode: Multi-AS, leaf_same_bgp_asn: True, bgp_asn_auto_allocation: True - ok, backward compatible, new parameter ignored

ND 4.2
1. bgp_asn_mode: Multi-AS, leaf_same_bgp_asn: True, bgp_asn_auto_allocation: False - ok, fabric created without ASN auto allocation
2. bgp_asn_mode: Multi-AS, leaf_same_bgp_asn: False, bgp_asn_auto_allocation: True - ok, fabric created with ASN auto allocation
3. bgp_asn_mode: Same-Tier-AS, leaf_same_bgp_asn: False, bgp_asn_auto_allocation: True - ok, fabric created, new parameter ignored

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->
3.2.1
4.2.1

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
