### PR TITLE
fixing indentation on ibgp spine and leaf templates

### DIFF
--- a/plugins/filter/dedent.py
+++ b/plugins/filter/dedent.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+DOCUMENTATION = r"""
+  name: dedent
+  version_added: "0.8.0"
+  short_description: Remove common leading whitespace from text
+  description:
+    - Remove common leading whitespace from every line in the input text.
+    - Useful for normalizing multiline strings defined with YAML block scalars (|2, |, etc.).
+  positional: text
+  options:
+    text:
+      description: The text to dedent.
+      type: str
+      required: true
+"""
+
+EXAMPLES = r"""
+
+# Basic usage - remove common leading whitespace
+dedented_text: "{{ my_multiline_var | cisco.nac_dc_vxlan.dedent }}"
+
+# Combine with indent to normalize and re-indent
+normalized_config: "{{ ibgp_template | cisco.nac_dc_vxlan.dedent | indent(6, true) }}"
+"""
+
+RETURN = r"""
+  _value:
+    description:
+      - The dedented string with common leading whitespace removed.
+    type: str
+"""
+
+import textwrap
+
+from ansible.module_utils.six import string_types
+from ansible.errors import AnsibleFilterError, AnsibleFilterTypeError
+from ansible.module_utils.common.text.converters import to_native
+from jinja2.runtime import Undefined
+from jinja2.exceptions import UndefinedError
+
+
+def dedent(text):
+    """
+    Remove common leading whitespace from every line in text.
+    Args:
+        text (str): The text string to dedent.
+    Returns:
+        str: The dedented text.
+    Raises:
+        AnsibleFilterTypeError: If the text argument is not a string.
+        AnsibleFilterError: If the dedent operation fails.
+    """
+    if isinstance(text, Undefined):
+        return text
+
+    if text is None:
+        return ""
+
+    if not isinstance(text, string_types):
+        raise AnsibleFilterTypeError(f"dedent requires a string, got: {type(text)}")
+
+    if not text:
+        return text
+
+    try:
+        return textwrap.dedent(text)
+    except UndefinedError:
+        raise
+    except Exception as e:
+        raise AnsibleFilterError("Unable to dedent text: %s" % to_native(e), orig_exc=e)
+
+
+# ---- Ansible filters ----
+class FilterModule(object):
+    """ Dedent filter - remove common leading whitespace """
+
+    def filters(self):
+        return {
+            "dedent": dedent
+        }

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
@@ -66,6 +66,6 @@
 {% endif %}
 {% endif %}
   IBGP_PEER_TEMPLATE: |2
-    {{ vxlan.global.ibgp.spine_ibgp_peer_template_freeform | default("") | indent(4, false) }}
+      {{ vxlan.global.ibgp.spine_ibgp_peer_template_freeform | default("") | indent(6, false) }}
   IBGP_PEER_TEMPLATE_LEAF: |2
-    {{ vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | default("") | indent(4, false) }}
+      {{ vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | default("") | indent(6, false) }}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
@@ -65,7 +65,11 @@
 {% endif %}
 {% endif %}
 {% endif %}
+{% if vxlan.global.ibgp.spine_ibgp_peer_template_freeform | default("") | trim %}
   IBGP_PEER_TEMPLATE: |2
-      {{ vxlan.global.ibgp.spine_ibgp_peer_template_freeform | default("") | indent(6, false) }}
+{{ vxlan.global.ibgp.spine_ibgp_peer_template_freeform | cisco.nac_dc_vxlan.dedent | indent(6, true) }}
+{% endif %}
+{% if vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | default("") | trim %}
   IBGP_PEER_TEMPLATE_LEAF: |2
-      {{ vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | default("") | indent(6, false) }}
+{{ vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | cisco.nac_dc_vxlan.dedent | indent(6, true) }}
+{% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
@@ -68,8 +68,13 @@
 {% if vxlan.global.ibgp.spine_ibgp_peer_template_freeform | default("") | trim %}
   IBGP_PEER_TEMPLATE: |2
 {{ vxlan.global.ibgp.spine_ibgp_peer_template_freeform | cisco.nac_dc_vxlan.dedent | indent(6, true) }}
+{% else %}
+  IBGP_PEER_TEMPLATE: ""
 {% endif %}
 {% if vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | default("") | trim %}
   IBGP_PEER_TEMPLATE_LEAF: |2
 {{ vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | cisco.nac_dc_vxlan.dedent | indent(6, true) }}
+{% else %}
+  IBGP_PEER_TEMPLATE_LEAF: ""
 {% endif %}
+  INBAND_MGMT_PREV: False

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
@@ -77,4 +77,3 @@
 {% else %}
   IBGP_PEER_TEMPLATE_LEAF: ""
 {% endif %}
-  INBAND_MGMT_PREV: False


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #758 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [X] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Fixing indentation on template, per error descripton:

iBGP peer template: bgp peer template command must have 2 leading spaces. Please fix spacing problem: template peer LEAVES. iBGP peer template: bgp peer template sub-command must have 4 or 6 leading spaces


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
4.1.1g


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
