### PR TITLE
Diff Run Fixes

### DIFF
--- a/plugins/action/dtc/remove_resources.py
+++ b/plugins/action/dtc/remove_resources.py
@@ -171,9 +171,20 @@ class ResourceRemover(PipelineRunnerBase):
         default_state = step.get('state')
         full_run_state = step.get('state_full_run')
         data_key_full_run = step.get('data_key_full_run', 'data')
+        full_run_override_key = step.get('data_key_overridden')
 
         if not isinstance(resource_entry, dict):
             return (resource_entry if resource_entry else [], default_state)
+
+        # Some remove steps are intentionally always full-reconciliation and
+        # never diff-narrowed (for example switch inventory removal, which
+        # always uses state=overridden in the original role).
+        if default_state == 'overridden':
+            data_key = full_run_override_key or data_key_full_run
+            if data_key == 'data' and 'module_data' in resource_entry:
+                data_key = 'module_data'
+            data = resource_entry.get(data_key, [])
+            return (data, default_state)
 
         # Diff-based run: use diff.removed with default state (deleted)
         if self.run_map_diff_run and not self.force_run_all:
@@ -204,12 +215,19 @@ class ResourceRemover(PipelineRunnerBase):
         # Full run with overridden strategy: send full data with state overridden
         # for full reconciliation against the controller.
         if full_run_strategy == 'overridden':
-            data_key = step.get('data_key_overridden', 'data')
+            data_key = (
+                full_run_override_key
+                or step.get('data_key_full_run')
+                or ('data_remove_overridden' if 'data_remove_overridden' in resource_entry else None)
+                or ('module_data' if 'module_data' in resource_entry else 'data')
+            )
             data = resource_entry.get(data_key, [])
             return (data, 'overridden')
 
         # Full run (legacy): use full data with full_run_state if declared
         resolved_state = full_run_state if full_run_state else default_state
+        if data_key_full_run == 'data' and 'module_data' in resource_entry:
+            data_key_full_run = 'module_data'
         data = resource_entry.get(data_key_full_run, [])
         return (data, resolved_state)
 

--- a/resources/create_resources.yml
+++ b/resources/create_resources.yml
@@ -225,8 +225,8 @@ create_resources:
       state: merged
       deploy: false
       data_model_guard: 
-        - vxlan.policy.switches
-        - vxlan.topology.policies
+        - vxlan.topology.switches
+        - vxlan.policy
       change_flag_guard: changes_detected_policy
       tag: cr_manage_policy
 
@@ -362,8 +362,8 @@ create_resources:
       state: merged
       deploy: false
       data_model_guard: 
-        - vxlan.policy.switches
-        - vxlan.topology.policies
+        - vxlan.topology.switches
+        - vxlan.policy
       change_flag_guard: changes_detected_policy
       tag: cr_manage_policy
 
@@ -421,7 +421,9 @@ create_resources:
       module: dcnm_policy
       state: merged
       deploy: false
-      data_model_guard: vxlan.policy.switches
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy
       change_flag_guard: changes_detected_policy
       tag: cr_manage_policy
 
@@ -513,7 +515,9 @@ create_resources:
       module: dcnm_policy
       state: merged
       deploy: false
-      data_model_guard: vxlan.policy.switches
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy
       change_flag_guard: changes_detected_policy
       tag: cr_manage_policy
 

--- a/resources/create_resources.yml
+++ b/resources/create_resources.yml
@@ -186,6 +186,7 @@ create_resources:
       module: dcnm_policy
       state: merged
       deploy: false
+      data_model_guard: vxlan.policy.switches
       change_flag_guard: changes_detected_policy
       tag: cr_manage_policy
 
@@ -308,6 +309,7 @@ create_resources:
       module: dcnm_policy
       state: merged
       deploy: false
+      data_model_guard: vxlan.policy.switches
       change_flag_guard: changes_detected_policy
       tag: cr_manage_policy
 
@@ -363,6 +365,7 @@ create_resources:
       module: dcnm_policy
       state: merged
       deploy: false
+      data_model_guard: vxlan.policy.switches
       change_flag_guard: changes_detected_policy
       tag: cr_manage_policy
 
@@ -449,6 +452,7 @@ create_resources:
       module: dcnm_policy
       state: merged
       deploy: false
+      data_model_guard: vxlan.policy.switches
       change_flag_guard: changes_detected_policy
       tag: cr_manage_policy
 

--- a/resources/remove_resources.yml
+++ b/resources/remove_resources.yml
@@ -119,9 +119,10 @@ remove_resources:
       tag: rr_manage_tor_pairing
 
     # Switches always use overridden (no diff_run branching)
-    - resource_name: inventory
+    - resource_name: inventory_no_bootstrap
       module: dcnm_inventory
       state: overridden
