### PR TITLE
Add 'env_var_' prefix option for handling secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,17 +297,26 @@ export NDFC_SW_USERNAME=admin
 export NDFC_SW_PASSWORD=Admin_123
 ```
 
+#### Handling Secrets
+
+This collection supports two options to securely handle secrets in the NaC VXLAN data model such as passwords and authentication keys:
+
+* **🔐 Ansible Vault**: Encrypts credentials
+* **✅ Environment Variables**: Resolves secrets from environment variables
+
+**📖 Guide**: [Handling Secrets Guide](docs/Handling_Secrets_Guide.md)
+
 ##### Switch Credential Management
 
-This collection supports flexible credential management for network switches with three security levels:
+For switch credentials specifically, this collection supports flexible credential management with three security levels:
 
 * **🔐 Ansible Vault**: Encrypted credentials for production deployments
 * **✅ Environment Variables**: Secure credential injection for CI/CD pipelines
 * **⚠️ Plain Text**: Simple credentials for lab testing only
 
-The system supports both switch-specific credentials and group-level defaults with automatic fallback. Environment variable lookups can be configured in group_vars for enhanced security and automation compatibility.
+NaC VXLAN supports both switch-specific credentials and group-level defaults with automatic fallback. Environment variable lookups can be configured in group_vars for enhanced security and automation compatibility.
 
-**📖 Complete Guide**: [Switch Credentials Configuration](docs/SWITCH_CREDENTIALS_GUIDE.md)
+**📖 Guide**: [Switch Credentials Configuration](docs/SWITCH_CREDENTIALS_GUIDE.md)
 
 ## Quick Start Guide
 

--- a/docs/Handling_Secrets_Guide.md
+++ b/docs/Handling_Secrets_Guide.md
@@ -1,0 +1,136 @@
+# Handling Secrets Guide
+
+This guide describes how to manage secrets such as passwords and authentication keys in the Network as Code VXLAN data model. There are two mechanisms available:
+
+1. **Ansible Vault** - Encrypts entire variable values at rest.
+2. **Environment Variable Lookup (`env_var_`)** - Resolves secrets from environment variables at runtime. Suitable for CI/CD integration.
+
+Both approaches ensure that plaintext secrets are not visible in the data YAML files. The key difference is that Ansible Vault encrypts whole values while `env_var_` replaces individual strings — making `env_var_` the only option for secrets embedded in freeform configuration blocks.
+
+---
+
+## Ansible Vault
+
+[Ansible Vault](https://docs.ansible.com/ansible/latest/vault_guide/index.html) encrypts sensitive data so it can be stored safely in data files. Encrypted values are decrypted automatically at playbook runtime when a vault password is provided.
+
+### Encrypting a Value
+
+```bash
+ansible-vault encrypt_string 'MySecretPassword' --name 'authentication_key'
+```
+
+This produces an encrypted variable which you can paste into your data files:
+
+```yaml
+vxlan:
+  underlay:
+    bgp:
+      authentication_enable: true
+      authentication_key_type: 3
+      authentication_key: !vault |
+        $ANSIBLE_VAULT;1.1;AES256
+        61626364656667686970...
+```
+
+### Running Playbooks with Vault
+
+```bash
+# Prompt for vault password
+ansible-playbook -i inventory deploy.yaml --ask-vault-pass
+
+# Use a password file
+ansible-playbook -i inventory deploy.yaml --vault-password-file ~/.vault_pass
+```
+
+### Limitation: Freeform Configurations
+
+Ansible Vault encrypts the entire value of a YAML field. This works for standalone fields like `authentication_key` where the complete value is a secret.
+
+However, freeform configuration blocks may contain a mix of regular configuration and secrets within a single multi-line string:
+
+```yaml
+# Does not work with Ansible Vault because only the TACACS key is a secret,
+# not the entire block.
+aaa_freeform: |
+  feature tacacs+
+  tacacs-server key 7 MySecretTacacsKey
+  ip tacacs source-interface mgmt0
+  tacacs-server timeout 20
+```
+
+Encrypting the entire `aaa_freeform` value with Ansible Vault would encrypt all four lines, which is not desired.
+
+---
+
+## Environment Variable Lookup (`env_var_`)
+
+The `env_var_` prefix instructs NaC to resolve a value from an environment variable at runtime. This works for:
+
+- **Standalone values** - the entire YAML value is an reference to an environment variable
+- **Embedded secrets** - `env_var_` references inside larger strings (e.g. freeform configuration blocks)
+
+### How It Works
+
+Any string value in the data model that contains `env_var_` is resolved by the NaC VXLAN `validate` role. The secret is replaced with the value of the corresponding environment variable.
+
+* Variable names in YAML must exactly match the environment variable names (including the env_var_ prefix).
+* Valid environment variable names may include letters, digits, and underscores.
+* Use single quotes to prevent shell interpretation of special characters
+* If the environment variable is not set, a warning is displayed and the secret is left unchanged.
+
+### Setting Environment Variables
+
+```bash
+export env_var_BGP_AUTH_KEY='MyBgpP@$$w0rd'
+export env_var_MCAST_AUTH_KEY='mcast_secret_123'
+export env_var_TACACS_KEY='TacacsSecret!'
+export env_var_DCI_PASSWORD='DciP@ssword'
+```
+
+### Examples: Standalone Values
+
+```yaml
+vxlan:
+  underlay:
+    multicast:
+      ipv4:
+        authentication_enable: true
+        authentication_key: env_var_MCAST_AUTH_KEY
+    bgp:
+      authentication_enable: true
+      authentication_key_type: 3
+      authentication_key: env_var_BGP_AUTH_KEY
+```
+
+```yaml
+vxlan:
+  multisite:
+    overlay_dci:
+      enable_ebgp_password: True
+      ebgp_password: env_var_DCI_PASSWORD
+      ebgp_password_encryption_type: 3
+```
+
+### Example: Freeform Configurations
+
+```yaml
+vxlan:
+  global:
+    ebgp:
+      aaa_freeform: |
+        feature tacacs+
+        tacacs-server key 7 env_var_TACACS_KEY
+        ip tacacs source-interface mgmt0
+        tacacs-server timeout 20
+```
+
+At runtime, only `env_var_TACACS_KEY` is replaced with the value of the `env_var_TACACS_KEY` environment variable. The rest of the block is unchanged:
+
+```
+feature tacacs+
+tacacs-server key 7 TacacsSecret!
+ip tacacs source-interface mgmt0
+tacacs-server timeout 20
+```
+
+This pattern works in any freeform field (`aaa_freeform`, `banner_freeform`, `bootstrap_freeform`, `intra_fabric_link_freeform`, `freeform_config`, etc.) and supports multiple `env_var_` tokens in the same block.

--- a/docs/Handling_Secrets_Guide.md
+++ b/docs/Handling_Secrets_Guide.md
@@ -86,7 +86,6 @@ Any string value in the data model that contains `env_var_` is resolved by NaC V
 The value stored in each variable must already be encoded for the field that references it. The placeholders below stand for the encrypted (ciphertext) values, not plaintext secrets:
 
 ```bash
