### PR TITLE
Msite cross reference child switches

### DIFF
--- a/roles/validate/files/rules/multisite/206_topology_switches_cross_reference.py
+++ b/roles/validate/files/rules/multisite/206_topology_switches_cross_reference.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from json import load
+
+
+class Rule:
+    id = "206"
+    description = "Cross check child fabric topology switches"
+    severity = "HIGH"
+
+    msg = "{0}"
+
+    @classmethod
+    def match(cls, data_model):
+        results = []
+
+        child_fabrics_switches = []
+        vrf_attach_group_switches = []
+        net_attach_group_switches = []
+
+        validate_files_path = Path(__file__).parents[2]
+
+        multisite_child_fabric_keys = ['vxlan', 'multisite', 'child_fabrics']
+        check = cls.data_model_key_check(data_model, multisite_child_fabric_keys)
+        if 'child_fabrics' in check['keys_found'] and 'child_fabrics' in check['keys_data']:
+            dm_child_fabrics = cls.safeget(data_model, multisite_child_fabric_keys)
+            for child_fabric in dm_child_fabrics:
+                service_model_filename = f"{child_fabric['name']}_service_model_golden.json"
+                service_model_path = validate_files_path / service_model_filename
+                try:
+                    with open(service_model_path, "r") as service_model_file:
+                        service_model = load(service_model_file)
+                except FileNotFoundError:
+                    results.append(cls.msg.format(f"{service_model_filename} file not found. Run role_validate against the child fabrics."))
+                else:
+                    child_fabrics_switches.extend(switch['name'] for switch in service_model.get('vxlan', {}).get('topology', {}).get('switches', []))
+
+        multisite_vrf_attach_group_keys = ['vxlan', 'multisite', 'overlay', 'vrf_attach_groups']
+        check = cls.data_model_key_check(data_model, multisite_vrf_attach_group_keys)
+        if 'vrf_attach_groups' in check['keys_found'] and 'vrf_attach_groups' in check['keys_data']:
+            dm_msite_vrf_attach_groups = cls.safeget(data_model, multisite_vrf_attach_group_keys)
+            for attach_group in dm_msite_vrf_attach_groups:
+                vrf_attach_group_switches.extend(switch['hostname'] for switch in attach_group['switches'])
+            for vag_switch in vrf_attach_group_switches:
+                if vag_switch not in child_fabrics_switches:
+                    results.append(cls.msg.format(f"{vag_switch} not pressent in child fabrics topology switches."))
+
+        multisite_net_attach_group_keys = ['vxlan', 'multisite', 'overlay', 'network_attach_groups']
+        check = cls.data_model_key_check(data_model, multisite_net_attach_group_keys)
+        if 'network_attach_groups' in check['keys_found'] and 'network_attach_groups' in check['keys_data']:
+            dm_msite_net_attach_groups = cls.safeget(data_model, multisite_net_attach_group_keys)
+            for attach_group in dm_msite_net_attach_groups:
+                net_attach_group_switches.extend(switch['hostname'] for switch in attach_group['switches'])
+            for nag_switch in net_attach_group_switches:
+                if nag_switch not in child_fabrics_switches:
+                    results.append(cls.msg.format(f"{nag_switch} not pressent in child fabrics topology switches."))
+
+        return results
+
+    @classmethod
+    def data_model_key_check(cls, tested_object, keys):
+        dm_key_dict = {'keys_found': [], 'keys_not_found': [], 'keys_data': [], 'keys_no_data': []}
+        for key in keys:
+            if tested_object and key in tested_object:
+                dm_key_dict['keys_found'].append(key)
+                tested_object = tested_object[key]
+                if tested_object:
+                    dm_key_dict['keys_data'].append(key)
+                else:
+                    dm_key_dict['keys_no_data'].append(key)
+            else:
+                dm_key_dict['keys_not_found'].append(key)
+        return dm_key_dict
+
+    @classmethod
+    def safeget(cls, dict, keys):
+        # Utility function to safely get nested dictionary values
+        for key in keys:
+            if dict is None:
+                return None
+            if key in dict:
+                dict = dict[key]
+            else:
+                return None
+
+        return dict