+      data_key_full_run: module_data
       change_flag_guard: changes_detected_inventory
       delete_mode_guard: inventory_delete_mode
       tag: rr_manage_switches
@@ -219,9 +220,10 @@ remove_resources:
       requires_switches: true
       tag: rr_manage_interfaces
 
-    - resource_name: inventory
+    - resource_name: inventory_no_bootstrap
       module: dcnm_inventory
       state: overridden
+      data_key_full_run: module_data
       change_flag_guard: changes_detected_inventory
       delete_mode_guard: inventory_delete_mode
       tag: rr_manage_switches
@@ -264,9 +266,10 @@ remove_resources:
       fabric_param: src_fabric
       tag: rr_manage_vpc_peers
 
-    - resource_name: inventory
+    - resource_name: inventory_no_bootstrap
       module: dcnm_inventory
       state: overridden
+      data_key_full_run: module_data
       change_flag_guard: changes_detected_inventory
       delete_mode_guard: inventory_delete_mode
       tag: rr_manage_switches

--- a/resources/remove_resources.yml
+++ b/resources/remove_resources.yml
@@ -184,9 +184,10 @@ remove_resources:
   #     skip_if_child_fabric: true
   #     tag: rr_manage_vrfs
 
-  #   - resource_name: inventory
+  #   - resource_name: inventory_no_bootstrap
   #     module: dcnm_inventory
   #     state: overridden
+  #     data_key_full_run: module_data
   #     change_flag_guard: changes_detected_inventory
   #     delete_mode_guard: inventory_delete_mode
   #     tag: rr_manage_switches

--- a/roles/dtc/common/templates/ndfc_policy.j2
+++ b/roles/dtc/common/templates/ndfc_policy.j2
@@ -2,7 +2,10 @@
 # This NDFC policy and switch attachments config data structure is auto-generated
 # DO NOT EDIT MANUALLY
 #
-{% if data_model_extended.vxlan.policy.policies | default([]) | length > 0 %}
+{% if
+  data_model_extended.vxlan.policy.policies | default([]) | length > 0
+  and data_model_extended.vxlan.policy.switches | default([]) | length > 0
+%}
 - switch:
 {% for switch in data_model_extended.vxlan.policy.switches %}
     - ip: {{ switch.mgmt_ip_address }}

--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -54,7 +54,7 @@
     data_model: "{{ data_model_extended }}"
     resource_data: "{{ resource_data }}"
     change_flags: "{{ change_flags }}"
-    diff_run: "{{ run_map_read_result.diff_run }}"
+    run_map_diff_run: "{{ run_map_read_result.diff_run }}"
     force_run_all: "{{ force_run_all | default(false) }}"
   register: remove_result
   when: change_flags.changes_detected_any


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Summary

This PR fixes two issues in the consolidated DTC pipeline:

- targeted remove behavior could resolve the wrong payload when `force_run_all: false`, which caused incorrect switch removals in the inventory delete path
- policy create could fail when `vxlan.policy.switches` was an empty list, which blocked the later remove phase from cleaning up unmanaged policies

## Fixes

### 1. Correct remove diff-run parameter wiring

The remove role was passing `diff_run`, while the consolidated remove pipeline expects `run_map_diff_run`.

This change aligns the role input with the pipeline contract so targeted/full remove behavior follows the run-map decision correctly.

Files:
- `collections/ansible_collections/cisco/nac_dc_vxlan/roles/dtc/remove/tasks/main.yml`

### 2. Fix targeted switch removal when `inventory_delete_mode: true`

In the remove pipeline, switch inventory removal was incorrectly resolving to an empty payload during targeted runs. Because the inventory step uses `state: overridden`, that empty payload could be interpreted as "desired switch inventory is empty", which caused switches to be removed from the fabric.

This change updates the switch remove step to use the credential-enriched `inventory_no_bootstrap` payload and fixes the resolver so overridden/full-reconciliation paths use full resource data instead of `diff.removed`.

Files:
- `collections/ansible_collections/cisco/nac_dc_vxlan/resources/remove_resources.yml`
- `collections/ansible_collections/cisco/nac_dc_vxlan/plugins/action/dtc/remove_resources.py`

### 3. Fix policy create failure when `vxlan.policy.switches: []`

When the policy model contained policy definitions/groups but an empty `switches` list, the policy template rendered an invalid payload:

```yaml
- switch:
```
This change makes policy create skip cleanly when there are no policy switch attachments, while still allowing the remove-side unmanaged-policy logic to run and clean up previously attached policies.


## Behavior After Fix
  * force_run_all: false now preserves targeted remove behavior without incorrectly deleting switches from inventory
an empty vxlan.policy.switches list no longer causes CREATE policy to fail
  * CREATE policy is skipped when there are no switch attachments
  * REMOVE policy can still run afterward to remove unmanaged nac_ policies from switches