-# Each value below is the ciphertext for its field's encryption type, not a plaintext secret.
 export env_var_BGP_AUTH_KEY='<3DES-encrypted BGP authentication key>'
 export env_var_MCAST_AUTH_KEY='<3DES-encrypted PIM hello key>'
 export env_var_TACACS_KEY='<type-7 encoded TACACS key>'

--- a/docs/Handling_Secrets_Guide.md
+++ b/docs/Handling_Secrets_Guide.md
@@ -145,3 +145,5 @@ This pattern works in any freeform field (`aaa_freeform`, `banner_freeform`, `bo
 * The `env_var_` lookup mechanism is not supported for policies referencing a file.
 
 * If an environment variable changes, the change will not be detected in case of a diff run (enabled by default), because the configuration in the data YAML files still looks the same. To enforce a new lookup, you can set the `force_run_all` parameter to true.
+
+* Secrets are not shown in rendered payload files, but the resolved value is handled in memory and may therefore still be visible in logs. This applies to NaC collection tasks as well as the `cisco.dcnm` collection. When `cisco.dcnm` logging is enabled, its modules can log the request parameters, payload, and controller response, which include the resolved value.

--- a/docs/Handling_Secrets_Guide.md
+++ b/docs/Handling_Secrets_Guide.md
@@ -71,20 +71,26 @@ The `env_var_` prefix instructs NaC to resolve a value from an environment varia
 
 ### How It Works
 
-Any string value in the data model that contains `env_var_` is resolved by NaC VXLAN. The secret is replaced with the value of the corresponding environment variable.
+Any string value in the data model that contains `env_var_` is resolved by NaC VXLAN. The string is replaced with the value of the corresponding environment variable.
 
+* Resolution is global. Any string in the data model that contains `env_var_` followed by word characters (`env_var_\w+`) is treated as a token, not only known secret fields. This allows `env_var_` to work inside freeform blocks, but it also means ordinary text that happens to contain the prefix is rewritten.
 * Variable names in YAML must exactly match the environment variable names (including the env_var_ prefix).
 * Valid environment variable names may include letters, digits, and underscores.
-* Use single quotes to prevent shell interpretation of special characters
-* If a referenced environment variable is not set, the run fails during the `validate` stage. The error lists every missing variable with its location in the data model. This behavior prevents an unresolved `env_var_` token from being sent to Nexus Dashboard as a literal credential value.
+* If a referenced environment variable is not set, the run fails during the `validate` stage. The error lists every missing variable with its location in the data model. This behavior prevents an unresolved `env_var_` string from being sent to Nexus Dashboard as a literal credential value.
+* `env_var_` performs substitution only, it does not encrypt. The resolved value is passed to Nexus Dashboard exactly as stored in the environment variable, with no transformation. It is the operator's responsibility to store a value that already matches what the target field expects.
+* For fields that carry an encryption type (for example `authentication_key` with `authentication_key_type: 3`, `ebgp_password` with `ebgp_password_encryption_type: 3`, or a `tacacs-server key 7 ...` line in a freeform block), the environment variable must contain the value already encoded for that type (the ciphertext), not the plaintext secret.
+* To keep literal `env_var_...` text (for example in a banner) from being resolved, avoid the exact `env_var_` prefix. For example break the word so it does not match, or reword the text. There is no dedicated escape sequence.
 
 ### Setting Environment Variables
 
+The value stored in each variable must already be encoded for the field that references it. The placeholders below stand for the encrypted (ciphertext) values, not plaintext secrets:
+
 ```bash
-export env_var_BGP_AUTH_KEY='MyBgpP@$$w0rd'
-export env_var_MCAST_AUTH_KEY='mcast_secret_123'
-export env_var_TACACS_KEY='TacacsSecret!'
-export env_var_DCI_PASSWORD='DciP@ssword'
+# Each value below is the ciphertext for its field's encryption type, not a plaintext secret.
+export env_var_BGP_AUTH_KEY='<3DES-encrypted BGP authentication key>'
+export env_var_MCAST_AUTH_KEY='<3DES-encrypted PIM hello key>'
+export env_var_TACACS_KEY='<type-7 encoded TACACS key>'
+export env_var_DCI_PASSWORD='<3DES-encrypted DCI password>'
 ```
 
 ### Examples: Standalone Values
@@ -124,11 +130,11 @@ vxlan:
         tacacs-server timeout 20
 ```
 
-At runtime, only `env_var_TACACS_KEY` is replaced with the value of the `env_var_TACACS_KEY` environment variable. The rest of the block is unchanged:
+At runtime, only `env_var_TACACS_KEY` is replaced with the value of the `env_var_TACACS_KEY` environment variable. Because the line uses `key 7`, the variable must contain the type-7 encoded key (not the plaintext). The rest of the block is unchanged:
 
 ```
 feature tacacs+
-tacacs-server key 7 TacacsSecret!
+tacacs-server key 7 076a0f1e1d0a19173e243f36
 ip tacacs source-interface mgmt0
 tacacs-server timeout 20
 ```

--- a/docs/Handling_Secrets_Guide.md
+++ b/docs/Handling_Secrets_Guide.md
@@ -76,7 +76,7 @@ Any string value in the data model that contains `env_var_` is resolved by NaC V
 * Variable names in YAML must exactly match the environment variable names (including the env_var_ prefix).
 * Valid environment variable names may include letters, digits, and underscores.
 * Use single quotes to prevent shell interpretation of special characters
-* If the environment variable is not set, a warning is displayed and the secret is left unchanged.
+* If a referenced environment variable is not set, the run fails during the `validate` stage. The error lists every missing variable with its location in the data model. This behavior prevents an unresolved `env_var_` token from being sent to Nexus Dashboard as a literal credential value.
 
 ### Setting Environment Variables
 

--- a/docs/Handling_Secrets_Guide.md
+++ b/docs/Handling_Secrets_Guide.md
@@ -71,7 +71,7 @@ The `env_var_` prefix instructs NaC to resolve a value from an environment varia
 
 ### How It Works
 
-Any string value in the data model that contains `env_var_` is resolved by the NaC VXLAN `validate` role. The secret is replaced with the value of the corresponding environment variable.
+Any string value in the data model that contains `env_var_` is resolved by NaC VXLAN. The secret is replaced with the value of the corresponding environment variable.
 
 * Variable names in YAML must exactly match the environment variable names (including the env_var_ prefix).
 * Valid environment variable names may include letters, digits, and underscores.
@@ -134,3 +134,9 @@ tacacs-server timeout 20
 ```
 
 This pattern works in any freeform field (`aaa_freeform`, `banner_freeform`, `bootstrap_freeform`, `intra_fabric_link_freeform`, `freeform_config`, etc.) and supports multiple `env_var_` tokens in the same block.
+
+### Limitations
+
+* The `env_var_` lookup mechanism is not supported for policies referencing a file.
+
+* If an environment variable changes, the change will not be detected in case of a diff run (enabled by default), because the configuration in the data YAML files still looks the same. To enforce a new lookup, you can set the `force_run_all` parameter to true.

--- a/plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py
+++ b/plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+import os
+import re
+from ansible.utils.display import Display
+
+display = Display()
+
+ENV_VAR_PREFIX = 'env_var_'
+
+# Matches env_var_ followed by one or more word characters (a-z, A-Z, 0-9, _)
+ENV_VAR_PATTERN = re.compile(r'env_var_\w+')
+
+
+def resolve_env_var_token(token, path):
+    """
+    Resolve a single env_var_ token to its environment variable value.
+
+    Note: Environment variables containing special characters like $, `, \\, etc.
+    should be properly escaped when setting them in the shell.
+    Example: export BGP_AUTH_KEY='MyP@$$w0rd' (use single quotes to prevent shell interpretation)
+    """
+    resolved = os.getenv(token)
+
+    if resolved is None:
+        display.warning(
+            f"Environment variable '{token}' referenced at "
+            f"'{path}' is not set. The value will not be resolved."
+        )
+        return token
+
+    display.vvv(f"Resolved '{token}' from environment variable at '{path}'")
+    return resolved
+
+
+def resolve_env_vars_in_string(value, path):
+    resolved_count = 0
+
+    def replace_match(match):
+        nonlocal resolved_count
+        token = match.group(0)
+        replacement = resolve_env_var_token(token, path)
+        if replacement != token:
+            resolved_count += 1
+        return replacement
+
+    new_value = ENV_VAR_PATTERN.sub(replace_match, value)
+    return new_value, resolved_count
+
+
+def resolve_env_vars_recursive(data, path=''):
+    resolved_count = 0
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            current_path = f"{path}.{key}" if path else key
+            if isinstance(value, str) and ENV_VAR_PREFIX in value:
+                data[key], count = resolve_env_vars_in_string(value, current_path)
+                resolved_count += count
+            elif isinstance(value, (dict, list)):
+                resolved_count += resolve_env_vars_recursive(value, current_path)
+    elif isinstance(data, list):
+        for index, item in enumerate(data):
+            current_path = f"{path}[{index}]"
+            if isinstance(item, str) and ENV_VAR_PREFIX in item:
+                data[index], count = resolve_env_vars_in_string(item, current_path)
+                resolved_count += count
+            elif isinstance(item, (dict, list)):
+                resolved_count += resolve_env_vars_recursive(item, current_path)
+
+    return resolved_count
+
+
+class PreparePlugin:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.keys = []
+
+    def prepare(self):
+        data_model = self.kwargs['results']['model_extended']
+
+        resolved_count = resolve_env_vars_recursive(data_model)
+        if resolved_count > 0:
+            display.v(f"Resolved {resolved_count} environment variable(s) in the data model")
+
+        self.kwargs['results']['model_extended'] = data_model
+        return self.kwargs['results']

--- a/plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py
+++ b/plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py
@@ -68,6 +68,13 @@ def resolve_env_vars_in_string(value, path):
 
 
 def resolve_env_vars_recursive(data, path=''):
+    """
+    Resolve all env_var_ tokens in a data structure by replacing them
+    with the corresponding environment variable values (in-place).
+
+    Used at runtime by build_resource_data to resolve tokens in
+    module_data (a deep copy) before sending to NDFC modules.
+    """
     resolved_count = 0
 
     if isinstance(data, dict):
@@ -90,6 +97,50 @@ def resolve_env_vars_recursive(data, path=''):
     return resolved_count
 
 
+def _validate_env_var_token(token, path):
+    if os.getenv(token) is None:
+        display.warning(
+            f"Environment variable '{token}' referenced at "
+            f"'{path}' is not set. The value will not be resolved at runtime."
+        )
+        return False
+
+    display.vvv(f"Validated '{token}' exists as environment variable at '{path}'")
+    return True
+
+
+def validate_env_vars_recursive(data, path=''):
+    """
+    Walk the data structure and validate that all env_var_ tokens have
+    corresponding environment variables set, without resolving them.
+
+    Tokens remain as-is in the data so that rendered files do not
+    contain secrets. Runtime resolution happens in build_resource_data.
+    """
+    validated_count = 0
+
+    if isinstance(data, dict):
+        for key, value in data.items():
+            current_path = f"{path}.{key}" if path else key
+            if isinstance(value, str) and ENV_VAR_PREFIX in value:
+                for match in ENV_VAR_PATTERN.finditer(value):
+                    if _validate_env_var_token(match.group(0), current_path):
+                        validated_count += 1
+            elif isinstance(value, (dict, list)):
+                validated_count += validate_env_vars_recursive(value, current_path)
+    elif isinstance(data, list):
+        for index, item in enumerate(data):
+            current_path = f"{path}[{index}]"
+            if isinstance(item, str) and ENV_VAR_PREFIX in item:
+                for match in ENV_VAR_PATTERN.finditer(item):
+                    if _validate_env_var_token(match.group(0), current_path):
+                        validated_count += 1
+            elif isinstance(item, (dict, list)):
+                validated_count += validate_env_vars_recursive(item, current_path)
+
+    return validated_count
+
+
 class PreparePlugin:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
@@ -98,9 +149,11 @@ class PreparePlugin:
     def prepare(self):
         data_model = self.kwargs['results']['model_extended']
 
-        resolved_count = resolve_env_vars_recursive(data_model)
-        if resolved_count > 0:
-            display.v(f"Resolved {resolved_count} environment variable(s) in the data model")
+        # Validate env vars exist but keep tokens as placeholders.
+        # Runtime resolution happens in build_resource_data.
+        validated_count = validate_env_vars_recursive(data_model)
+        if validated_count > 0:
+            display.v(f"Validated {validated_count} environment variable(s) in the data model")
 
         self.kwargs['results']['model_extended'] = data_model
         return self.kwargs['results']

--- a/plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py
+++ b/plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py
@@ -31,9 +31,23 @@ ENV_VAR_PREFIX = 'env_var_'
 ENV_VAR_PATTERN = re.compile(r'env_var_\w+')
 
 
+class UnresolvedEnvVarError(Exception):
+    """
+    Raised when an env_var_ token cannot be resolved to an environment
+    variable at runtime. This is a fail-closed guard that prevents a literal
+    env_var_ token from being sent to NDFC as configuration data.
+    """
+    pass
+
+
 def resolve_env_var_token(token, path):
     """
     Resolve a single env_var_ token to its environment variable value.
+
+    Fails closed: if the environment variable is not set, raises
+    UnresolvedEnvVarError instead of returning the literal token. This
+    guarantees that a missing secret can never be submitted to NDFC as an
+    executable credential value.
 
     Note: Environment variables containing special characters like $, `, \\, etc.
     should be properly escaped when setting them in the shell.
@@ -42,11 +56,9 @@ def resolve_env_var_token(token, path):
     resolved = os.getenv(token)
 
     if resolved is None:
-        display.warning(
-            f"Environment variable '{token}' referenced at "
-            f"'{path}' is not set. The value will not be resolved."
+        raise UnresolvedEnvVarError(
+            f"Environment variable '{token}' referenced at '{path}' is not set."
         )
-        return token
 
     display.vvv(f"Resolved '{token}' from environment variable at '{path}'")
     return resolved
@@ -97,48 +109,55 @@ def resolve_env_vars_recursive(data, path=''):
     return resolved_count
 
 
-def _validate_env_var_token(token, path):
-    if os.getenv(token) is None:
-        display.warning(
-            f"Environment variable '{token}' referenced at "
-            f"'{path}' is not set. The value will not be resolved at runtime."
-        )
-        return False
-
-    display.vvv(f"Validated '{token}' exists as environment variable at '{path}'")
-    return True
-
-
-def validate_env_vars_recursive(data, path=''):
+def validate_env_vars_recursive(data, path='', missing=None, validated=None):
     """
     Walk the data structure and validate that all env_var_ tokens have
     corresponding environment variables set, without resolving them.
 
     Tokens remain as-is in the data so that rendered files do not
     contain secrets. Runtime resolution happens in build_resource_data.
+
+    Aggregates every missing token together with its data model path into
+    the ``missing`` list so the caller can fail closed with a single,
+    complete error message rather than a stream of warnings that are easy
+    to lose in automation output.
+
+    Returns:
+        (validated_count, missing) where ``missing`` is a list of
+        (token, path) tuples for every referenced env var that is not set.
     """
-    validated_count = 0
+    if missing is None:
+        missing = []
+    if validated is None:
+        validated = [0]
+
+    def _check(value, current_path):
+        for match in ENV_VAR_PATTERN.finditer(value):
+            token = match.group(0)
+            if os.getenv(token) is None:
+                missing.append((token, current_path))
+            else:
+                display.vvv(
+                    f"Validated '{token}' exists as environment variable at '{current_path}'"
+                )
+                validated[0] += 1
 
     if isinstance(data, dict):
         for key, value in data.items():
             current_path = f"{path}.{key}" if path else key
             if isinstance(value, str) and ENV_VAR_PREFIX in value:
-                for match in ENV_VAR_PATTERN.finditer(value):
-                    if _validate_env_var_token(match.group(0), current_path):
-                        validated_count += 1
+                _check(value, current_path)
             elif isinstance(value, (dict, list)):
-                validated_count += validate_env_vars_recursive(value, current_path)
+                validate_env_vars_recursive(value, current_path, missing, validated)
     elif isinstance(data, list):
         for index, item in enumerate(data):
             current_path = f"{path}[{index}]"
             if isinstance(item, str) and ENV_VAR_PREFIX in item:
-                for match in ENV_VAR_PATTERN.finditer(item):
-                    if _validate_env_var_token(match.group(0), current_path):
-                        validated_count += 1
+                _check(item, current_path)
             elif isinstance(item, (dict, list)):
-                validated_count += validate_env_vars_recursive(item, current_path)
+                validate_env_vars_recursive(item, current_path, missing, validated)
 
-    return validated_count
+    return validated[0], missing
 
 
 class PreparePlugin:
@@ -149,9 +168,24 @@ class PreparePlugin:
     def prepare(self):
         data_model = self.kwargs['results']['model_extended']
 
-        # Validate env vars exist but keep tokens as placeholders.
-        # Runtime resolution happens in build_resource_data.
-        validated_count = validate_env_vars_recursive(data_model)
+        # Fail closed: stop here (during validate, before any rendering or NDFC
+        # mutation) if any referenced env var is missing, so a literal env_var_
+        # token can never reach NDFC as a credential value. Tokens are kept as
+        # placeholders; runtime resolution happens in build_resource_data.
+        validated_count, missing = validate_env_vars_recursive(data_model)
+
+        if missing:
+            lines = "\n".join(
+                f"  - '{token}' referenced at '{path}'" for token, path in missing
+            )
+            self.kwargs['results']['failed'] = True
+            self.kwargs['results']['msg'] = (
+                f"{len(missing)} environment variable(s) referenced in the data "
+                f"model with the '{ENV_VAR_PREFIX}' prefix are not set:\n{lines}\n"
+                "The run is stopped to avoid sending unresolved tokens to Nexus Dashboard."
+            )
+            return self.kwargs['results']
+
         if validated_count > 0:
             display.v(f"Validated {validated_count} environment variable(s) in the data model")
 

--- a/plugins/action/dtc/build_resource_data.py
+++ b/plugins/action/dtc/build_resource_data.py
@@ -48,6 +48,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import copy
 import hashlib
 import os
 import re
@@ -60,6 +61,9 @@ from ansible.utils.display import Display
 
 from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.registry_loader import (
     RegistryLoader,
+)
+from ansible_collections.cisco.nac_dc_vxlan.plugins.action.common.prepare_plugins.prep_005_resolve_env_vars import (
+    resolve_env_vars_recursive,
 )
 
 display = Display()
@@ -328,6 +332,15 @@ class ResourceDataBuilder:
                 if isinstance(hook_result, dict) and 'module_data' in hook_result:
                     module_data = hook_result['module_data']
                     break
+
+        resolved_data = copy.deepcopy(module_data)
+        env_count = resolve_env_vars_recursive(resolved_data)
+        if env_count > 0:
+            module_data = resolved_data
+            display.vvv(
+                f"COMMON [{self.fabric_name}] Resolved {env_count} env_var_ "
+                f"token(s) in module_data for {resource_name}"
+            )
 
         if module_data is not data:
             resource_entry['module_data'] = module_data

--- a/plugins/action/dtc/manage_resources.py
+++ b/plugins/action/dtc/manage_resources.py
@@ -39,9 +39,14 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import copy
 import json
 
 from ansible.utils.display import Display
+
+from ansible_collections.cisco.nac_dc_vxlan.plugins.action.common.prepare_plugins.prep_005_resolve_env_vars import (
+    resolve_env_vars_recursive,
+)
 
 from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.pipeline_base import (
     PipelineRunnerBase,
@@ -127,7 +132,17 @@ class ResourceManager(PipelineRunnerBase):
             if diff and isinstance(diff, dict):
                 diff_data = diff.get('updated')
                 if diff_data is not None:
-                    data = diff_data
+                    # diff.updated comes from the structural diff computed on
+                    # rendered YAML before env var resolution.  Deep-copy and
+                    # resolve so that env_var_ tokens are replaced with their
+                    # environment variable values before sending to NDFC.
+                    data = copy.deepcopy(diff_data)
+                    env_count = resolve_env_vars_recursive(data)
+                    if env_count > 0:
+                        display.vvv(
+                            f"CREATE [{self.fabric_name}] Resolved {env_count} "
+                            f"env_var_ token(s) in diff.updated for {resource_name}"
+                        )
 
         return data
 

--- a/plugins/action/dtc/manage_resources.py
+++ b/plugins/action/dtc/manage_resources.py
@@ -610,10 +610,12 @@ class ResourceManager(PipelineRunnerBase):
         for key, val in desired_vars.items():
             ctrl_val = ctrl_nv.get(key)
             if ctrl_val is None or str(val).strip() != str(ctrl_val).strip():
+                # Log only the differing key and presence, never the values:
+                # policy_vars can hold resolved env_var_ secrets.
                 display.vvv(
-                    f"POLICY DIFF [{desc}]: var {key} "
-                    f"desired={repr(str(val).strip()[:80])} vs "
-                    f"ctrl={repr(str(ctrl_val).strip()[:80] if ctrl_val is not None else None)}"
+                    f"POLICY DIFF [{desc}]: var {key} differs "
+                    f"(desired={'set' if str(val).strip() else 'empty'}, "
+                    f"ctrl={'missing' if ctrl_val is None else 'set'})"
                 )
                 return True
 

--- a/plugins/plugin_utils/pipeline_base.py
+++ b/plugins/plugin_utils/pipeline_base.py
@@ -648,6 +648,14 @@ class PipelineRunnerBase(ABC):
                     f"{self.OPERATION.upper()} [{self.fabric_name}] "
                     f"Failed to load overlay cache, re-rendering: {e}"
                 )
+            finally:
+                # Cache may hold resolved env_var_ secrets: remove it as soon as
+                # it has been consumed (or failed to load) so plaintext does not
+                # persist after the run.
+                try:
+                    os.remove(cache_file)
+                except OSError:
+                    pass
 
         check_roles = self.task_vars.get('check_roles', {})
 
@@ -702,7 +710,9 @@ class PipelineRunnerBase(ABC):
                     'resource_data': self._make_json_safe(new_resource_data),
                     'change_flags': dict(new_change_flags),
                 }
-                with open(cache_file, 'w') as f:
+                # Cache can carry resolved env_var_ secrets: restrict to owner rw.
+                fd = os.open(cache_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+                with os.fdopen(fd, 'w') as f:
                     json.dump(cache_data, f)
             except (TypeError, IOError) as e:
                 display.warning(

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -4,6 +4,7 @@ plugins/action/common/prepare_plugins/prep_001_fabric.py action-plugin-docs # ac
 plugins/action/common/prepare_plugins/prep_002_global.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_003_list_defaults.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_004_calculate_md5_policies.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_104_topology_switches.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_106_topology_interfaces.py action-plugin-docs # action plugin has no matching module to provide documentation

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -4,6 +4,7 @@ plugins/action/common/prepare_plugins/prep_001_fabric.py action-plugin-docs # ac
 plugins/action/common/prepare_plugins/prep_002_global.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_003_list_defaults.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_004_calculate_md5_policies.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_104_topology_switches.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_106_topology_interfaces.py action-plugin-docs # action plugin has no matching module to provide documentation

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -4,6 +4,7 @@ plugins/action/common/prepare_plugins/prep_001_fabric.py action-plugin-docs # ac
 plugins/action/common/prepare_plugins/prep_002_global.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_003_list_defaults.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_004_calculate_md5_policies.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_104_topology_switches.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_106_topology_interfaces.py action-plugin-docs # action plugin has no matching module to provide documentation

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -4,6 +4,7 @@ plugins/action/common/prepare_plugins/prep_001_fabric.py action-plugin-docs # ac
 plugins/action/common/prepare_plugins/prep_002_global.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_003_list_defaults.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_004_calculate_md5_policies.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_104_topology_switches.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_106_topology_interfaces.py action-plugin-docs # action plugin has no matching module to provide documentation

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -4,6 +4,7 @@ plugins/action/common/prepare_plugins/prep_001_fabric.py action-plugin-docs # ac
 plugins/action/common/prepare_plugins/prep_002_global.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_003_list_defaults.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_004_calculate_md5_policies.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_104_topology_switches.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_106_topology_interfaces.py action-plugin-docs # action plugin has no matching module to provide documentation


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->
Fixes #720 

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [x] vxlan.global
* [ ] vxlan.topology
* [x] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [x] vxlan.policy
* [x] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
Add plugin to lookup up secrets starting with the 'env_var_' prefix. Same functionality as already supported for switch credentials. Examples:
```
---
---
vxlan:
  underlay:
    bgp:
      max_paths: 4
      authentication_enable: true
      authentication_key_type: 3
      authentication_key: env_var_bgp_auth_key
    multicast:
      ipv4:
        authentication_enable: true
        authentication_key: env_var_mcast_auth_key
  global:
    ebgp:
      aaa_freeform: |
        feature tacacs+
        tacacs-server key 7 env_var_tacacs_key
        ip tacacs source-interface mgmt0
        tacacs-server timeout 20
```
- Created plugins/action/common/prepare_plugins/prep_005_resolve_env_vars.py
- Runs as prepare plugin 005 in the prepare_service_model pipeline — after fabric/global setup and list defaults (001–004), before any topology processing (104+)
- Recursively walks the entire model_extended data model
- Any string value starting with env_var_ is resolved via os.getenv()
- If the env var isn't set, a warning is emitted and the original string is kept unchanged
- Verbose logging (-v) shows how many variables were resolved; -vvv shows each individually with its data model path
- No impact on existing switch credential flow: get_credentials.py operates on the rendered inv_list (after templates), not the raw data model. The two mechanisms are complementary and don't interfere.

## Test Notes
<!--- Please provide notes or description of testing -->
1) BGP Fabric
```
TASK [cisco.nac_dc_vxlan.validate : Prepare Service Model] ***************************************************************************************************
task path: /Users/marehler/Git/sac-ndfc/nac-ndfc/collections/ansible_collections/cisco/nac_dc_vxlan/roles/validate/tasks/sub_main.yml:110
Resolved 'env_var_mcast_auth_key' from environment variable at 'vxlan.underlay.multicast.ipv4.authentication_key'
Resolved 'env_var_bgp_auth_key' from environment variable at 'vxlan.underlay.bgp.authentication_key'
Resolved 'env_var_tacacs_key' from environment variable at 'vxlan.global.ebgp.aaa_freeform'
Resolved 3 environment variable(s) in the data model
```
2) VXLAN EVPN Fabric
```
TASK [cisco.nac_dc_vxlan.validate : Prepare Service Model] *******************************************************************
task path: /Users/marehler/Git/sac-ndfc/nac-ndfc/collections/ansible_collections/cisco/nac_dc_vxlan/roles/validate/tasks/sub_main.yml:110
Resolved 'env_var_ospf_auth_key' from environment variable at 'vxlan.underlay.ospf.authentication_key'
Resolved 1 environment variable(s) in the data model
```
3) MSD Fabric
```
TASK [cisco.nac_dc_vxlan.validate : Prepare Service Model] ***************************************************************************************************
task path: /Users/marehler/Git/sac-ndfc/nac-ndfc/collections/ansible_collections/cisco/nac_dc_vxlan/roles/validate/tasks/sub_main.yml:110
Resolved 'env_var_dci_password' from environment variable at 'vxlan.multisite.overlay_dci.ebgp_password'
Resolved 1 environment variable(s) in the data model
````

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->
3.2.2
4.2.1
4.3.1

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
