### PR TITLE
Improve role validate performance

### DIFF
--- a/plugins/action/common/nac_dc_validate.py
+++ b/plugins/action/common/nac_dc_validate.py
@@ -89,10 +89,12 @@ class ActionModule(ActionBase):
             schema = DEFAULT_SCHEMA
 
         rules_list = []
+        data_model_loaded = None
         if rules and task_vars['role_path'] in rules:
             # Load in-memory data model using iac-validate
             # Perform the load in this if block to avoid loading the data model multiple times when custom enhanced rules are provided
             results['data'] = load_yaml_files([mdata])
+            data_model_loaded = results['data']
 
             # Introduce common directory to the rules list by default once vrf and network rules are updated
             parent_keys = ['vxlan', 'fabric']
@@ -156,11 +158,17 @@ class ActionModule(ActionBase):
             # Else block to pickup custom enhanced rules provided by the user
             rules_list.append(f'{rules}')
 
+        syntax_validated = False
         for rules_item in rules_list:
             validator = nac_validate.validator.Validator(schema, rules_item)
-            if schema:
+            if schema and not syntax_validated and validator.schema is not None:
                 validator.validate_syntax([mdata])
+                syntax_validated = True
             if rules_item:
+                if data_model_loaded is None:
+                    data_model_loaded = load_yaml_files([mdata])
+                    results['data'] = data_model_loaded
+                validator.data = data_model_loaded
                 validator.validate_semantics([mdata])
 
             msg = ""

--- a/plugins/action/common/read_run_map.py
+++ b/plugins/action/common/read_run_map.py
@@ -40,9 +40,11 @@ class ActionModule(ActionBase):
         results['diff_run'] = True
         results['validate_only_run'] = False
 
+        fabric_name = self._task.args.get('fabric_name')
         data_model = self._task.args.get('data_model')
         play_tags = self._task.args.get('play_tags')
-        fabric_name = data_model['vxlan']['fabric']['name']
+        if fabric_name is None:
+            fabric_name = data_model['vxlan']['fabric']['name']
 
         if 'dtc' in task_vars['role_path']:
             common_role_path = os.path.dirname(task_vars['role_path'])

--- a/plugins/action/common/run_map.py
+++ b/plugins/action/common/run_map.py
@@ -41,10 +41,12 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         results['failed'] = False
 
+        fabric_name = self._task.args.get('fabric_name')
         data_model = self._task.args.get('data_model')
         stage = self._task.args['stage']
 
-        fabric_name = data_model['vxlan']['fabric']['name']
+        if fabric_name is None:
+            fabric_name = data_model['vxlan']['fabric']['name']
 
         if 'dtc' in task_vars['role_path']:
             common_role_path = os.path.dirname(task_vars['role_path'])

--- a/plugins/action/dtc/build_resource_data.py
+++ b/plugins/action/dtc/build_resource_data.py
@@ -79,8 +79,8 @@ class ResourceDataBuilder:
         self.fabric_name = params['fabric_name']
         self.data_model = params['data_model']
         self.role_path = params['role_path']
-        self.run_map_diff_run = params.get('run_map_diff_run', True)
-        self.force_run_all = params.get('force_run_all', False)
+        self.run_map_diff_run = self._to_bool(params.get('run_map_diff_run', True))
+        self.force_run_all = self._to_bool(params.get('force_run_all', False))
         self.check_roles = params.get('check_roles', {})
         self.resource_filter = params.get('resource_filter', None)
 
@@ -106,7 +106,19 @@ class ResourceDataBuilder:
         # Collected results
         self.resource_data = {}
         self.change_flags = {}
-        self.diff_results = {}
+
+    @staticmethod
+    def _to_bool(value):
+        """Convert Ansible bool-like values into real booleans."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ('1', 'true', 'yes', 'on')
+        return bool(value)
+
+    def _should_run_structural_diff(self, diff_compare):
+        """Structural diff data is only consumed during targeted diff runs."""
+        return bool(diff_compare) and self.run_map_diff_run and not self.force_run_all
 
     def build(self):
         """
