### PR TITLE
fix to all 3 network templates for deploy flag not always getting included

### DIFF
--- a/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
@@ -78,7 +78,6 @@
 {% endfor %}
 {% endif %}
 {% endfor %}
-  deploy: false
 {% endif %}
-
+  deploy: false
 {% endfor %}

--- a/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
@@ -78,6 +78,6 @@
       ports: {{ attach['ports'] }}
 {% endif %}
 {% endfor %}
-  deploy: false
 {% endif %}
+  deploy: false
 {% endfor %}

--- a/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
@@ -78,6 +78,6 @@
       ports: {{ attach['ports'] }}
 {% endif %}
 {% endfor %}
-  deploy: false
 {% endif %}
+  deploy: false
 {% endfor %}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->
Fixes #786 
Issue occurs when you provide no attach group under a network, the deploy flag being explicitly set to false was dependent of the existence of an attach group, now deploy flag is always included

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [x] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
