### PR TITLE
Remove PTP VLAN ID for eBGP fabric type

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/advanced/ebgp_vxlan_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/advanced/ebgp_vxlan_fabric_advanced.j2
@@ -22,8 +22,5 @@
 {% if vxlan.global.ebgp.ptp.enable is defined and vxlan.global.ebgp.ptp.enable | ansible.builtin.bool %}
   PTP_DOMAIN_ID: {{ vxlan.global.ebgp.ptp.domain_id | default(defaults.vxlan.global.ebgp.ptp.domain_id) }}
   PTP_LB_ID: {{ vxlan.global.ebgp.ptp.lb_id | default(defaults.vxlan.global.ebgp.ptp.lb_id) }}
-{% if vxlan.global.ebgp.ptp.vlan_id is defined %}
-  PTP_VLAN_ID: {{ vxlan.global.ebgp.ptp.vlan_id }}
-{% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->
Fixes #767 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [x] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Remove ptp_vlan_id parameter from template. It is not supported for eBGP fabric type.

## Test Notes
<!--- Please provide notes or description of testing -->
ptp.vlan_id parameter is ignored.

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->
3.2.1
4.2.1

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