@@ -119,7 +131,6 @@ class ResourceDataBuilder:
             dict with:
               - 'resource_data': Dict of rendered data keyed by resource_name
               - 'change_flags': Dict of change flag states
-              - 'diff_results': Dict of structural diff results
               - 'namespace': Fabric type namespace name
               - 'failed': Boolean
               - 'msg': Summary message
@@ -164,7 +175,6 @@ class ResourceDataBuilder:
                     return {
                         'resource_data': self.resource_data,
                         'change_flags': self.change_flags,
-                        'diff_results': self.diff_results,
                         'namespace': self.namespace,
                         'results': step_results,
                         'failed': True,
@@ -181,7 +191,6 @@ class ResourceDataBuilder:
                     return {
                         'resource_data': self.resource_data,
                         'change_flags': self.change_flags,
-                        'diff_results': self.diff_results,
                         'namespace': self.namespace,
                         'results': step_results,
                         'failed': True,
@@ -206,7 +215,6 @@ class ResourceDataBuilder:
                 return {
                     'resource_data': self.resource_data,
                     'change_flags': self.change_flags,
-                    'diff_results': self.diff_results,
                     'namespace': self.namespace,
                     'results': step_results,
                     'failed': True,
@@ -230,7 +238,6 @@ class ResourceDataBuilder:
         return {
             'resource_data': self.resource_data,
             'change_flags': self.change_flags,
-            'diff_results': self.diff_results,
             'namespace': self.namespace,
             'results': step_results,
             'failed': False,
@@ -292,9 +299,8 @@ class ResourceDataBuilder:
 
         # ── Step 6: Structural diff (diff_compare) ───────────────────
         diff_result = None
-        if diff_compare:
+        if self._should_run_structural_diff(diff_compare):
             diff_result = self._run_diff_compare(old_file_path, output_file_path)
-            self.diff_results[resource_name] = diff_result
 
         # ── Step 7: MD5 diff for change detection ─────────────────────
         file_changed = self._run_diff_model_changes(old_file_path, output_file_path)
@@ -307,7 +313,8 @@ class ResourceDataBuilder:
         # module_data is the authoritative data for downstream NDFC module calls.
         # Default is the raw rendered template data. Post-hooks can override this
         # by returning a 'module_data' key in their result dict (convention).
-        resource_entry = {'data': data, 'module_data': data, 'var_name': var_name}
+        module_data = data
+        resource_entry = {'data': data, 'var_name': var_name}
         if diff_result is not None:
             resource_entry['diff'] = diff_result
 
@@ -319,8 +326,11 @@ class ResourceDataBuilder:
             # inventory from get_credentials).
             for hook_result in pre_hook_data.values():
                 if isinstance(hook_result, dict) and 'module_data' in hook_result:
-                    resource_entry['module_data'] = hook_result['module_data']
+                    module_data = hook_result['module_data']
                     break
+
+        if module_data is not data:
+            resource_entry['module_data'] = module_data
 
         self.resource_data[resource_name] = resource_entry
 
@@ -764,8 +774,10 @@ class ResourceDataBuilder:
         with open(output_file, 'w') as f:
             yaml.dump(create_list, f, default_flow_style=False)
 
-        # Run structural diff
-        diff_result = self._run_diff_compare(old_file, output_file)
+        # Run structural diff only when downstream targeted processing needs it.
+        diff_result = None
+        if self._should_run_structural_diff(rt.get('diff_compare', False)):
+            diff_result = self._run_diff_compare(old_file, output_file)
 
         # Run MD5 diff
         file_changed = self._run_diff_model_changes(old_file, output_file)
@@ -778,10 +790,10 @@ class ResourceDataBuilder:
         self.resource_data['interface_all'] = {
             'data': create_list,
             'data_remove_overridden': remove_list,
-            'diff': diff_result,
             'var_name': 'interface_all_create',
         }
-        self.diff_results['interface_all'] = diff_result
+        if diff_result is not None:
+            self.resource_data['interface_all']['diff'] = diff_result
 
         display.v(
             f"COMMON [{self.fabric_name}] Aggregated interface_all: "

--- a/roles/dtc/common/tasks/main.yml
+++ b/roles/dtc/common/tasks/main.yml
@@ -75,12 +75,6 @@
   tags: "{{ nac_tags.common_role }}"
   delegate_to: localhost
 
-- name: Store Diff Results For Use In Subsequent Roles
-  ansible.builtin.set_fact:
-    diff_results: "{{ build_result.diff_results }}"
-  tags: "{{ nac_tags.common_role }}"
-  delegate_to: localhost
-
 - name: Display Change Flag Values
   ansible.builtin.debug:
     msg: "Change flags: {{ change_flags }}"

--- a/roles/dtc/create/tasks/main.yml
+++ b/roles/dtc/create/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: Mark Stage Role Create Completed
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_create_completed
   register: run_map
   delegate_to: localhost

--- a/roles/dtc/deploy/tasks/main.yml
+++ b/roles/dtc/deploy/tasks/main.yml
@@ -51,7 +51,7 @@
 
 - name: Mark Stage Role Deploy Completed
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_deploy_completed
   register: run_map
   delegate_to: localhost

--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -91,7 +91,7 @@
 
 - name: Mark Stage Role Remove Completed
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_remove_completed
   register: run_map
   delegate_to: localhost

--- a/roles/validate/tasks/cleanup_model_files.yml
+++ b/roles/validate/tasks/cleanup_model_files.yml
@@ -24,7 +24,7 @@
 - name: Remove Service Model JSON Files
   ansible.builtin.find:
     paths: "{{ role_path }}/files/"
-    patterns: "{{ data_model_extended.vxlan.fabric.name }}_service_model*.json"
+    patterns: "{{ data_model_extended.vxlan.fabric.name }}_service_model*_previous.json"
     file_type: file
     recurse: false
   register: files_to_delete

--- a/roles/validate/tasks/main.yml
+++ b/roles/validate/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - name: Mark Stage Role Validate Completed
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_validate_completed
   register: run_map
   delegate_to: localhost

--- a/roles/validate/tasks/manage_model_files_current.yml
+++ b/roles/validate/tasks/manage_model_files_current.yml
@@ -39,11 +39,26 @@
     force: true
   delegate_to: localhost
 
+- name: Stat Current Golden Service Model Data
+  ansible.builtin.stat:
+    path: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_golden.json"
+  register: current_golden_stat
+  when: validate_checksum_compare_enabled | default(false) | bool
+  delegate_to: localhost
+
+- name: Stat Current Extended Service Model Data
+  ansible.builtin.stat:
+    path: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_extended.json"
+  register: current_extended_stat
+  when: validate_checksum_compare_enabled | default(false) | bool
+  delegate_to: localhost
+
 # Read current golden service model data into a variable called 'smd_golden_current'
 - name: Read Current Service Model Data from Host
   ansible.builtin.include_vars:
     file: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_golden.json"
   register: smd_golden_current
+  when: validate_model_diff_enabled | default(false) | bool
   delegate_to: localhost
 
 # Read current extended service model data into a variable called 'data_model_extended_current'
@@ -51,41 +66,46 @@
   ansible.builtin.include_vars:
     file: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_extended.json"
   register: data_model_extended_current
+  when: validate_model_diff_enabled | default(false) | bool
   delegate_to: localhost
 
 - name: Display Model File Changes
   ansible.utils.fact_diff:
-    before: "{{ smd_golden_previous }}"
-    after: "{{ smd_golden_current }}"
+    before: "{{ smd_golden_previous | default({}) }}"
+    after: "{{ smd_golden_current | default({}) }}"
   register: smd_golden_diff
-  when: check_roles['save_previous']
+  when:
+    - validate_model_diff_enabled | default(false) | bool
+    - golden_stat.stat.exists | default(false)
   delegate_to: localhost
 
 - name: Display Extended Service Model File Changes
   ansible.utils.fact_diff:
-    before: "{{ data_model_extended_previous }}"
-    after: "{{ data_model_extended_current }}"
+    before: "{{ data_model_extended_previous | default({}) }}"
+    after: "{{ data_model_extended_current | default({}) }}"
   register: data_model_extended_diff
-  when: check_roles['save_previous']
+  when:
+    - validate_model_diff_enabled | default(false) | bool
+    - extended_stat.stat.exists | default(false)
   delegate_to: localhost
 
 - name: Mark All Stages Completed When No Model Changes Detected
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_all_completed
   when:
-    - check_roles['save_previous']
-    - smd_golden_diff.diff_lines | length == 0
-    - smd_golden_diff.diff_text | length == 0
-    - data_model_extended_diff.diff_lines | length == 0
-    - data_model_extended_diff.diff_text | length == 0
-    - run_map_read_result.diff_run is true
-    - force_run_all is false|bool
+    - validate_checksum_compare_enabled | default(false) | bool
+    - golden_stat.stat.exists | default(false)
+    - extended_stat.stat.exists | default(false)
+    - current_golden_stat.stat.exists | default(false)
+    - current_extended_stat.stat.exists | default(false)
+    - (golden_stat.stat.checksum | default('')) == (current_golden_stat.stat.checksum | default('__missing_current_golden__'))
+    - (extended_stat.stat.checksum | default('')) == (current_extended_stat.stat.checksum | default('__missing_current_extended__'))
   delegate_to: localhost
 
 - name: Mark All Stages Completed When Only The Validate Role Is Run
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_all_completed
   when: run_map_read_result.validate_only_run is true|bool
   delegate_to: localhost
@@ -93,13 +113,13 @@
 - name: No Model Changes Detected
   ansible.builtin.meta: end_host
   when:
-    - check_roles['save_previous']
-    - smd_golden_diff.diff_lines | length == 0
-    - smd_golden_diff.diff_text | length == 0
-    - data_model_extended_diff.diff_lines | length == 0
-    - data_model_extended_diff.diff_text | length == 0
-    - run_map_read_result.diff_run is true|bool
-    - force_run_all is false|bool
+    - validate_checksum_compare_enabled | default(false) | bool
+    - golden_stat.stat.exists | default(false)
+    - extended_stat.stat.exists | default(false)
+    - current_golden_stat.stat.exists | default(false)
+    - current_extended_stat.stat.exists | default(false)
+    - (golden_stat.stat.checksum | default('')) == (current_golden_stat.stat.checksum | default('__missing_current_golden__'))
+    - (extended_stat.stat.checksum | default('')) == (current_extended_stat.stat.checksum | default('__missing_current_extended__'))
   delegate_to: localhost
 
 # ------------------------------------------------------------------------

--- a/roles/validate/tasks/manage_model_files_previous.yml
+++ b/roles/validate/tasks/manage_model_files_previous.yml
@@ -39,7 +39,9 @@
   ansible.builtin.include_vars:
     file: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_golden.json"
   register: smd_golden_previous
-  when: golden_stat.stat.exists and check_roles['save_previous']
+  when:
+    - golden_stat.stat.exists
+    - validate_model_diff_enabled | default(false) | bool
   delegate_to: localhost
 
 # Read and store previous extended service model data into a variable called 'data_model_extended_previous'
@@ -47,7 +49,9 @@
   ansible.builtin.include_vars:
     file: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_extended.json"
   register: data_model_extended_previous
-  when: extended_stat.stat.exists and check_roles['save_previous']
+  when:
+    - extended_stat.stat.exists
+    - validate_model_diff_enabled | default(false) | bool
   delegate_to: localhost
 
 # Rename golden file from previous run to append '_previous' to the filename

--- a/roles/validate/tasks/sub_main.yml
+++ b/roles/validate/tasks/sub_main.yml
@@ -135,14 +135,41 @@
 
 - name: Read Run Map From Previous Run
   cisco.nac_dc_vxlan.common.read_run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     play_tags: "{{ ansible_run_tags }}"
   register: run_map_read_result
   delegate_to: localhost
 
+- name: Set Validate Runtime Mode
+  ansible.builtin.set_fact:
+    validate_checksum_compare_enabled: >-
+      {{
+        check_roles['save_previous'] | bool and
+        run_map_read_result.diff_run | bool and
+        not (force_run_all | default(false) | bool)
+      }}
+    validate_model_diff_enabled: >-
+      {{
+        check_roles['save_previous'] | bool and
+        run_map_read_result.diff_run | bool and
+        not (force_run_all | default(false) | bool) and
+        display_model_diff | default(false) | bool
+      }}
+  delegate_to: localhost
+
+- name: Display Validate Runtime Mode
+  ansible.builtin.debug:
+    msg:
+      - "force_run_all={{ force_run_all | default(false) | bool }}"
+      - "diff_run={{ run_map_read_result.diff_run | bool }}"
+      - "ansible_run_tags={{ ansible_run_tags }}"
+      - "checksum_compare={{ validate_checksum_compare_enabled | bool }}"
+      - "display_model_diff={{ validate_model_diff_enabled | bool }}"
+  delegate_to: localhost
+
 - name: Initialize Run Map
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: starting_execution
   register: run_map
   delegate_to: localhost


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [x] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [x] vxlan.fabric
* [x] vxlan.global
* [x] vxlan.topology
* [x] vxlan.underlay
* [x] vxlan.overlay
* [x] vxlan.overlay_extensions
* [x] vxlan.policy
* [x] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

### Summary

This PR adds several validate/run-map performance optimizations for NAC VXLAN runs, for both targeted runs with `force_run_all: false` and full runs `force_run_all: true`.

The main improvement is avoiding expensive model loading, model diff generation, and full data-model argument passing when they are not needed. Functional behavior is preserved, while no-change targeted runs can short-circuit faster.

### Performance Updates

- Reused the loaded validation data model across semantic rule checks instead of reloading it repeatedly.
- Ensured syntax validation runs only once per validation execution when a schema is present.
- Added lightweight `fabric_name` support to run-map action plugins so tasks do not need to pass the full extended data model just to update/read run-map state.
- Added validate runtime mode flags:
  - `validate_checksum_compare_enabled`
  - `validate_model_diff_enabled`
- Replaced expensive no-change model comparisons with checksum-based comparisons when model diff display is disabled.
- Skipped `include_vars` loading of previous/current model JSON files unless `display_model_diff: true` and the run mode actually requires diff display.
- Preserved optional model diff display behavior behind `display_model_diff`.
- Narrowed cleanup so it only removes previous model JSON files instead of matching all service model JSON files.
- Kept `force_run_all: true` behavior as a full run path and optimized `force_run_all: false` for targeted/no-change detection.

### Details Hot Areas

<img width="873" height="783" alt="Screenshot 2026-05-03 at 7 39 51 PM" src="https://github.com/user-attachments/assets/9dc0b181-f4ed-4d01-964c-6c77b83a1bac" />

### Behavior Notes

- `display_model_diff: false` avoids the expensive model diff display path.
- `display_model_diff: true` still allows model changes to be displayed when running in a diff-enabled targeted mode.
- `force_run_all: true` bypasses the targeted checksum short-circuit behavior, as expected.
- The run-map plugins remain backward compatible by falling back to `data_model.vxlan.fabric.name` if `fabric_name` is not provided.

### Validation

Validated with the full re-resync playbook:

```bash
source env.sh ; ansible-playbook -i inventory.yaml vxlan.yaml

Playbook result: success
Total runtime: 1:09:07
Recap: ok=48 changed=4 unreachable=0 failed=0 skipped=18
```

## Test Notes
<!--- Please provide notes or description of testing -->

### Testbed Scale

<img width="648" height="638" alt="Screenshot 2026-05-03 at 6 22 29 PM" src="https://github.com/user-attachments/assets/7638534e-918a-442f-8c9f-6b2b823ff2a5" />


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
