### PR TITLE
Refactor - enhance diff controller links

### DIFF
--- a/plugins/action/dtc/existing_links_check.py
+++ b/plugins/action/dtc/existing_links_check.py
@@ -36,6 +36,73 @@ class ActionModule(ActionBase):
     looking to add to the fabric. If the link already exists, it will be added to
     the not_required_links list.
     """
+
+    # Profile field -> nvPairs key mapping for value-level comparison
+    PROFILE_TO_NV = {
+        'admin_state': 'ADMIN_STATE',
+        'mtu': 'MTU',
+        'peer1_description': 'PEER1_DESC',
+        'peer2_description': 'PEER2_DESC',
+        'peer1_cmds': 'PEER1_CONF',
+        'peer2_cmds': 'PEER2_CONF',
+        'peer1_ipv4_addr': 'PEER1_IP',
+        'peer2_ipv4_addr': 'PEER2_IP',
+        'enable_macsec': 'ENABLE_MACSEC',
+    }
+
+    # Optional/conditional fields that may be absent from desired profile
+    # but present on controller (field removal detection)
+    REMOVAL_KEYS = {
+        'peer1_cmds': 'PEER1_CONF',
+        'peer2_cmds': 'PEER2_CONF',
+    }
+
+    def _link_profile_changed(self, link, existing_link):
+        """
+        Compare enriched link profile against controller nvPairs.
+
+        Returns True if any profile value differs from the controller,
+        or if the controller has non-empty values for fields absent
+        from the desired profile (field removal detection).
+        """
+        nv = existing_link.get('nvPairs', {})
+        profile = link.get('profile', {})
+        src = link.get('src_device', '')
+        src_if = link.get('src_interface', '')
+        dst = link.get('dst_device', '')
+        dst_if = link.get('dst_interface', '')
+
+        # Forward check: desired profile keys differ from controller
+        for pkey, nv_key in self.PROFILE_TO_NV.items():
+            if pkey in profile:
+                desired_val = str(profile[pkey]).strip()
+                ctrl_val = str(nv.get(nv_key, '')).strip()
+                if desired_val.lower() != ctrl_val.lower():
+                    display.vvv(
+                        f"existing_links_check: DIFF [{src}:{src_if}->{dst}:{dst_if}]: "
+                        f"{pkey}={desired_val!r} vs {nv_key}={ctrl_val!r}"
+                    )
+                    return True
+
+        # Reverse check: controller has non-empty values for keys
+        # absent from desired profile (field was removed by user)
+        for pkey, nv_key in self.REMOVAL_KEYS.items():
+            if pkey not in profile:
+                ctrl_val = str(nv.get(nv_key, '')).strip()
+                if ctrl_val:
+                    display.vvv(
+                        f"existing_links_check: DIFF [{src}:{src_if}->{dst}:{dst_if}]: "
+                        f"{nv_key}={ctrl_val!r} on controller but "
+                        f"{pkey} absent from desired profile (removed)"
+                    )
+                    return True
+
+        display.vvv(
+            f"existing_links_check: NO DIFF [{src}:{src_if}->{dst}:{dst_if}]: "
+            f"profile matches controller"
+        )
+        return False
+
     def run(self, tmp=None, task_vars=None):
         results = super(ActionModule, self).run(tmp, task_vars)
         existing_links = self._task.args['existing_links']
@@ -128,12 +195,20 @@ class ActionModule(ActionBase):
                                 link['profile']['enable_macsec'] = existing_link['nvPairs']['ENABLE_MACSEC']
                             else:
                                 link['profile']['enable_macsec'] = 'false'
-                            display.vvv("existing_links_check: → REQUIRED (num_link, enriched with IPs)")
-                            required_links.append(link)
+                            if self._link_profile_changed(link, existing_link):
+                                display.vvv("existing_links_check: → REQUIRED (num_link, enriched, profile changed)")
+                                required_links.append(link)
+                            else:
+                                display.vvv("existing_links_check: → NOT REQUIRED (num_link, enriched, profile matches)")
+                                not_required_links.append(link)
                         elif existing_link['templateName'] == 'int_intra_fabric_unnum_link':
                             link["template"] = "int_intra_fabric_unnum_link"
-                            display.vvv("existing_links_check: → REQUIRED (unnum_link)")
-                            required_links.append(link)
+                            if self._link_profile_changed(link, existing_link):
+                                display.vvv("existing_links_check: → REQUIRED (unnum_link, profile changed)")
+                                required_links.append(link)
+                            else:
+                                display.vvv("existing_links_check: → NOT REQUIRED (unnum_link, profile matches)")
+                                not_required_links.append(link)
                         else:
                             display.vvv(
                                 f"existing_links_check: → NOT REQUIRED "

--- a/plugins/action/dtc/manage_resources.py
+++ b/plugins/action/dtc/manage_resources.py
@@ -190,97 +190,20 @@ class ResourceManager(PipelineRunnerBase):
                 ),
             }
 
-        # Step 4: Post-enrichment diff — compare enriched links against controller
+        # Step 4: Update resource data with filtered links
+        # Value-level profile comparison is now done inside existing_links_check
+        # during endpoint matching — no second pass needed.
         required_links = filter_result.get('required_links', [])
-
-        # Build lookup of existing links: {(sw1_ip_or_name, if1, sw2_ip_or_name, if2): nvPairs}
-        existing_lookup = {}
-        for el in existing_links:
-            sw1 = el.get('sw1-info', {})
-            sw2 = el.get('sw2-info', {})
-            key_fwd = (
-                sw1.get('sw-sys-name', '').lower(),
-                sw1.get('if-name', '').lower(),
-                sw2.get('sw-sys-name', '').lower(),
-                sw2.get('if-name', '').lower(),
-            )
-            key_rev = (key_fwd[2], key_fwd[3], key_fwd[0], key_fwd[1])
-            existing_lookup[key_fwd] = el
-            existing_lookup[key_rev] = el
-
-        # Profile field -> nvPairs key mapping
-        profile_to_nv = {
-            'admin_state': 'ADMIN_STATE',
-            'mtu': 'MTU',
-            'peer1_description': 'PEER1_DESC',
-            'peer2_description': 'PEER2_DESC',
-            'peer1_cmds': 'PEER1_CONF',
-            'peer2_cmds': 'PEER2_CONF',
-            'peer1_freeform': 'PEER1_CONF',
-            'peer2_freeform': 'PEER2_CONF',
-            'peer1_ipv4_addr': 'PEER1_IP',
-            'peer2_ipv4_addr': 'PEER2_IP',
-            'enable_macsec': 'ENABLE_MACSEC',
-        }
-
-        diff_links = []
-        for link in required_links:
-            src = link.get('src_device', '').lower()
-            src_if = link.get('src_interface', '').lower()
-            dst = link.get('dst_device', '').lower()
-            dst_if = link.get('dst_interface', '').lower()
-
-            el = existing_lookup.get((src, src_if, dst, dst_if))
-            if el is None:
-                # New link — not on controller
-                diff_links.append(link)
-                continue
-
-            # Template change — skip if NDFC upgraded pre-provision to num/unnum
-            desired_tpl = link.get('template', '')
-            ctrl_tpl = el.get('templateName', '')
-            if desired_tpl and desired_tpl != ctrl_tpl:
-                # Pre-provision -> numbered/unnumbered is expected NDFC behavior
-                ndfc_upgraded = (
-                    desired_tpl == 'int_pre_provision_intra_fabric_link'
-                    and ctrl_tpl in (
-                        'int_intra_fabric_num_link',
-                        'int_intra_fabric_unnum_link',
-                    )
-                )
-                if not ndfc_upgraded:
-                    diff_links.append(link)
-                    continue
-
-            # Compare profile fields against nvPairs
-            nv = el.get('nvPairs', {})
-            profile = link.get('profile', {})
-            changed = False
-            for pkey, nv_key in profile_to_nv.items():
-                if pkey in profile:
-                    desired_val = str(profile[pkey]).strip()
-                    ctrl_val = str(nv.get(nv_key, '')).strip()
-                    # Case-insensitive for booleans
-                    if desired_val.lower() != ctrl_val.lower():
-                        display.vvv(
-                            f"LINK DIFF [{src}:{src_if}->{dst}:{dst_if}]: "
-                            f"{pkey}={desired_val!r} vs {nv_key}={ctrl_val!r}"
-                        )
-                        changed = True
-                        break
-            if changed:
-                diff_links.append(link)
 
         resource_entry = self.resource_data.get('fabric_links', {})
         if isinstance(resource_entry, dict):
-            resource_entry['module_data'] = diff_links
+            resource_entry['module_data'] = required_links
         else:
-            self.resource_data['fabric_links'] = {'module_data': diff_links}
+            self.resource_data['fabric_links'] = {'module_data': required_links}
 
         display.v(
             f"CREATE [{self.fabric_name}] fabric_links: "
-            f"{len(data)} configured → {len(required_links)} enriched "
-            f"→ {len(diff_links)} after diff"
+            f"{len(data)} configured → {len(required_links)} after filter"
         )
 
         return {'changed': False}

--- a/plugins/action/dtc/manage_resources.py
+++ b/plugins/action/dtc/manage_resources.py
@@ -190,18 +190,97 @@ class ResourceManager(PipelineRunnerBase):
                 ),
             }
 
-        # Step 4: Update resource_data so the next step picks up filtered links
+        # Step 4: Post-enrichment diff — compare enriched links against controller
         required_links = filter_result.get('required_links', [])
+
+        # Build lookup of existing links: {(sw1_ip_or_name, if1, sw2_ip_or_name, if2): nvPairs}
+        existing_lookup = {}
+        for el in existing_links:
+            sw1 = el.get('sw1-info', {})
+            sw2 = el.get('sw2-info', {})
+            key_fwd = (
+                sw1.get('sw-sys-name', '').lower(),
+                sw1.get('if-name', '').lower(),
+                sw2.get('sw-sys-name', '').lower(),
+                sw2.get('if-name', '').lower(),
+            )
+            key_rev = (key_fwd[2], key_fwd[3], key_fwd[0], key_fwd[1])
+            existing_lookup[key_fwd] = el
+            existing_lookup[key_rev] = el
+
+        # Profile field -> nvPairs key mapping
+        profile_to_nv = {
+            'admin_state': 'ADMIN_STATE',
+            'mtu': 'MTU',
+            'peer1_description': 'PEER1_DESC',
+            'peer2_description': 'PEER2_DESC',
+            'peer1_cmds': 'PEER1_CONF',
+            'peer2_cmds': 'PEER2_CONF',
+            'peer1_freeform': 'PEER1_CONF',
+            'peer2_freeform': 'PEER2_CONF',
+            'peer1_ipv4_addr': 'PEER1_IP',
+            'peer2_ipv4_addr': 'PEER2_IP',
+            'enable_macsec': 'ENABLE_MACSEC',
+        }
+
+        diff_links = []
+        for link in required_links:
+            src = link.get('src_device', '').lower()
+            src_if = link.get('src_interface', '').lower()
+            dst = link.get('dst_device', '').lower()
+            dst_if = link.get('dst_interface', '').lower()
+
+            el = existing_lookup.get((src, src_if, dst, dst_if))
+            if el is None:
+                # New link — not on controller
+                diff_links.append(link)
+                continue
+
+            # Template change — skip if NDFC upgraded pre-provision to num/unnum
+            desired_tpl = link.get('template', '')
+            ctrl_tpl = el.get('templateName', '')
+            if desired_tpl and desired_tpl != ctrl_tpl:
+                # Pre-provision -> numbered/unnumbered is expected NDFC behavior
+                ndfc_upgraded = (
+                    desired_tpl == 'int_pre_provision_intra_fabric_link'
+                    and ctrl_tpl in (
+                        'int_intra_fabric_num_link',
+                        'int_intra_fabric_unnum_link',
+                    )
+                )
+                if not ndfc_upgraded:
+                    diff_links.append(link)
+                    continue
+
+            # Compare profile fields against nvPairs
+            nv = el.get('nvPairs', {})
+            profile = link.get('profile', {})
+            changed = False
+            for pkey, nv_key in profile_to_nv.items():
+                if pkey in profile:
+                    desired_val = str(profile[pkey]).strip()
+                    ctrl_val = str(nv.get(nv_key, '')).strip()
+                    # Case-insensitive for booleans
+                    if desired_val.lower() != ctrl_val.lower():
+                        display.vvv(
+                            f"LINK DIFF [{src}:{src_if}->{dst}:{dst_if}]: "
+                            f"{pkey}={desired_val!r} vs {nv_key}={ctrl_val!r}"
+                        )
+                        changed = True
+                        break
+            if changed:
+                diff_links.append(link)
 
         resource_entry = self.resource_data.get('fabric_links', {})
         if isinstance(resource_entry, dict):
-            resource_entry['module_data'] = required_links
+            resource_entry['module_data'] = diff_links
         else:
-            self.resource_data['fabric_links'] = {'module_data': required_links}
+            self.resource_data['fabric_links'] = {'module_data': diff_links}
 
         display.v(
             f"CREATE [{self.fabric_name}] fabric_links: "
-            f"{len(data)} configured → {len(required_links)} after filter"
+            f"{len(data)} configured → {len(required_links)} enriched "
+            f"→ {len(diff_links)} after diff"
         )
 
         return {'changed': False}

--- a/plugins/action/dtc/manage_resources.py
+++ b/plugins/action/dtc/manage_resources.py
@@ -190,9 +190,7 @@ class ResourceManager(PipelineRunnerBase):
                 ),
             }
 
-        # Step 4: Update resource data with filtered links
-        # Value-level profile comparison is now done inside existing_links_check
-        # during endpoint matching — no second pass needed.
+        # Step 4: Update resource_data so the next step picks up filtered links
         required_links = filter_result.get('required_links', [])
 
         resource_entry = self.resource_data.get('fabric_links', {})


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

Fabric Links: Pre-Filtering and Diff Optimization

This enhancement adds a pre-filtering and diff step for fabric links before invoking dcnm_links, reducing unnecessary API calls in large-scale fabrics (100+ switches, 200+ links).

- 4-step pipeline:
  1. Resolve desired fabric links from the data model (respecting diff_run mode)
  2. Query all existing links from NDFC controller (dcnm_links state: query)
  3. Enrich desired links with serial numbers and resolve hostnames via existing_links_check
  4. Post-enrichment diff — compare enriched links field-by-field against controller state
- Field-level comparison: compares template name and profile fields (MTU, admin state, peer descriptions, freeform config, IPv4 addresses, MACsec) against NDFC nvPairs
- Template normalization awareness: accounts for NDFC auto-upgrading int_pre_provision_intra_fabric_link to int_intra_fabric_num_link / int_intra_fabric_unnum_link when switches come online — these transitions are not flagged as changes
- Bidirectional matching: builds a lookup keyed by (switch, interface) pairs in both directions so link A→B matches B→A on the controller regardless of how NDFC stores it
- Result: only new or modified links are sent to dcnm_links with state: merged, skipping links that already match the desired state on the controller

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
