### PR TITLE
fix: ND 4.2 / NDFC 12.5 compatibility - null interfaces and empty overridden config

### DIFF
--- a/plugins/action/common/prepare_plugins/prep_106_topology_interfaces.py
+++ b/plugins/action/common/prepare_plugins/prep_106_topology_interfaces.py
@@ -66,7 +66,7 @@ class PreparePlugin:
 
         for switch in data_model.get('vxlan').get('topology').get('switches'):
             # loop through interfaces
-            for interface in switch.get('interfaces'):
+            for interface in (switch.get('interfaces') or []):
                 # loop through interface modes direct and count
                 for interface_mode in self.mode_direct:
                     # if interface mode is a direct match, then increment the count for that mode

--- a/roles/dtc/remove/tasks/common/interfaces.yml
+++ b/roles/dtc/remove/tasks/common/interfaces.yml
@@ -97,6 +97,7 @@
   register: int_data
   when:
     - switch_list.response.DATA | length > 0
+    - vars_common_local.interface_all_remove_overridden | length > 0
     - (interface_delete_mode is defined) and (interface_delete_mode is true|bool)
     - run_map_read_result.diff_run is false|bool or force_run_all is true|bool
 


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [x] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Fix 1 — `prep_106_topology_interfaces.py`: null `interfaces` field

**File:** `plugins/action/common/prepare_plugins/prep_106_topology_interfaces.py`

### Root Cause
In ND 4.2 / NDFC 12.5, the `switchesByFabric` API now returns `null` for the `interfaces` field on switches in **ISN** and **External** fabric types, instead of returning an empty list `[]` as in previous versions.

The prepare plugin iterated directly over this value:
\`\`\`python
Before (crashes when interfaces is null)
for interface in switch.get('interfaces'):
\`\`\`

Iterating over `None` raises `'NoneType' object is not subscriptable`.

Fix
Coerce `null` to an empty list using `or []`:

\`\`\`python
After (safe for null and empty list)
for interface in (switch.get('interfaces') or []):
\`\`\`

---

Fix 2 — `roles/dtc/remove/tasks/common/interfaces.yml`: empty config crashes `cisco.dcnm.dcnm_interface`
**File:** `roles/dtc/remove/tasks/common/interfaces.yml`

### Root Cause
The **Remove Unmanaged Fabric Interfaces** task calls `cisco.dcnm.dcnm_interface` with `state: overridden` and `config: "{{ vars_common_local.interface_all_remove_overridden }}"`. For ISN and External fabrics, this list is always empty (`[]`).

On ND 4.2, the `cisco.dcnm.dcnm_interface` module crashes with `'NoneType' object is not subscriptable` when called with `state: overridden` and an empty `config` list. This is a bug in the upstream `cisco.dcnm` collection against the ND 4.2 API, but can be guarded against on our side.

### Fix
Add a length guard so the task is skipped entirely when there are no interfaces to override:

\`\`\`yaml
Added condition:
- vars_common_local.interface_all_remove_overridden | length > 0
\`\`\`

This prevents `dcnm_interface` from being called with an empty list, which is a no-op anyway.

## Error messages before this fix
TASK [cisco.nac_dc_vxlan.remove : Remove Unmanaged Fabric Interfaces in Nexus Dashboard - Diff Run Feature Disabled] ***
Friday 20 March 2026  18:56:23 +0000 (0:00:00.047)       0:03:21.507 ********** 
Friday 20 March 2026  18:56:23 +0000 (0:00:00.047)       0:03:21.507 ********** 
fatal: [nac-isn1]: FAILED! => {"changed": false, "module_stderr": "'NoneType' object is not subscriptable", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error"}

## Test Notes
<!--- Please provide notes or description of testing -->
ISN and External fabics deployed successfully in pipeline

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->
**ND Version:** 4.2.1.10
**NDFC Version:** 12.5.0.475

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