--- a/roles/validate/files/rules/multisite/301_multisite_no_cluster.py
+++ b/roles/validate/files/rules/multisite/301_multisite_no_cluster.py
@@ -1,0 +1,48 @@
+class Rule:
+    id = "301"
+    description = "Verify multisite fabric does not reference clusters"
+    severity = "LOW"
+
+    msg = "{0} multisite child fabric should not reference clusters"
+
+    @classmethod
+    def match(cls, data_model):
+        results = []
+
+        multisite_child_fabric_keys = ['vxlan', 'multisite', 'child_fabrics']
+        check = cls.data_model_key_check(data_model, multisite_child_fabric_keys)
+        if 'child_fabrics' in check['keys_found'] and 'child_fabrics' in check['keys_data']:
+            dm_child_fabrics = cls.safeget(data_model, multisite_child_fabric_keys)
+            for child_fabric in dm_child_fabrics:
+                if child_fabric.get('cluster', False):
+                    results.append(cls.msg.format(child_fabric['name']))
+
+        return results
+
+    @classmethod
+    def data_model_key_check(cls, tested_object, keys):
+        dm_key_dict = {'keys_found': [], 'keys_not_found': [], 'keys_data': [], 'keys_no_data': []}
+        for key in keys:
+            if tested_object and key in tested_object:
+                dm_key_dict['keys_found'].append(key)
+                tested_object = tested_object[key]
+                if tested_object:
+                    dm_key_dict['keys_data'].append(key)
+                else:
+                    dm_key_dict['keys_no_data'].append(key)
+            else:
+                dm_key_dict['keys_not_found'].append(key)
+        return dm_key_dict
+
+    @classmethod
+    def safeget(cls, dict, keys):
+        # Utility function to safely get nested dictionary values
+        for key in keys:
+            if dict is None:
+                return None
+            if key in dict:
+                dict = dict[key]
+            else:
+                return None
+
+        return dict

--- a/roles/validate/files/rules/multisite/301_multisite_no_cluster.py
+++ b/roles/validate/files/rules/multisite/301_multisite_no_cluster.py
@@ -1,6 +1,6 @@
 class Rule:
     id = "301"
-    description = "Verify multisite fabric does not reference clusters"
+    description = "Verify MSD fabric does not reference clusters"
     severity = "LOW"
 
     msg = "{0} multisite child fabric should not reference clusters"
@@ -9,12 +9,20 @@ class Rule:
     def match(cls, data_model):
         results = []
 
+        fabric_type = ''
+
+        vxlan_fabric_keys = ['vxlan', 'fabric']
+        check = cls.data_model_key_check(data_model, vxlan_fabric_keys)
+        if 'fabric' in check['keys_found'] and 'fabric' in check['keys_data']:
+            dm_fabric = cls.safeget(data_model, vxlan_fabric_keys)
+            fabric_type = dm_fabric.get('type', '')
+
         multisite_child_fabric_keys = ['vxlan', 'multisite', 'child_fabrics']
         check = cls.data_model_key_check(data_model, multisite_child_fabric_keys)
         if 'child_fabrics' in check['keys_found'] and 'child_fabrics' in check['keys_data']:
             dm_child_fabrics = cls.safeget(data_model, multisite_child_fabric_keys)
             for child_fabric in dm_child_fabrics:
-                if child_fabric.get('cluster', False):
+                if fabric_type == 'MSD' and child_fabric.get('cluster', False):
                     results.append(cls.msg.format(child_fabric['name']))
 
         return results


### PR DESCRIPTION
## Related Issue(s)
Fix #762 
Fix #763 

## Related Collection Role
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
* Add a new rule that will validate that the switches referenced under msite VRF or NET attach groups have been defined in the child fabrics topology.
* Add a new rule that verifies that the `cluster` key is not being used under a child fabric definition if the fabric type is MSD.


## Test Notes
* Ran local tests in my laptop to verify that the new rules notify the user with a proper error message.


## Cisco Nexus Dashboard Version
* ND 4.1


## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
