### PR TITLE
Fix vPC peering default payload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,10 @@ on:
     branches:
       - develop
       - main
-      - refactor_collection
   pull_request:
     branches:
       - develop
       - main
-      - refactor_collection
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,12 @@ on:
     branches:
       - develop
       - main
+      - refactor_collection
   pull_request:
     branches:
       - develop
       - main
+      - refactor_collection
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,54 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 .. contents:: ``Release Versions``
 
+`0.8.0`_
+=====================
+
+**Release Date:** ``2026-05-31``
+
+Added
+-----
+* This release delivers the DTC Pythonic Consolidation
+  * This is a major architectural refactor of the Direct-to-Controller (DTC) roles that replaces per-fabric YAML task files with a unified, data-driven pipeline powered by Python action plugins and externalized YAML registries.
+* ``cr_manage_vrfs_networks`` split into independent ``cr_manage_vrfs`` and ``cr_manage_networks`` tags
+* Added ``role_create`` and ``role_remove`` top-level role tags
+* Added ``cr_manage_links`` and ``cr_manage_tor_pairing`` to iBGP and eBGP VXLAN tag sets
+* General performance improvements
+
+Fixed
+-----
+
+* https://github.com/netascode/ansible-dc-vxlan/issues/767
+* https://github.com/netascode/ansible-dc-vxlan/issues/783
+* https://github.com/netascode/ansible-dc-vxlan/issues/786
+
+* Template Fixes
+  
+  * ndfc_bgw_anycast_vip.j2, ndfc_underlay_ip_address.j2, ndfc_vpc_domain_id_resource.j2
+
+    * Switched from bare ``vxlan.*`` references to fully-qualified ``data_model_extended.vxlan.*``
+
+  * ndfc_fabric_links.j2
+
+    * Added ``peer1_ipv4_addr`` / ``peer2_ipv4_addr`` support for numbered fabric links
+
+  * ndfc_policy.j2
+
+    * Added guard for empty switches list to prevent empty policy render
+
+  * dc_vxlan_fabric_attach_vrfs_loopbacks.j2, msd_fabric_attach_vrfs_loopbacks.j2, mcfg_fabric_attach_vrfs_loopbacks.j2
+
+    * Widened loopback attach condition to include ``loopback_ipv4``, ``loopback_ipv6``, and ``freeform_config``
+
+  * ndfc_underlay_ip_address.j2
+
+    * Added anycast RP resource allocation for multicast replication mode
+
+  * mcfg_fabric_attach_vrfs_loopbacks.j2
+
+    * Fixed ``vlan_id`` type (quoted string for NDFC API)
+
+
 `0.7.2`_
 =====================
 
@@ -520,6 +568,7 @@ The following roles have been added to the collection:
 
 This version of the collection includes support for an IPv4 Underlay only.  Support for IPv6 Underlay will be available in the next release.
 
+.. _0.8.0: https://github.com/netascode/ansible-dc-vxlan/compare/0.7.2...0.8.0
 .. _0.7.2: https://github.com/netascode/ansible-dc-vxlan/compare/0.7.1...0.7.2
 .. _0.7.1: https://github.com/netascode/ansible-dc-vxlan/compare/0.7.0...0.7.1
 .. _0.7.0: https://github.com/netascode/ansible-dc-vxlan/compare/0.6.0...0.7.0

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ We welcome community contributions to this collection. If you find problems, ple
 
 MIT License
 
-Copyright (c) 2024-2025 Cisco and/or its affiliates.
+Copyright (c) 2024-2026 Cisco and/or its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ Inside the [example repository](https://github.com/netascode/ansible-dc-vxlan-ex
 
 ```yaml
 # Control Parameters for 'Remove' role tasks in VXLAN EVPN fabric
+edge_connections_delete_mode: false
 interface_delete_mode: false
 inventory_delete_mode: false
 link_fabric_delete_mode: false
 link_vpc_delete_mode: false
 network_delete_mode: false
 policy_delete_mode: false
+tor_pairing_delete_mode: false
 vpc_delete_mode: false
 vrf_delete_mode: false
 
@@ -83,16 +85,19 @@ The following control variables are available in this collection.
 | Variable | Description | Default Value |
 | -------- | ------- | ------- |
 | `force_run_all` | Force all roles in the collection to run | `false` |
+| `edge_connections_delete_mode` | Remove edge_connections state as part of the remove role | `false` |
 | `interface_delete_mode` | Remove interface state as part of the remove role | `false` |
 | `inventory_delete_mode` | Remove inventory state as part of the remove role | `false` |
+| `link_fabric_delete_mode` | Remove fabric link state as part of the remove role | `false` |
 | `link_vpc_delete_mode` | Remove vpc link state as part of the remove role | `false` |
 | `multisite_child_fabric_delete_mode` | Remove child fabric from MSD fabric as part of the remove role | `false` |
 | `multisite_network_delete_mode` | Remove network state as part of the remove role for multisite (MSD) fabrics | `false` |
 | `multisite_vrf_delete_mode` | Remove vrf state as part of the remove role for multisite (MSD) fabrics | `false` |
 | `network_delete_mode` | Remove network state as part of the remove role | `false` |
 | `policy_delete_mode` | Remove policy state as part of the remove role | `false` |
-| `vrf_delete_mode` | Remove vrf state as part of the remove role | `false` |
+| `tor_pairing_delete_mode` | Remove tor pairing state as part of the remove role | `false` |
 | `vpc_delete_mode` | Remove vpc pair state as part of the remove role | `false` |
+| `vrf_delete_mode` | Remove vrf state as part of the remove role | `false` |
 
 These variables are described in more detail in different sections of this document.
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: nac_dc_vxlan
-version: 0.7.2-dev
+version: 0.8.0-dev
 readme: README.md
 authors:
   - Charly Coueffe <ccoueffe>
@@ -32,5 +32,5 @@ tags: [cisco, dc, nd, ndfc, nxos, networking, vxlan, evpn, nac, sac]
 
 dependencies:
   "ansible.netcommon": ">=4.1.0"
-  "cisco.dcnm": ">=3.11.1"
+  "cisco.dcnm": ">=3.12.0"
   "community.general": ">=8.5.0"

--- a/plugins/action/common/get_credentials.py
+++ b/plugins/action/common/get_credentials.py
@@ -207,4 +207,7 @@ class ActionModule(ActionBase):
                     display.vvv(f"Using group_vars discovery credentials from model data for device {device_ip}")
 
         results['updated_inv_list'] = updated_inv_list
+        # Convention: post-hooks that produce module-ready data set 'module_data'
+        # so build_resource_data can pass it directly to downstream NDFC modules.
+        results['module_data'] = updated_inv_list
         return results

--- a/plugins/action/common/nac_dc_validate.py
+++ b/plugins/action/common/nac_dc_validate.py
@@ -89,10 +89,12 @@ class ActionModule(ActionBase):
             schema = DEFAULT_SCHEMA
 
         rules_list = []
+        data_model_loaded = None
         if rules and task_vars['role_path'] in rules:
             # Load in-memory data model using iac-validate
             # Perform the load in this if block to avoid loading the data model multiple times when custom enhanced rules are provided
             results['data'] = load_yaml_files([mdata])
+            data_model_loaded = results['data']
 
             # Introduce common directory to the rules list by default once vrf and network rules are updated
             parent_keys = ['vxlan', 'fabric']
@@ -156,11 +158,17 @@ class ActionModule(ActionBase):
             # Else block to pickup custom enhanced rules provided by the user
             rules_list.append(f'{rules}')
 
+        syntax_validated = False
         for rules_item in rules_list:
             validator = nac_validate.validator.Validator(schema, rules_item)
-            if schema:
+            if schema and not syntax_validated and validator.schema is not None:
                 validator.validate_syntax([mdata])
+                syntax_validated = True
             if rules_item:
+                if data_model_loaded is None:
+                    data_model_loaded = load_yaml_files([mdata])
+                    results['data'] = data_model_loaded
+                validator.data = data_model_loaded
                 validator.validate_semantics([mdata])
 
             msg = ""

--- a/plugins/action/common/read_run_map.py
+++ b/plugins/action/common/read_run_map.py
@@ -40,9 +40,11 @@ class ActionModule(ActionBase):
         results['diff_run'] = True
         results['validate_only_run'] = False
 
+        fabric_name = self._task.args.get('fabric_name')
         data_model = self._task.args.get('data_model')
         play_tags = self._task.args.get('play_tags')
-        fabric_name = data_model['vxlan']['fabric']['name']
+        if fabric_name is None:
+            fabric_name = data_model['vxlan']['fabric']['name']
 
         if 'dtc' in task_vars['role_path']:
             common_role_path = os.path.dirname(task_vars['role_path'])

--- a/plugins/action/common/run_map.py
+++ b/plugins/action/common/run_map.py
@@ -41,10 +41,12 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         results['failed'] = False
 
+        fabric_name = self._task.args.get('fabric_name')
         data_model = self._task.args.get('data_model')
         stage = self._task.args['stage']
 
-        fabric_name = data_model['vxlan']['fabric']['name']
+        if fabric_name is None:
+            fabric_name = data_model['vxlan']['fabric']['name']
 
         if 'dtc' in task_vars['role_path']:
             common_role_path = os.path.dirname(task_vars['role_path'])

--- a/plugins/action/dtc/build_resource_data.py
+++ b/plugins/action/dtc/build_resource_data.py
@@ -1,0 +1,957 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Build Resource Data — Consolidated Template→Render→Diff→Flag pipeline for all fabric types.
+
+Replaces the dtc/common role's per-fabric-type sub_main_*.yml files and
+~50 individual resource task files with a single data-driven action plugin.
+
+Resource type metadata is loaded from resources/resource_types.yml.
+Each resource declares its applicable fabric_types — the plugin filters
+to only process entries matching the current fabric.
+
+Implements the same Template→Render→Diff→Flag cycle as the original YAML tasks:
+  1. Backup previous rendered file (if exists)
+  2. Render Jinja2 template to output file
+  3. Load rendered YAML data into variable
+  4. Run structural diff (diff_compare) for resources that support it
+  5. Run MD5 diff (diff_model_changes) to detect any changes
+  6. Set change flag if data changed and save_previous is active
+
+Entries with template: null are non-template steps dispatched to
+internal methods by resource name:
+  - child_fabrics:    Prepare MSD child fabric associations
+  - interface_all:    Aggregate all interface types into combined lists
+  - check_msd_child:  Validate overlay not managed from MSD child fabric
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import hashlib
+import os
+import re
+import shutil
+
+import yaml
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.registry_loader import (
+    RegistryLoader,
+)
+
+display = Display()
+
+
+class ResourceDataBuilder:
+    """
+    Core Template→Render→Diff→Flag pipeline logic.
+
+    Iterates through resource_types.yml filtered by fabric_type,
+    rendering templates, detecting changes, and collecting resource
+    data for downstream create/remove plugins.
+    """
+
+    def __init__(self, params, action_module, task_vars, tmp=None):
+        self.fabric_type = params['fabric_type']
+        self.fabric_name = params['fabric_name']
+        self.data_model = params['data_model']
+        self.role_path = params['role_path']
+        self.run_map_diff_run = self._to_bool(params.get('run_map_diff_run', True))
+        self.force_run_all = self._to_bool(params.get('force_run_all', False))
+        self.check_roles = params.get('check_roles', {})
+        self.resource_filter = params.get('resource_filter', None)
+
+        self.action_module = action_module
+        self.task_vars = task_vars
+        self.tmp = tmp
+
+        # Load registries
+        collection_path = RegistryLoader.get_collection_path()
+        self.resource_types = RegistryLoader.load(collection_path, 'resource_types').get('resource_types', {})
+        self.fabric_types = RegistryLoader.load(collection_path, 'fabric_types').get('fabric_types', {})
+
+        # Get fabric type config
+        self.fabric_type_config = self.fabric_types.get(self.fabric_type, {})
+        self.file_subdir = self.fabric_type_config.get('file_subdir', '')
+        self.namespace = self.fabric_type_config.get('namespace', '')
+
+        # Output path: {role_path}/files/{file_subdir}/{fabric_name}/
+        self.output_path = os.path.join(
+            self.role_path, 'files', self.file_subdir, self.fabric_name
+        )
+
+        # Collected results
+        self.resource_data = {}
+        self.change_flags = {}
+
+    @staticmethod
+    def _to_bool(value):
+        """Convert Ansible bool-like values into real booleans."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.lower() in ('1', 'true', 'yes', 'on')
+        return bool(value)
+
+    def _should_run_structural_diff(self, diff_compare):
+        """Structural diff data is only consumed during targeted diff runs."""
+        return bool(diff_compare) and self.run_map_diff_run and not self.force_run_all
+
+    def build(self):
+        """
+        Execute the resource pipeline for the current fabric type.
+
+        Iterates resource_types.yml in order, processing only entries
+        whose fabric_types list includes the current fabric type.
+
+        Returns:
+            dict with:
+              - 'resource_data': Dict of rendered data keyed by resource_name
+              - 'change_flags': Dict of change flag states
+              - 'namespace': Fabric type namespace name
+              - 'failed': Boolean
+              - 'msg': Summary message
+        """
+        # Cleanup output directory if not a diff run
+        # Skip cleanup when using resource_filter (deferred build) since the
+        # output directory was already set up by the common-phase build.
+        if not self.resource_filter:
+            if not self.run_map_diff_run or self.force_run_all:
+                self._cleanup_files()
+
+        # Ensure output directory exists
+        os.makedirs(self.output_path, exist_ok=True)
+
+        step_results = []
+
+        for resource_name, rt in self.resource_types.items():
+            # When resource_filter is set (deferred build for MSD/MCFG),
+            # process only the named resources and skip fabric_types check.
+            # Otherwise, apply the standard fabric_type filter.
+            if self.resource_filter:
+                if resource_name not in self.resource_filter:
+                    continue
+            else:
+                applicable_fabrics = rt.get('fabric_types', [])
+                if self.fabric_type not in applicable_fabrics:
+                    continue
+
+            template = rt.get('template')
+
+            # ── Non-template step: dispatch to internal method ────────
+            if template is None:
+                method_name = f'_{resource_name}'
+                try:
+                    method = getattr(self, method_name)
+                except AttributeError:
+                    step_results.append({
+                        'resource_name': resource_name,
+                        'status': 'failed',
+                        'reason': f"Internal method '{method_name}' not found",
+                    })
+                    return {
+                        'resource_data': self.resource_data,
+                        'change_flags': self.change_flags,
+                        'namespace': self.namespace,
+                        'results': step_results,
+                        'failed': True,
+                        'msg': f"Internal method '{method_name}' not found on ResourceDataBuilder",
+                    }
+
+                result = method(rt)
+                step_results.append({
+                    'resource_name': resource_name,
+                    'status': 'ok',
+                    'result': result,
+                })
+                if isinstance(result, dict) and result.get('failed'):
+                    return {
+                        'resource_data': self.resource_data,
+                        'change_flags': self.change_flags,
+                        'namespace': self.namespace,
+                        'results': step_results,
+                        'failed': True,
+                        'msg': result.get('msg', f"Step '{resource_name}' failed"),
+                    }
+                continue
+
+            # ── Resolve template (apply fabric-specific override) ─────
+            template_overrides = rt.get('template_overrides', {})
+            if self.fabric_type in template_overrides:
+                template = template_overrides[self.fabric_type]
+
+            # ── Standard resource build ───────────────────────────────
+            result = self._build_resource(resource_name, rt, template)
+            step_results.append({
+                'resource_name': resource_name,
+                'status': 'ok' if not result.get('failed') else 'failed',
+                'result': result,
+            })
+
+            if result.get('failed'):
+                return {
+                    'resource_data': self.resource_data,
+                    'change_flags': self.change_flags,
+                    'namespace': self.namespace,
+                    'results': step_results,
+                    'failed': True,
+                    'msg': f"Build failed at step '{resource_name}': {result.get('msg', '')}",
+                }
+
+        # ── MSD/MCFG deferred overlay change detection ───────────────
+        # VRF/network overlay data for MSD/MCFG is not rendered during the
+        # common-phase build (deferred to _msite_build_overlay in the
+        # create/remove pipeline). However, we must detect overlay data model
+        # changes here so that changes_detected_any correctly gates the
+        # pipeline. Without this, adding VRFs/networks to MSD for the first
+        # time (or modifying them) would leave changes_detected_any=False
+        # and skip the entire create pipeline.
+        if not self.resource_filter and self.fabric_type in ('MSD', 'MCFG'):
+            self._detect_msite_overlay_changes()
+
+        # Compute aggregate change flag
+        self.change_flags['changes_detected_any'] = any(self.change_flags.values())
+
+        return {
+            'resource_data': self.resource_data,
+            'change_flags': self.change_flags,
+            'namespace': self.namespace,
+            'results': step_results,
+            'failed': False,
+            'msg': f"Common pipeline completed for {self.fabric_type} fabric '{self.fabric_name}'",
+        }
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Core Build Cycle
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _build_resource(self, resource_name, rt, template):
+        """
+        Execute the Template→Render→Diff→Flag cycle for one resource.
+
+        Args:
+            resource_name: Logical name of the resource.
+            rt: Resource type config dict from resource_types.yml.
+            template: Template path (may be overridden by pipeline step).
+
+        Returns:
+            dict with build result.
+        """
+        output_file = rt['output_file']
+        change_flag = rt['change_flag']
+        diff_compare = rt.get('diff_compare', False)
+        var_name = rt.get('var_name', resource_name)
+
+        output_file_path = os.path.join(self.output_path, output_file)
+        old_file_path = output_file_path + '.old'
+
+        # ── Step 1: Backup previous file ──────────────────────────────
+        if os.path.exists(output_file_path):
+            shutil.copy2(output_file_path, old_file_path)
+            os.remove(output_file_path)
+
+        # ── Step 2: Execute pre-hooks ─────────────────────────────────
+        pre_hook_data = {}
+        for hook in rt.get('pre_hooks', []):
+            hook_result = self._execute_hook(hook)
+            pre_hook_data[hook] = hook_result
+
+        # ── Step 3: Render template ───────────────────────────────────
+        try:
+            self._render_template(template, output_file_path)
+        except Exception as e:
+            return {
+                'failed': True,
+                'msg': f"Template rendering failed for {resource_name}: {str(e)}",
+            }
+
+        # ── Step 4: Load rendered data ────────────────────────────────
+        data = self._load_yaml(output_file_path)
+
+        # ── Step 5: Execute post-hooks ────────────────────────────────
+        for hook in rt.get('post_hooks', []):
+            hook_result = self._execute_post_hook(hook, resource_name, data)
+            if hook_result is not None:
+                pre_hook_data[hook] = hook_result
+
+        # ── Step 6: Structural diff (diff_compare) ───────────────────
+        diff_result = None
+        if self._should_run_structural_diff(diff_compare):
+            diff_result = self._run_diff_compare(old_file_path, output_file_path)
+
+        # ── Step 7: MD5 diff for change detection ─────────────────────
+        file_changed = self._run_diff_model_changes(old_file_path, output_file_path)
+
+        # ── Step 8: Set change flag ───────────────────────────────────
+        if change_flag and file_changed and self.check_roles.get('save_previous', False):
+            self.change_flags[change_flag] = True
+
+        # ── Store resource data ───────────────────────────────────────
+        # module_data is the authoritative data for downstream NDFC module calls.
+        # Default is the raw rendered template data. Post-hooks can override this
+        # by returning a 'module_data' key in their result dict (convention).
+        module_data = data
+        resource_entry = {'data': data, 'var_name': var_name}
+        if diff_result is not None:
+            resource_entry['diff'] = diff_result
+
+        # Store hook data alongside resource data
+        if pre_hook_data:
+            resource_entry['hook_data'] = pre_hook_data
+            # Convention: if any post-hook returned 'module_data', use it as the
+            # authoritative data for downstream modules (e.g., credential-enriched
+            # inventory from get_credentials).
+            for hook_result in pre_hook_data.values():
+                if isinstance(hook_result, dict) and 'module_data' in hook_result:
+                    module_data = hook_result['module_data']
+                    break
+
+        if module_data is not data:
+            resource_entry['module_data'] = module_data
+
+        self.resource_data[resource_name] = resource_entry
+
+        display.v(
+            f"COMMON [{self.fabric_name}] Built {resource_name}: "
+            f"items={len(data) if isinstance(data, list) else '?'}, "
+            f"changed={file_changed}"
+        )
+
+        return {'failed': False, 'changed': file_changed}
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Template Rendering
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _render_template(self, template_name, output_path):
+        """
+        Render a Jinja2 template using Ansible's Templar.
+
+        Uses Ansible's Templar to render Jinja2 templates with all available
+        task variables. The template is loaded from the role's templates
+        directory.
+
+        Args:
+            template_name: Template path relative to role templates dir.
+            output_path: Absolute path for the rendered output file.
+        """
+        from jinja2 import ChoiceLoader, FileSystemLoader
+
+        template_dir = os.path.join(self.role_path, 'templates')
+        template_path = os.path.join(template_dir, template_name)
+
+        if not os.path.exists(template_path):
+            raise FileNotFoundError(f"Template not found: {template_path}")
+
+        with open(template_path) as f:
+            template_content = f.read()
+
+        templar = self.action_module._templar
+        original_loader = templar.environment.loader
+
+        # Add role templates dir to Jinja2 loader for {% include %} and {% import %}
+        new_loader = ChoiceLoader([
+            FileSystemLoader(template_dir),
+            original_loader,
+        ])
+        templar.environment.loader = new_loader
+        old_vars = templar.available_variables
+
+        try:
+            templar.available_variables = self.task_vars
+
+            rendered = templar.template(
+                template_content,
+                preserve_trailing_newlines=True,
+                convert_data=False,
+            )
+        finally:
+            templar.environment.loader = original_loader
+            templar.available_variables = old_vars
+
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, 'w') as f:
+            f.write(rendered)
+
+    def _load_yaml(self, path):
+        """Load a YAML file and return its contents, or empty list."""
+        if not os.path.exists(path):
+            return []
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        return data if data else []
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Diff Operations
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _run_diff_model_changes(self, old_path, current_path):
+        """
+        Compare previous and current files via MD5 hash (with omit placeholder normalization).
+
+        Replicates the logic from dtc.diff_model_changes action plugin.
+        If files are identical, removes the .old backup file.
+
+        Args:
+            old_path: Path to the previous file (.old).
+            current_path: Path to the current file.
+
+        Returns:
+            True if file data changed, False otherwise.
+        """
+        if not os.path.exists(old_path):
+            return True
+
+        with open(old_path, 'r') as f:
+            data_previous = f.read()
+        with open(current_path, 'r') as f:
+            data_current = f.read()
+
+        md5_prev = hashlib.md5(data_previous.encode()).hexdigest()
+        md5_curr = hashlib.md5(data_current.encode()).hexdigest()
+
+        if md5_prev == md5_curr:
+            os.remove(old_path)
+            return False
+
+        # Normalize omit placeholders and compare again
+        pattern = r'__omit_place_holder__\S+'
+        data_previous = re.sub(pattern, 'NORMALIZED', data_previous, flags=re.MULTILINE)
+        data_current = re.sub(pattern, 'NORMALIZED', data_current, flags=re.MULTILINE)
+
+        md5_prev = hashlib.md5(data_previous.encode()).hexdigest()
+        md5_curr = hashlib.md5(data_current.encode()).hexdigest()
+
+        if md5_prev == md5_curr:
+            os.remove(old_path)
+            return False
+
+        return True
+
+    def _detect_msite_overlay_changes(self):
+        """
+        Detect changes in MSD/MCFG multisite overlay data model.
+
+        VRF/network overlay resources for MSD/MCFG are built at pipeline
+        execution time by _msite_build_overlay, not during common-phase.
+        This method serializes the ENTIRE multisite overlay section of the
+        data model (including vrf_attach_groups and network_attach_groups)
+        to a sentinel file and compares against the previous version.
+
+        When a change is detected, sets BOTH the aggregate flag
+        (changes_detected_msite_overlay) AND per-resource flags
+        (changes_detected_vrfs, changes_detected_networks) so that
+        downstream pipeline steps pass their change_flag_guard checks.
+
+        Also cleans up the deferred build cache file from any prior
+        pipeline run in this playbook execution.
+        """
+        # Clean up deferred build cache from prior pipeline runs so that
+        # each playbook run starts with a fresh cache.
+        cache_file = os.path.join(self.output_path, '_msite_overlay_cache.json')
+        if os.path.exists(cache_file):
+            os.remove(cache_file)
+
+        overlay = (
+            self.data_model
+            .get('vxlan', {})
+            .get('multisite', {})
+            .get('overlay', {})
+        )
+
+        sentinel_file = os.path.join(self.output_path, '_msite_overlay_sentinel.yml')
+        old_sentinel = sentinel_file + '.old'
+
+        # Handle empty/missing overlay: still need to detect removal of
+        # previously existing overlay data (user removed all VRFs/networks).
+        if not overlay:
+            if not os.path.exists(sentinel_file):
+                # No previous sentinel and no current overlay — nothing to detect
+                return
+            # Previous sentinel exists but overlay is now empty — detect removal
+            shutil.copy2(sentinel_file, old_sentinel)
+            os.remove(sentinel_file)
+            with open(sentinel_file, 'w') as f:
+                f.write(yaml.dump({}, default_flow_style=False, sort_keys=True))
+            if self._run_diff_model_changes(old_sentinel, sentinel_file):
+                if self.check_roles.get('save_previous', False):
+                    self.change_flags['changes_detected_msite_overlay'] = True
+                    self.change_flags['changes_detected_vrfs'] = True
+                    self.change_flags['changes_detected_networks'] = True
+                    display.v(
+                        f"COMMON [{self.fabric_name}] Multisite overlay "
+                        f"removed — all overlay data cleared"
+                    )
+            return
+
+        # Backup previous sentinel file
+        if os.path.exists(sentinel_file):
+            shutil.copy2(sentinel_file, old_sentinel)
+            os.remove(sentinel_file)
+
+        # Capture the ENTIRE overlay dict (vrfs, networks, vrf_attach_groups,
+        # network_attach_groups, etc.) for change detection. Previously only
+        # vrfs and networks were captured, missing attach group modifications.
+        overlay_content = yaml.dump(
+            overlay,
+            default_flow_style=False,
+            sort_keys=True,
+        )
+        with open(sentinel_file, 'w') as f:
+            f.write(overlay_content)
+
+        overlay_vrfs = overlay.get('vrfs', [])
+        overlay_networks = overlay.get('networks', [])
+
+        # Compare using existing MD5 diff logic
+        if self._run_diff_model_changes(old_sentinel, sentinel_file):
+            if self.check_roles.get('save_previous', False):
+                self.change_flags['changes_detected_msite_overlay'] = True
+                # Set per-resource flags so pipeline steps pass their
+                # change_flag_guard checks. Both CREATE and REMOVE pipelines
+                # gate VRF/network steps on these flags.
+                if overlay_vrfs or self._sentinel_had_key(old_sentinel, 'vrfs'):
+                    self.change_flags['changes_detected_vrfs'] = True
+                if overlay_networks or self._sentinel_had_key(old_sentinel, 'networks'):
+                    self.change_flags['changes_detected_networks'] = True
+                display.v(
+                    f"COMMON [{self.fabric_name}] Multisite overlay data "
+                    f"model change detected (vrfs={len(overlay_vrfs)}, "
+                    f"networks={len(overlay_networks)})"
+                )
+
+    def _sentinel_had_key(self, sentinel_path, key):
+        """
+        Check if a previous sentinel file contained a non-empty value for key.
+
+        Used by _detect_msite_overlay_changes to determine which per-resource
+        change flags to set when the overlay data model has changed.
+        """
+        if not os.path.exists(sentinel_path):
+            return False
+        try:
+            with open(sentinel_path) as f:
+                prev_data = yaml.safe_load(f)
+            return bool(prev_data.get(key)) if isinstance(prev_data, dict) else False
+        except (yaml.YAMLError, IOError):
+            return False
+
+    def _run_diff_compare(self, old_path, new_path):
+        """
+        Run structural diff comparison for targeted create/remove data.
+
+        Delegates to the existing diff_compare action plugin to compute
+        updated, removed, and equal item lists.
+
+        Args:
+            old_path: Path to the previous file (.old).
+            new_path: Path to the current file.
+
+        Returns:
+            Dict with 'updated', 'removed', 'equal' lists.
+        """
+        result = self._run_action_plugin(
+            "cisco.nac_dc_vxlan.dtc.diff_compare",
+            {"old_file": old_path, "new_file": new_path},
+        )
+        return result
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Action Plugin Invocation
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _run_action_plugin(self, action_name, args):
+        """
+        Instantiate and run another action plugin by fully-qualified name.
+
+        Used for hooks like get_poap_data and get_credentials which are
+        action plugins (not modules) and cannot be called via _execute_module.
+        """
+        task = self.action_module._task.copy()
+        task.action = action_name
+        task.args = args
+
+        action = self.action_module._shared_loader_obj.action_loader.get(
+            action_name,
+            task=task,
+            connection=self.action_module._connection,
+            play_context=self.action_module._play_context,
+            loader=self.action_module._loader,
+            templar=self.action_module._templar,
+            shared_loader_obj=self.action_module._shared_loader_obj,
+        )
+
+        if action is None:
+            return {
+                'failed': True,
+                'msg': f"Action plugin '{action_name}' not found via action_loader",
+            }
+
+        return action.run(task_vars=self.task_vars, tmp=self.tmp)
+
+    def _execute_rest(self, method, path):
+        """
+        Execute a dcnm_rest API call.
+
+        Args:
+            method: HTTP method (GET, POST, etc.).
+            path: NDFC API path.
+
+        Returns:
+            Module result dict.
+        """
+        return self.action_module._execute_module(
+            module_name="cisco.dcnm.dcnm_rest",
+            module_args={"method": method, "path": path},
+            task_vars=self.task_vars,
+            tmp=self.tmp,
+        )
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Hooks
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _execute_hook(self, hook_name):
+        """
+        Execute a pre-hook before template rendering.
+
+        Currently supports:
+          - get_poap_data: Retrieve POAP data from POAP-enabled devices.
+
+        Args:
+            hook_name: Name of the hook to execute.
+
+        Returns:
+            Hook result dict.
+        """
+        if hook_name == 'get_poap_data':
+            result = self._run_action_plugin(
+                "cisco.nac_dc_vxlan.dtc.get_poap_data",
+                {"data_model": self.data_model},
+            )
+            # Store poap_data in task_vars for template rendering
+            self.task_vars['poap_data'] = result
+            return result
+
+        display.warning(f"Unknown pre-hook: {hook_name}")
+        return {}
+
+    def _execute_post_hook(self, hook_name, resource_name, data):
+        """
+        Execute a post-hook after template rendering and data loading.
+
+        Currently supports:
+          - get_credentials: Retrieve NDFC device credentials and update
+            inventory config.
+
+        Args:
+            hook_name: Name of the hook to execute.
+            resource_name: Name of the resource being built.
+            data: Rendered data from the template.
+
+        Returns:
+            Updated data dict, or None if hook doesn't modify data.
+        """
+        if hook_name == 'get_credentials':
+            result = self._run_action_plugin(
+                "cisco.nac_dc_vxlan.common.get_credentials",
+                {"inv_list": data, "data_model": self.data_model},
+            )
+            if result.get('retrieve_failed'):
+                raise RuntimeError(f"Credential retrieval failed: {result}")
+            return result
+
+        display.warning(f"Unknown post-hook: {hook_name}")
+        return None
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # File Operations
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _cleanup_files(self):
+        """
+        Remove all files from the output directory for a clean full run.
+
+        Matches the original cleanup_files.yml behavior: delete directory
+        contents and recreate the empty directory.
+        """
+        if os.path.exists(self.output_path):
+            shutil.rmtree(self.output_path)
+        os.makedirs(self.output_path, exist_ok=True)
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Internal Methods (called from pipeline via '_' prefix in resource_name)
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _interface_all(self, rt):
+        """
+        Aggregate all individual interface type data into combined lists.
+
+        Produces two aggregated lists:
+          - interface_all_create: All interfaces EXCEPT breakout_preprov
+            (used by create pipeline with state: merged)
+          - interface_all_remove_overridden: ALL interfaces including breakout_preprov
+            (used by remove pipeline with state: overridden)
+
+        Also runs diff_compare on the aggregated list for targeted operations.
+        """
+        interface_types_create = [
+            'interface_breakout',
+            'interface_trunk',
+            'interface_routed',
+            'sub_interface_routed',
+            'interface_access',
+            'interface_trunk_po',
+            'interface_access_po',
+            'interface_po_routed',
+            'interface_loopback',
+            'interface_dot1q',
+            'interface_vpc',
+        ]
+
+        interface_types_remove = [
+            'interface_breakout',
+            'interface_breakout_preprov',
+            'interface_trunk',
+            'interface_routed',
+            'sub_interface_routed',
+            'interface_access',
+            'interface_trunk_po',
+            'interface_access_po',
+            'interface_po_routed',
+            'interface_loopback',
+            'interface_dot1q',
+            'interface_vpc',
+        ]
+
+        # Aggregate create list (no breakout_preprov)
+        create_list = []
+        for itype in interface_types_create:
+            entry = self.resource_data.get(itype, {})
+            data = entry.get('data', []) if isinstance(entry, dict) else []
+            create_list.extend(data)
+
+        # Aggregate remove/overridden list (includes breakout_preprov)
+        remove_list = []
+        for itype in interface_types_remove:
+            entry = self.resource_data.get(itype, {})
+            data = entry.get('data', []) if isinstance(entry, dict) else []
+            remove_list.extend(data)
+
+        # Write aggregated file for diff comparison
+        output_file = os.path.join(self.output_path, 'ndfc_interface_all.yml')
+        old_file = output_file + '.old'
+
+        # Backup previous
+        if os.path.exists(output_file):
+            shutil.copy2(output_file, old_file)
+            os.remove(output_file)
+
+        # Write current
+        with open(output_file, 'w') as f:
+            yaml.dump(create_list, f, default_flow_style=False)
+
+        # Run structural diff only when downstream targeted processing needs it.
+        diff_result = None
+        if self._should_run_structural_diff(rt.get('diff_compare', False)):
+            diff_result = self._run_diff_compare(old_file, output_file)
+
+        # Run MD5 diff
+        file_changed = self._run_diff_model_changes(old_file, output_file)
+
+        # Set change flag
+        if file_changed and self.check_roles.get('save_previous', False):
+            self.change_flags['changes_detected_interfaces'] = True
+
+        # Store aggregated data
+        self.resource_data['interface_all'] = {
+            'data': create_list,
+            'data_remove_overridden': remove_list,
+            'var_name': 'interface_all_create',
+        }
+        if diff_result is not None:
+            self.resource_data['interface_all']['diff'] = diff_result
+
+        display.v(
+            f"COMMON [{self.fabric_name}] Aggregated interface_all: "
+            f"create={len(create_list)}, remove={len(remove_list)}, "
+            f"changed={file_changed}"
+        )
+
+        return {'failed': False}
+
+    def _child_fabrics(self, rt):
+        """
+        Prepare MSD child fabric association data.
+
+        Delegates to the existing prepare_msite_child_fabrics_data plugin.
+        This is not template-based — it queries the controller for fabric
+        association information.
+
+        Sets the changes_detected_child_fabrics flag when there are child
+        fabrics to add or remove, so that changes_detected_any gates the
+        pipeline correctly. Without this, commenting out all child_fabrics
+        in the data model would leave changes_detected_any=False and skip
+        the entire remove pipeline, preventing child fabric removal.
+        """
+        child_fabrics = self.data_model.get('vxlan', {}).get('multisite', {}).get('child_fabrics')
+
+        if not child_fabrics:
+            child_fabrics = []
+
+        result = self._run_action_plugin(
+            "cisco.nac_dc_vxlan.dtc.prepare_msite_child_fabrics_data",
+            {
+                "parent_fabric": self.fabric_name,
+                "parent_fabric_type": self.fabric_type,
+                "child_fabrics": child_fabrics,
+            },
+        )
+
+        self.resource_data['child_fabrics'] = {
+            'data': result,
+            'var_name': 'child_fabrics',
+        }
+
+        # Signal that child fabric changes are pending so that
+        # changes_detected_any is set and the pipeline is not skipped.
+        to_be_added = result.get('to_be_added', [])
+        to_be_removed = result.get('to_be_removed', [])
+        if (to_be_added or to_be_removed) and self.check_roles.get('save_previous', False):
+            self.change_flags['changes_detected_child_fabrics'] = True
+            display.v(
+                f"COMMON [{self.fabric_name}] Child fabric changes detected: "
+                f"to_add={len(to_be_added)}, to_remove={len(to_be_removed)}"
+            )
+
+        return result
+
+    def _check_msd_child(self, rt):
+        """
+        Check if the current fabric is an active child in an MSD deployment.
+
+        If the fabric is a child of an MSD parent, VRFs and Networks cannot
+        be managed from the child fabric level — they must be managed from
+        the MSD parent. This method fails the pipeline if the user attempts
+        to manage overlay resources from a child fabric.
+        """
+        # Check if already determined
+        is_child = self.task_vars.get('is_active_child_fabric')
+
+        if is_child is None:
+            # Query controller for MSD fabric associations
+            result = self._execute_rest(
+                "GET",
+                "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control"
+                "/fabrics/msd/fabric-associations",
+            )
+
+            is_child = False
+            try:
+                associations = result.get('response', {}).get('DATA', [])
+                if isinstance(associations, list):
+                    for assoc in associations:
+                        if (assoc.get('fabricName') == self.fabric_name and
+                                assoc.get('fabricParent', 'None') != 'None'):
+                            is_child = True
+                            break
+            except (KeyError, TypeError, IndexError):
+                pass
+
+            # Store for downstream use
+            self.task_vars['is_active_child_fabric'] = is_child
+
+        # Check for overlay data on child fabric
+        vrf_entry = self.resource_data.get('vrfs', {})
+        vrf_data = vrf_entry.get('data', []) if isinstance(vrf_entry, dict) else []
+
+        net_entry = self.resource_data.get('networks', {})
+        net_data = net_entry.get('data', []) if isinstance(net_entry, dict) else []
+
+        if is_child and vrf_data:
+            return {
+                'failed': True,
+                'msg': (
+                    f"VRFs cannot be managed from fabric '{self.fabric_name}' "
+                    f"as it is a child fabric part of a Multisite fabric."
+                ),
+            }
+
+        if is_child and net_data:
+            return {
+                'failed': True,
+                'msg': (
+                    f"Networks cannot be managed from fabric '{self.fabric_name}' "
+                    f"as it is a child fabric part of a Multisite fabric."
+                ),
+            }
+
+        return {'failed': False, 'is_active_child_fabric': is_child}
+
+
+class ActionModule(ActionBase):
+    """
+    Ansible ActionBase wrapper for build_resource_data.
+
+    Handles parameter validation, error handling, and delegation
+    to the ResourceDataBuilder domain class.
+    """
+
+    REQUIRED_PARAMS = [
+        'fabric_type', 'fabric_name', 'data_model', 'role_path',
+    ]
+
+    def run(self, tmp=None, task_vars=None):
+        results = super(ActionModule, self).run(tmp, task_vars)
+        task_vars = task_vars or {}
+
+        # Validate required parameters
+        params = self._task.args
+        missing = [p for p in self.REQUIRED_PARAMS if p not in params]
+        if missing:
+            results['failed'] = True
+            results['msg'] = f"Missing required parameters: {missing}"
+            return results
+
+        try:
+            builder = ResourceDataBuilder(params, self, task_vars, tmp)
+            result = builder.build()
+
+            results.update(result)
+            if result.get('failed'):
+                results['failed'] = True
+            else:
+                results['changed'] = any(
+                    r.get('result', {}).get('changed', False)
+                    for r in result.get('results', [])
+                    if isinstance(r.get('result'), dict)
+                )
+
+        except Exception as e:
+            results['failed'] = True
+            results['msg'] = f"Build resource data failed: {str(e)}"
+
+        return results

--- a/plugins/action/dtc/diff_compare.py
+++ b/plugins/action/dtc/diff_compare.py
@@ -84,10 +84,14 @@ class ActionModule(ActionBase):
         # Normalize omit placeholder strings between old and new items
         old_items, new_items = self.normalize_omit_placeholders(old_items, new_items)
 
-        updated_items, removed_items, equal_items = self.compare_items(old_items, new_items)
-
-        if self.new_file_path.endswith('ndfc_interface_all.yml'):
+        # File-type specific comparison
+        if self.new_file_path.endswith('ndfc_policy.yml'):
+            updated_items, removed_items, equal_items = self.compare_policies(old_items, new_items)
+        elif self.new_file_path.endswith('ndfc_interface_all.yml'):
+            updated_items, removed_items, equal_items = self.compare_items(old_items, new_items)
             removed_items = self.order_interface_remove(removed_items)
+        else:
+            updated_items, removed_items, equal_items = self.compare_items(old_items, new_items)
 
         results['compare'] = {"updated": updated_items, "removed": removed_items, "equal": equal_items}
 
@@ -95,6 +99,15 @@ class ActionModule(ActionBase):
         self.write_comparison_results(results['compare'])
 
         return results['compare']
+
+    @staticmethod
+    def _count_policies(switch_blocks):
+        """Count individual policies across nested switch blocks."""
+        count = 0
+        for sb in switch_blocks:
+            for sw in sb.get('switch', []):
+                count += len(sw.get('policies', []))
+        return count
 
     def write_comparison_results(self, compare_results):
         """
@@ -116,13 +129,26 @@ class ActionModule(ActionBase):
         output_path = os.path.join(output_dir, output_filename)
 
         # Prepare the data to write
+        is_policy = self.new_file_path.endswith('ndfc_policy.yml')
         output_data = {
             'comparison_summary': {
                 'timestamp': datetime.datetime.now().isoformat(),
                 'source_file': self.new_file_path,
-                'total_updated': len(compare_results.get('updated', [])),
-                'total_removed': len(compare_results.get('removed', [])),
-                'total_equal': len(compare_results.get('equal', []))
+                'total_updated': (
+                    self._count_policies(compare_results.get('updated', []))
+                    if is_policy
+                    else len(compare_results.get('updated', []))
+                ),
+                'total_removed': (
+                    self._count_policies(compare_results.get('removed', []))
+                    if is_policy
+                    else len(compare_results.get('removed', []))
+                ),
+                'total_equal': (
+                    self._count_policies(compare_results.get('equal', []))
+                    if is_policy
+                    else len(compare_results.get('equal', []))
+                ),
             },
             'updated_items': compare_results.get('updated', []),
             'removed_items': compare_results.get('removed', []),
@@ -258,6 +284,61 @@ class ActionModule(ActionBase):
                 return item.get(key_attr)
 
         return None
+
+    def compare_policies(self, old_items, new_items):
+        """
+        Compare old and new policy data with nested switch-block structure.
+
+        Policy structure: [{switch: [{ip: str, policies: [{description, name, ...}]}]}]
+        Comparison key: (switch_ip, policy_description)
+        Compared fields: name, priority, policy_vars
+
+        Returns:
+            tuple: (updated, removed, equal) as lists of switch blocks.
+        """
+        old_lookup = {}
+        for switch_block in old_items:
+            for sw in switch_block.get('switch', []):
+                ip = sw.get('ip', '')
+                for pol in sw.get('policies', []):
+                    key = (ip, pol.get('description', ''))
+                    old_lookup[key] = pol
+
+        updated_switches = {}
+        equal_switches = {}
+
+        for switch_block in new_items:
+            for sw in switch_block.get('switch', []):
+                ip = sw.get('ip', '')
+                for pol in sw.get('policies', []):
+                    key = (ip, pol.get('description', ''))
+                    old_pol = old_lookup.pop(key, None)
+                    if old_pol is None or self._policy_differs(pol, old_pol):
+                        updated_switches.setdefault(ip, []).append(pol)
+                    else:
+                        equal_switches.setdefault(ip, []).append(pol)
+
+        removed_switches = {}
+        for key, pol in old_lookup.items():
+            removed_switches.setdefault(key[0], []).append(pol)
+
+        def to_switch_blocks(ip_dict):
+            if not ip_dict:
+                return []
+            return [{'switch': [{'ip': ip, 'policies': pols} for ip, pols in ip_dict.items()]}]
+
+        return to_switch_blocks(updated_switches), to_switch_blocks(removed_switches), to_switch_blocks(equal_switches)
+
+    @staticmethod
+    def _policy_differs(desired, previous):
+        """Compare two local policy dicts (rendered YAML). Returns True if different."""
+        if desired.get('name') != previous.get('name'):
+            return True
+        if desired.get('priority') != previous.get('priority'):
+            return True
+        if desired.get('policy_vars') != previous.get('policy_vars'):
+            return True
+        return False
 
     def compare_items(self, old_items, new_items):
         """

--- a/plugins/action/dtc/existing_links_check.py
+++ b/plugins/action/dtc/existing_links_check.py
@@ -36,6 +36,73 @@ class ActionModule(ActionBase):
     looking to add to the fabric. If the link already exists, it will be added to
     the not_required_links list.
     """
+
+    # Profile field -> nvPairs key mapping for value-level comparison
+    PROFILE_TO_NV = {
+        'admin_state': 'ADMIN_STATE',
+        'mtu': 'MTU',
+        'peer1_description': 'PEER1_DESC',
+        'peer2_description': 'PEER2_DESC',
+        'peer1_cmds': 'PEER1_CONF',
+        'peer2_cmds': 'PEER2_CONF',
+        'peer1_ipv4_addr': 'PEER1_IP',
+        'peer2_ipv4_addr': 'PEER2_IP',
+        'enable_macsec': 'ENABLE_MACSEC',
+    }
+
+    # Optional/conditional fields that may be absent from desired profile
+    # but present on controller (field removal detection)
+    REMOVAL_KEYS = {
+        'peer1_cmds': 'PEER1_CONF',
+        'peer2_cmds': 'PEER2_CONF',
+    }
+
+    def _link_profile_changed(self, link, existing_link):
+        """
+        Compare enriched link profile against controller nvPairs.
+
+        Returns True if any profile value differs from the controller,
+        or if the controller has non-empty values for fields absent
+        from the desired profile (field removal detection).
+        """
+        nv = existing_link.get('nvPairs', {})
+        profile = link.get('profile', {})
+        src = link.get('src_device', '')
+        src_if = link.get('src_interface', '')
+        dst = link.get('dst_device', '')
+        dst_if = link.get('dst_interface', '')
+
+        # Forward check: desired profile keys differ from controller
+        for pkey, nv_key in self.PROFILE_TO_NV.items():
+            if pkey in profile:
+                desired_val = str(profile[pkey]).strip()
+                ctrl_val = str(nv.get(nv_key, '')).strip()
+                if desired_val.lower() != ctrl_val.lower():
+                    display.vvv(
+                        f"existing_links_check: DIFF [{src}:{src_if}->{dst}:{dst_if}]: "
+                        f"{pkey}={desired_val!r} vs {nv_key}={ctrl_val!r}"
+                    )
+                    return True
+
+        # Reverse check: controller has non-empty values for keys
+        # absent from desired profile (field was removed by user)
+        for pkey, nv_key in self.REMOVAL_KEYS.items():
+            if pkey not in profile:
+                ctrl_val = str(nv.get(nv_key, '')).strip()
+                if ctrl_val:
+                    display.vvv(
+                        f"existing_links_check: DIFF [{src}:{src_if}->{dst}:{dst_if}]: "
+                        f"{nv_key}={ctrl_val!r} on controller but "
+                        f"{pkey} absent from desired profile (removed)"
+                    )
+                    return True
+
+        display.vvv(
+            f"existing_links_check: NO DIFF [{src}:{src_if}->{dst}:{dst_if}]: "
+            f"profile matches controller"
+        )
+        return False
+
     def run(self, tmp=None, task_vars=None):
         results = super(ActionModule, self).run(tmp, task_vars)
         existing_links = self._task.args['existing_links']
@@ -43,7 +110,14 @@ class ActionModule(ActionBase):
         switch_list = self._task.args['switch_data_model']
         required_links = []
         not_required_links = []
+        display.vvv(f"existing_links_check: {len(fabric_links)} configured links, {len(existing_links)} existing links from NDFC")
         for link in fabric_links:
+            display.vvv(
+                f"existing_links_check: evaluating configured link "
+                f"src={link.get('src_device')}:{link.get('src_interface')} → "
+                f"dst={link.get('dst_device')}:{link.get('dst_interface')} "
+                f"template={link.get('template')}"
+            )
             for existing_link in existing_links:
                 if (
                     'sw1-info' in existing_link and
@@ -66,6 +140,14 @@ class ActionModule(ActionBase):
                          existing_link['sw1-info']['if-name'].lower() == link['dst_interface'].lower() and
                          existing_link['sw2-info']['sw-sys-name'].lower() == link['src_device'].lower() and
                          existing_link['sw2-info']['if-name'].lower() == link['src_interface'].lower())):
+
+                        existing_template = existing_link.get('templateName', '<missing>')
+                        display.vvv(
+                            f"existing_links_check: MATCH found — "
+                            f"existing sw1={existing_link['sw1-info']['sw-sys-name']}:{existing_link['sw1-info']['if-name']} "
+                            f"sw2={existing_link['sw2-info']['sw-sys-name']}:{existing_link['sw2-info']['if-name']} "
+                            f"templateName={existing_template}"
+                        )
 
                         # If the link is in reverse order, swap the src and dst to match
                         # swap also in profile peer1 and peer2
@@ -95,8 +177,10 @@ class ActionModule(ActionBase):
                                 link['profile']['peer2_freeform'] = p1_free
 
                         if 'templateName' not in existing_link:
+                            display.vvv("existing_links_check: → NOT REQUIRED (templateName missing)")
                             not_required_links.append(link)
                         elif existing_link['templateName'] == 'int_pre_provision_intra_fabric_link':
+                            display.vvv("existing_links_check: → REQUIRED (pre-provision)")
                             required_links.append(link)
                         elif existing_link['templateName'] == 'int_intra_fabric_num_link':
                             # Populate additional fields from existing link
@@ -111,13 +195,33 @@ class ActionModule(ActionBase):
                                 link['profile']['enable_macsec'] = existing_link['nvPairs']['ENABLE_MACSEC']
                             else:
                                 link['profile']['enable_macsec'] = 'false'
-                            required_links.append(link)
+                            if self._link_profile_changed(link, existing_link):
+                                display.vvv("existing_links_check: → REQUIRED (num_link, enriched, profile changed)")
+                                required_links.append(link)
+                            else:
+                                display.vvv("existing_links_check: → NOT REQUIRED (num_link, enriched, profile matches)")
+                                not_required_links.append(link)
                         elif existing_link['templateName'] == 'int_intra_fabric_unnum_link':
-                            required_links.append(link)
+                            link["template"] = "int_intra_fabric_unnum_link"
+                            if self._link_profile_changed(link, existing_link):
+                                display.vvv("existing_links_check: → REQUIRED (unnum_link, profile changed)")
+                                required_links.append(link)
+                            else:
+                                display.vvv("existing_links_check: → NOT REQUIRED (unnum_link, profile matches)")
+                                not_required_links.append(link)
                         else:
+                            display.vvv(
+                                f"existing_links_check: → NOT REQUIRED "
+                                f"(unrecognized templateName={existing_link['templateName']})"
+                            )
                             not_required_links.append(link)
             if link not in required_links and link not in not_required_links:
+                display.vvv("existing_links_check: → REQUIRED (no existing match, new link)")
                 required_links.append(link)
 
+        display.vvv(
+            f"existing_links_check: RESULT — "
+            f"required={len(required_links)}, not_required={len(not_required_links)}"
+        )
         results['required_links'] = required_links
         return results

--- a/plugins/action/dtc/fabric_deploy_manager.py
+++ b/plugins/action/dtc/fabric_deploy_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2025-2026 Cisco Systems, Inc. and its affiliates
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -19,6 +19,33 @@
 #
 # SPDX-License-Identifier: MIT
 
+"""
+Fabric Deploy Manager — Consolidated deployment for all fabric types.
+
+Replaces the dtc/deploy role's per-fabric-type sub_main_*.yml files with a
+single action plugin that resolves all fabric-type-specific parameters
+internally from task_vars and data_model.
+
+Deployment model:
+  - operation 'all': Switch-level deploy — queries switch inventory, filters
+    by ccStatus (NA/Pending/Out-of-Sync) and upTimeStr (non-empty), deploys
+    only switches that need it. Config-save is NOT part of this workflow.
+  - operation 'config_save': Standalone config-save (also used by pipeline_base
+    _config_save delegation from create/remove pipelines).
+  - operation 'fabric_deploy': Fabric-level deploy fallback (entire fabric).
+  - operation 'switch_deploy': Standalone switch-level deploy.
+  - operation 'check_sync': Check fabric sync status.
+
+Refactored for SOLID:
+  - ApiPathResolver: Strategy pattern for API path selection (OCP)
+    Resolves MCFG_Child_Fabric onepath/fedproxy vs standard paths once at
+    construction, eliminating repeated if/elif branching in every method.
+  - ChildFabricChangeDetector: Extracts VRF/Network change merging (SRP)
+    Pure data logic separated from deployment orchestration.
+  - FabricDeployManager: Uses ApiPathResolver for path resolution with no
+    fabric-type branching in individual methods.
+"""
+
 from __future__ import absolute_import, division, print_function
 
 
@@ -27,26 +54,173 @@ __metaclass__ = type
 from ansible.utils.display import Display
 from ansible.plugins.action import ActionBase
 from ansible_collections.cisco.nac_dc_vxlan.plugins.filter.version_compare import version_compare
-import inspect
-from time import sleep
+from time import monotonic, sleep
 import re
 
 display = Display()
 
 
+# ═══════════════════════════════════════════════════════════════════════════
+# Multisite Fabric Types — Used for child fabric type classification
+# ═══════════════════════════════════════════════════════════════════════════
+MULTISITE_FABRIC_TYPES = ('MSD', 'MCFG')
+
+# Border gateway switch roles — NDFC switchRole values that correspond to
+# data model roles border_gateway, border_gateway_spine, border_gateway_super_spine
+BGW_SWITCH_ROLES = ('border gateway', 'border gateway spine', 'border gateway super spine')
+
+# VRF/Network response variable names per multisite fabric type
+# These are registered facts set by the create role's fabric-specific task files
+MULTISITE_RESPONSE_VARS = {
+    'MSD': {
+        'vrf_result': 'manage_msd_vrf_result',
+        'network_result': 'manage_msd_network_result',
+    },
+    'MCFG': {
+        'vrf_result': 'manage_mcfg_vrf_result',
+        'network_result': 'manage_mcfg_network_result',
+    },
+}
+
+
+class ApiPathResolver:
+    """Resolves API paths based on fabric type, eliminating per-method branching.
+
+    For MCFG parent fabrics, routes through the onemanage API path.
+    For MCFG child fabrics, routes through onepath (ND <=3.2.2) or fedproxy
+    (ND >=4.1.1) prefixes. For all other fabric types, uses the standard
+    NDFC LAN fabric REST base path.
+
+    This is constructed once per FabricDeployManager instance, so each
+    method can simply reference self.paths.<property> without branching.
+    """
+
+    ONEMANAGE_BASE = "/onemanage/appcenter/cisco/ndfc/api/v1/onemanage"
+
+    def __init__(self, fabric_name, fabric_type, cluster_name=None, nd_version=None):
+        self._fabric_type = fabric_type
+        self._base = self._resolve_base(fabric_type, cluster_name, nd_version)
+        self.fabric_name = fabric_name
+
+    def _resolve_base(self, fabric_type, cluster_name, nd_version):
+        base = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest"
+        if fabric_type == 'MCFG_Child_Fabric' and cluster_name:
+            if version_compare(nd_version, '3.2.2', '<='):
+                return f"/onepath/{cluster_name}{base}"
+            elif version_compare(nd_version, '4.1.1', '>='):
+                return f"/fedproxy/{cluster_name}{base}"
+        return base
+
+    @property
+    def switches_by_fabric(self):
+        if self._fabric_type == 'MCFG':
+            return f"{self.ONEMANAGE_BASE}/fabrics/{self.fabric_name}/inventory/switchesByFabric"
+        return f"{self._base}/control/fabrics/{self.fabric_name}/inventory/switchesByFabric"
+
+    @property
+    def config_save(self):
+        if self._fabric_type == 'MCFG':
+            return f"{self.ONEMANAGE_BASE}/fabrics/{self.fabric_name}/config-save"
+        return f"{self._base}/control/fabrics/{self.fabric_name}/config-save"
+
+    @property
+    def config_deploy(self):
+        if self._fabric_type == 'MCFG':
+            return f"{self.ONEMANAGE_BASE}/fabrics/{self.fabric_name}/config-deploy?forceShowRun=false"
+        return f"{self._base}/control/fabrics/{self.fabric_name}/config-deploy?forceShowRun=false"
+
+    def switch_deploy(self, serial_list):
+        """Path for switch-level config-deploy given a comma-separated serial number list."""
+        if self._fabric_type == 'MCFG':
+            return (
+                f"{self.ONEMANAGE_BASE}/fabrics/{self.fabric_name}"
+                f"/config-deploy/{serial_list}?forceShowRun=false"
+            )
+        return (
+            f"{self._base}/control/fabrics/{self.fabric_name}"
+            f"/config-deploy/{serial_list}?forceShowRun=false"
+        )
+
+    def config_preview(self, serial_list):
+        """Path for config-preview given a comma-separated serial number list."""
+        if self._fabric_type == 'MCFG':
+            return (
+                f"{self.ONEMANAGE_BASE}/fabrics/{self.fabric_name}"
+                f"/config-preview/{serial_list}?forceShowRun=false&showBrief=true"
+            )
+        return (
+            f"{self._base}/control/fabrics/{self.fabric_name}"
+            f"/config-preview/{serial_list}?forceShowRun=false&showBrief=true"
+        )
+
+    @property
+    def fabric_history(self):
+        return (
+            f"{self._base}/config/delivery/deployerHistoryByFabric/"
+            f"{self.fabric_name}?sort=completedTime%3ADES&limit=5"
+        )
+
+
+class ChildFabricChangeDetector:
+    """Determines which child fabrics need deployment based on VRF/Network changes.
+
+    Handles the merge-and-deduplicate logic for VRF and Network response data
+    from the create role, producing a list of child fabrics that need deployment.
+
+    If force_run_all is True or run_map_diff_run is False, all child fabrics
+    are returned (full reconciliation). Otherwise, only child fabrics with
+    detected VRF or Network changes are returned.
+    """
+
+    @staticmethod
+    def detect(force_run_all, run_map_diff_run, child_fabrics, vrf_response_data, network_response_data):
+        """Return list of child fabrics requiring deployment."""
+        if force_run_all or not run_map_diff_run:
+            return child_fabrics
+        return ChildFabricChangeDetector._merge_changes(vrf_response_data, network_response_data)
+
+    @staticmethod
+    def _merge_changes(vrf_response_data, network_response_data):
+        """Merge VRF and Network change data, deduplicating by fabric name."""
+        vrf_changed = []
+        if vrf_response_data and isinstance(vrf_response_data, dict):
+            if vrf_response_data.get('child_fabrics'):
+                vrf_changed = [
+                    {'name': item['fabric'], 'cluster': item.get('cluster')}
+                    for item in vrf_response_data['child_fabrics']
+                    if item.get('changed')
+                ]
+
+        vrf_names = {f['name'] for f in vrf_changed}
+
+        network_changed = []
+        if network_response_data and isinstance(network_response_data, dict):
+            if network_response_data.get('child_fabrics'):
+                network_changed = [
+                    {'name': item['fabric_name'], 'cluster': item.get('cluster_name')}
+                    for item in network_response_data['child_fabrics']
+                    if item.get('changed') and item['fabric_name'] not in vrf_names
+                ]
+
+        return vrf_changed + network_changed
+
+
 class FabricDeployManager:
-    """Manages fabric deployment tasks."""
+    """Manages fabric deployment operations via NDFC REST API.
+
+    Uses ApiPathResolver to select the correct API paths at construction,
+    so path resolution has no fabric-type branching in individual methods.
+
+    Supports both fabric-level deployment (fabric_deploy) and switch-level
+    deployment (get_deployable_switches + switch_deploy) which filters by
+    ccStatus and upTimeStr to deploy only switches that need it.
+    """
 
     def __init__(self, params):
-        self.class_name = self.__class__.__name__
-        method_name = inspect.stack()[0][3]
 
         # Fabric Parameters
         self.fabric_name = params['fabric_name']
         self.fabric_type = params['fabric_type']
-        self.fabric_cluster_name = params.get('cluster_name', None)
-
-        self.nd_version = params.get('nd_major_minor_patch', None)
 
         # Module Execution Parameters
         self.task_vars = params['task_vars']
@@ -54,31 +228,13 @@ class FabricDeployManager:
         self.action_module = params['action_module']
         self.module_name = "cisco.dcnm.dcnm_rest"
 
-        # Module API Paths
-        base_path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest"
-
-        if (
-            self.fabric_type == 'MCFG_Child_Fabric' and
-            self.fabric_cluster_name and
-            version_compare(self.nd_version, '3.2.2', '<=')
-        ):
-            base_path = f"/onepath/{self.fabric_cluster_name}{base_path}"
-        elif (
-            self.fabric_type == 'MCFG_Child_Fabric' and
-            self.fabric_cluster_name and
-            version_compare(self.nd_version, '4.1.1', '>=')
-        ):
-            base_path = f"/fedproxy/{self.fabric_cluster_name}{base_path}"
-
-        self.api_paths = {
-            "get_switches_by_fabric": f"{base_path}/control/fabrics/{self.fabric_name}/inventory/switchesByFabric",
-            "config_save": f"{base_path}/control/fabrics/{self.fabric_name}/config-save",
-            "config_deploy": f"{base_path}/control/fabrics/{self.fabric_name}/config-deploy?forceShowRun=false",
-            "fabric_history": f"{base_path}/config/delivery/deployerHistoryByFabric/{self.fabric_name}?sort=completedTime%3ADES&limit=5",
-            "onemanage_get_switches_by_fabric": f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/fabrics/{self.fabric_name}/inventory/switchesByFabric",
-            "onemanage_config_save": f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/fabrics/{self.fabric_name}/config-save",
-            "onemanage_config_deploy": f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/fabrics/{self.fabric_name}/config-deploy?forceShowRun=false",
-        }
+        # API Path Resolution (Strategy Pattern)
+        self.paths = ApiPathResolver(
+            fabric_name=self.fabric_name,
+            fabric_type=self.fabric_type,
+            cluster_name=params.get('cluster_name'),
+            nd_version=params.get('nd_major_minor_patch'),
+        )
 
         # Fabric State Booleans
         self.fabric_in_sync = True
@@ -90,33 +246,51 @@ class FabricDeployManager:
 
     def fabric_check_sync(self):
         """Check if the fabric is in sync."""
-        method_name = inspect.stack()[0][3]
-        display.banner(f"{self.class_name}.{method_name}() Fabric: ({self.fabric_name}) Type: ({self.fabric_type})")
+        step_start = monotonic()
+        display.display(
+            f"\n{'─' * display.columns}\n"
+            f"DEPLOY [{self.fabric_name}] check_sync\n"
+            f"{'─' * display.columns}",
+            color='dark gray',
+        )
 
         self.fabric_in_sync = True
+        response = self._send_request("GET", self.paths.switches_by_fabric)
 
-        if self.fabric_type not in ['MCFG']:
-            response = self._send_request("GET", self.api_paths["get_switches_by_fabric"])
-        elif self.fabric_type in ['MCFG']:
-            response = self._send_request("GET", self.api_paths["onemanage_get_switches_by_fabric"])
-
-        # For non-Multisite fabrics, retry up to 5 times if out-of-sync
+        # For non-Multisite fabrics, retry up to 60 times if out-of-sync
         # Exclude Multisite parent fabrics (MSD or MCFG) as they are dependent on child fabrics being in sync
-        if self.fabric_type not in ['MSD', 'MCFG']:
-            for attempt in range(5):
+        RETRY_COUNT = 60
+        if self.fabric_type not in MULTISITE_FABRIC_TYPES:
+            for attempt in range(RETRY_COUNT):
                 self._fabric_check_sync_helper(response)
                 if self.fabric_in_sync:
                     break
-                if (attempt + 1) == 5 and not self.fabric_in_sync:
+                if (attempt + 1) == RETRY_COUNT and not self.fabric_in_sync:
                     break
                 else:
-                    display.warning(f"Fabric {self.fabric_name} is out of sync. Attempt {attempt + 1}/5. Sleeping 2 seconds before retry.")
-                    sleep(2)
+                    elapsed = monotonic() - step_start
+                    display.display(
+                        f"DEPLOY [{self.fabric_name}] "
+                        f"check_sync → out of sync, retry {attempt + 1}/{RETRY_COUNT} [{elapsed:.1f}s]",
+                        color='yellow',
+                    )
+                    sleep(10)
                     self.fabric_in_sync = True
-                    response = self._send_request("GET", self.api_paths["get_switches_by_fabric"])
+                    response = self._send_request("GET", self.paths.switches_by_fabric)
 
-        display.banner(f">>>> Fabric: ({self.fabric_name}) Type: ({self.fabric_type}) in sync: {self.fabric_in_sync}")
-        display.banner(">>>>")
+        elapsed = monotonic() - step_start
+        if self.fabric_in_sync:
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"check_sync → ok (in_sync=True) [{elapsed:.1f}s]",
+                color='green',
+            )
+        else:
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"check_sync → warning (in_sync=False) [{elapsed:.1f}s]",
+                color='yellow',
+            )
 
     def _fabric_check_sync_helper(self, response):
         if response.get('DATA'):
@@ -129,46 +303,202 @@ class FabricDeployManager:
 
     def fabric_config_save(self):
         """Trigger a config-save on the fabric."""
-        method_name = inspect.stack()[0][3]
-        display.banner(f"{self.class_name}.{method_name}() Fabric: ({self.fabric_name}) Type: ({self.fabric_type})")
+        step_start = monotonic()
+        display.display(
+            f"\n{'─' * display.columns}\n"
+            f"DEPLOY [{self.fabric_name}] config_save\n"
+            f"{'─' * display.columns}",
+            color='dark gray',
+        )
 
-        if self.fabric_type not in ['MCFG']:
-            response = self._send_request("POST", self.api_paths["config_save"])
-        elif self.fabric_type in ['MCFG']:
-            response = self._send_request("POST", self.api_paths["onemanage_config_save"])
-
-        if response.get('RETURN_CODE') == 200:
-            pass
-        else:
+        config_save_path = self.paths.config_save
+        # display.display(
+        #     f"DEBUG [{self.fabric_name}] config_save request: POST {config_save_path}",
+        #     color='blue',
+        # )
+        response = self._send_request("POST", config_save_path)
+        # display.display(
+        #     f"DEBUG [{self.fabric_name}] config_save response: {response}",
+        #     color='blue',
+        # )
+        elapsed = monotonic() - step_start
+        if response.get('RETURN_CODE') != 200:
             self.fabric_save_succeeded = False
-            display.warning(f">>>> Failed for Fabric {self.fabric_name}: {response}")
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"config_save → failed [{elapsed:.1f}s]",
+                color='red',
+            )
+            display.v(f"DEPLOY [{self.fabric_name}] config_save failure detail: {response}")
+        else:
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"config_save → ok [{elapsed:.1f}s]",
+                color='green',
+            )
 
     def fabric_deploy(self):
-        """Deploy the fabric configuration."""
-        method_name = inspect.stack()[0][3]
-        display.banner(f"{self.class_name}.{method_name}() Fabric: ({self.fabric_name}) Type: ({self.fabric_type})")
+        """Deploy the fabric configuration (fabric-level)."""
+        step_start = monotonic()
+        display.display(
+            f"\n{'─' * display.columns}\n"
+            f"DEPLOY [{self.fabric_name}] fabric_deploy\n"
+            f"{'─' * display.columns}",
+            color='dark gray',
+        )
 
-        if self.fabric_type not in ['MCFG']:
-            response = self._send_request("POST", self.api_paths["config_deploy"])
-        elif self.fabric_type in ['MCFG']:
-            response = self._send_request("POST", self.api_paths["onemanage_config_deploy"])
-
-        if response.get('RETURN_CODE') == 200:
-            pass
-        else:
+        response = self._send_request("POST", self.paths.config_deploy)
+        elapsed = monotonic() - step_start
+        if response.get('RETURN_CODE') != 200:
             self.fabric_deploy_succeeded = False
-            display.warning(f">>>> Failed for Fabric {self.fabric_name}: {response}")
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"fabric_deploy → failed [{elapsed:.1f}s]",
+                color='red',
+            )
+            display.v(f"DEPLOY [{self.fabric_name}] fabric_deploy failure detail: {response}")
+        else:
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"fabric_deploy → ok [{elapsed:.1f}s]",
+                color='green',
+            )
+
+    def get_deployable_switches(self, defer_summary=False):
+        """Query switch inventory and return serial numbers needing deployment.
+
+        A switch needs deployment when both conditions are true:
+          - ccStatus is one of: NA, Pending, Out-of-Sync
+          - upTimeStr is not an empty string (switch is up and reachable)
+
+        When defer_summary is True, the summary line is suppressed so the
+        caller can print a combined summary after merging additional serials
+        (e.g. BGW config-preview results). total_switch_count is always
+        stored for the caller's use.
+        """
+        DEPLOYABLE_CC_STATUSES = ('NA', 'Pending', 'Out-of-Sync')
+
+        step_start = monotonic()
+        display.display(
+            f"\n{'─' * display.columns}\n"
+            f"DEPLOY [{self.fabric_name}] get_deployable_switches\n"
+            f"{'─' * display.columns}",
+            color='dark gray',
+        )
+
+        response = self._send_request("GET", self.paths.switches_by_fabric)
+        switches = response.get('DATA', [])
+        self.total_switch_count = len(switches)
+
+        deployable_serials = []
+        for switch in switches:
+            cc_status = switch.get('ccStatus', '')
+            up_time_str = switch.get('upTimeStr', '')
+            serial = switch.get('serialNumber', '')
+            hostname = switch.get('hostName', switch.get('logicalName', 'unknown'))
+
+            if cc_status in DEPLOYABLE_CC_STATUSES and up_time_str:
+                display.v(
+                    f"  Switch {hostname} ({serial}): ccStatus={cc_status}, "
+                    f"upTimeStr={up_time_str} — needs deployment"
+                )
+                deployable_serials.append(serial)
+            else:
+                display.v(
+                    f"  Switch {hostname} ({serial}): ccStatus={cc_status}, "
+                    f"upTimeStr={up_time_str} — skipping"
+                )
+
+        if not defer_summary:
+            elapsed = monotonic() - step_start
+            if deployable_serials:
+                display.display(
+                    f"DEPLOY [{self.fabric_name}] "
+                    f"get_deployable_switches → ok "
+                    f"(changed={len(deployable_serials)}/{len(switches)}) [{elapsed:.1f}s]",
+                    color='yellow',
+                )
+            else:
+                display.display(
+                    f"DEPLOY [{self.fabric_name}] "
+                    f"get_deployable_switches → ok "
+                    f"(changed=0/{len(switches)}) [{elapsed:.1f}s]",
+                    color='green',
+                )
+        return deployable_serials
+
+    def switch_deploy(self, serial_numbers):
+        """Deploy configuration to specific switches by serial number list."""
+        step_start = monotonic()
+        display.display(
+            f"\n{'─' * display.columns}\n"
+            f"DEPLOY [{self.fabric_name}] switch_deploy ({len(serial_numbers)} switches)\n"
+            f"{'─' * display.columns}",
+            color='dark gray',
+        )
+
+        if not serial_numbers:
+            elapsed = monotonic() - step_start
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"switch_deploy → skipped (no switches) [{elapsed:.1f}s]",
+                color='cyan',
+            )
+            return
+
+        serial_list = ','.join(serial_numbers)
+        display.display(
+            f"DEPLOY [{self.fabric_name}] "
+            f"switch_deploy request: POST {self.paths.switch_deploy(serial_list)}",
+            color='blue',
+        )
+        response = self._send_request("POST", self.paths.switch_deploy(serial_list))
+        display.display(
+            f"DEPLOY [{self.fabric_name}] "
+            f"switch_deploy response: {response}",
+            color='blue',
+        )
+        elapsed = monotonic() - step_start
+        if response.get('RETURN_CODE') != 200:
+            self.fabric_deploy_succeeded = False
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"switch_deploy → failed [{elapsed:.1f}s]",
+                color='red',
+            )
+            display.v(f"DEPLOY [{self.fabric_name}] switch_deploy failure detail: {response}")
+        else:
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"switch_deploy → ok (changed={len(serial_numbers)}) [{elapsed:.1f}s]",
+                color='yellow',
+            )
 
     def fabric_history_get(self):
         """Retrieve fabric deployment history."""
-        method_name = inspect.stack()[0][3]
-        display.banner(f"{self.class_name}.{method_name}() Fabric: ({self.fabric_name}) Type: ({self.fabric_type})")
+        step_start = monotonic()
+        display.display(
+            f"\n{'─' * display.columns}\n"
+            f"DEPLOY [{self.fabric_name}] fabric_history_get\n"
+            f"{'─' * display.columns}",
+            color='dark gray',
+        )
 
-        response = self._send_request("GET", self.api_paths["fabric_history"])
-        if response.get('RETURN_CODE') == 200:
-            pass
+        response = self._send_request("GET", self.paths.fabric_history)
+        elapsed = monotonic() - step_start
+        if response.get('RETURN_CODE') != 200:
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"fabric_history_get → failed [{elapsed:.1f}s]",
+                color='red',
+            )
+            display.v(f"DEPLOY [{self.fabric_name}] fabric_history_get failure detail: {response}")
         else:
-            display.warning(f">>>> Failed for Fabric {self.fabric_name}: {response}")
+            display.display(
+                f"DEPLOY [{self.fabric_name}] "
+                f"fabric_history_get → ok [{elapsed:.1f}s]",
+                color='green',
+            )
 
         # Get last 2 history entries
         self.fabric_history = response.get('DATA', [])[0:2]
@@ -189,10 +519,13 @@ class FabricDeployManager:
             task_vars=self.task_vars,
             tmp=self.tmp
         )
-        if 'response' in response.keys():
+        if isinstance(response, dict) and 'response' in response:
             response = response['response']
-        if 'msg' in response.keys():
+        if isinstance(response, dict) and 'msg' in response and isinstance(response['msg'], dict):
             response = response['msg']
+        # Safety: ensure callers always receive a dict they can call .get() on
+        if not isinstance(response, dict):
+            response = {'DATA': response, 'RETURN_CODE': -1, 'msg': str(response)}
         return response
 
 
@@ -211,143 +544,173 @@ class ActionModule(ActionBase):
         params['fabric_name'] = self._task.args["fabric_name"]
         params['fabric_type'] = self._task.args["fabric_type"]
 
-        # Operations supported include 'all', 'config_save', 'config_deploy', 'check_sync'
+        # Operations supported include 'all', 'config_save', 'fabric_deploy', 'switch_deploy', 'check_sync'
         params['operation'] = self._task.args.get("operation")
 
         # Manage Deployment For Multisite (MSD or MCFG) Parent or Standalone Fabric
+        # Acquire msite_data before parent deploy so manage_fabrics can
+        # include BGW switches via config-preview. This is needed on all
+        # runs (not just day-0/full reconciliation) because BGW switches
+        # from child fabrics may not appear as Out-of-Sync in the parent
+        # fabric's switchesByFabric inventory query.
+        if params['fabric_type'] in MULTISITE_FABRIC_TYPES:
+            data_model = self._task.args.get("data_model", {})
+            child_fabrics = data_model.get('vxlan', {}).get('multisite', {}).get('child_fabrics', [])
+
+            if child_fabrics:
+                params['msite_data'] = self._acquire_msite_data(params)
+
         results = self.manage_fabrics(results, params)
         if results.get('failed'):
             return results
 
-        if params['fabric_type'] in ['MSD', 'MCFG']:
-            # Manage Deployment For Child Fabrics if Multisite (MSD or MCFG)
-            # Child Fabrics are only deployed if there are VRF or Network changes detected by passing in the response data from those tasks
-            # If force_run_all is set to True or run_map_diff_run is set to False, all child fabrics will be deployed regardless of change detection
-
-            if params['fabric_type'] == 'MCFG':
-
-                nd_version = self._task.args["nd_version"]
-
-                # Extract major, minor, patch and patch letter from nd_version
-                # that is set in nac_dc_vxlan.dtc.connectivity_check role
-                # Example nd_version: "3.1.1l" or "3.2.2m"
-                # where 3.1.1/3.2.2 are major.minor.patch respectively
-                # and l/m are the patch letter respectively
-                nd_major_minor_patch = None
-                nd_patch_letter = None
-                match = re.match(r'^(\d+\.\d+\.\d+)([a-z])?$', nd_version)
-                if match:
-                    nd_major_minor_patch = match.group(1)
-                    nd_patch_letter = match.group(2)
-
-                params['nd_major_minor_patch'] = nd_major_minor_patch
-
-            params['force_run_all'] = self._task.args.get("force_run_all", False)
-            params['run_map_diff_run'] = self._task.args.get("run_map_diff_run", True)
-            params['dm_child_fabrics'] = self._task.args.get("data_model_child_fabrics")
-            params['vrf_response_data'] = self._task.args.get("vrf_response_data", False)
-            params['network_response_data'] = self._task.args.get("network_response_data", False)
-
-            results = self.process_child_fabric_changes(results, params)
+        if params['fabric_type'] in MULTISITE_FABRIC_TYPES:
+            # Manage Deployment For Child Fabrics
+            # Child fabrics are only deployed if there are VRF or Network changes
+            # detected. If force_run_all is True or run_map_diff_run is False,
+            # all child fabrics will be deployed regardless of change detection.
+            results = self._resolve_and_process_child_fabrics(results, params)
             if results.get('failed'):
                 return results
 
         return results
 
-    def manage_fabrics(self, results, params):
-        """Manage fabric deployments based on operation parameter."""
+    def _acquire_msite_data(self, params):
+        """Acquire multisite data from create_result cache or controller query fallback.
 
-        for key in ['fabric_type', 'fabric_name', 'operation']:
-            if params[key] is None:
-                results['failed'] = True
-                results['msg'] = f"Missing required parameter '{key}'"
-                return results
+        Checks task_vars['create_result']['msite_data'] first (populated when
+        the create pipeline ran). Falls back to calling prepare_msite_data
+        plugin directly when create was skipped.
 
-        if params['operation'] not in ['all', 'config_save', 'config_deploy', 'check_sync']:
-            results['failed'] = True
-            results['msg'] = "Parameter 'operation' must be one of: [all, config_save, config_deploy, check_sync]"
-            return results
+        Returns:
+            msite_data dict or None if not a multisite fabric.
+        """
+        # Try cached data from create pipeline
+        create_result = params['task_vars'].get('create_result')
+        if isinstance(create_result, dict):
+            msite_data = create_result.get('msite_data')
+            if msite_data:
+                display.v(
+                    f"DEPLOY [{params['fabric_name']}] "
+                    f"Using msite_data from create pipeline cache"
+                )
+                return msite_data
 
-        fabric_manager = FabricDeployManager(params)
+        # Fallback: query controller directly via action plugin dispatch
+        # prepare_msite_data is an action plugin, not a module — must use
+        # action_loader to invoke it properly.
+        display.display(
+            f"DEPLOY [{params['fabric_name']}] "
+            f"msite_data not in create_result — querying controller",
+            color='yellow',
+        )
+        data_model = self._task.args.get("data_model", {})
+        plugin_name = "cisco.nac_dc_vxlan.dtc.prepare_msite_data"
+        plugin_args = {
+            "data_model": data_model,
+            "parent_fabric": params['fabric_name'],
+            "parent_fabric_type": params['fabric_type'],
+            "nd_version": self._task.args.get("nd_version", ""),
+        }
 
-        # Workflows
-        if params['operation'] in ['all']:
-            fabric_manager.fabric_config_save()
-            fabric_manager.fabric_deploy()
-            fabric_manager.fabric_check_sync()
+        original_args = self._task.args
+        original_action = self._task.action
+        try:
+            self._task.args = plugin_args
+            self._task.action = plugin_name
 
-            # For non-Multisite fabrics, check fabric history and retry deployment if out-of-sync
-            # Multisite parent fabrics (MSD or MCFG) are excluded as they are dependent on child fabrics being in sync
-            if not fabric_manager.fabric_in_sync and params['fabric_type'] not in ['MSD', 'MCFG']:
-                # If the fabric is out of sync after deployment try one more time before giving up
-                fabric_manager.fabric_history_get()
-                display.warning(fabric_manager.fabric_history)
-                display.warning("Fabric is out of sync after initial deployment. Attempting one more deployment.")
-                fabric_manager.fabric_config_save()
-                fabric_manager.fabric_deploy()
-                fabric_manager.fabric_check_sync()
+            action_plugin = self._shared_loader_obj.action_loader.get(
+                plugin_name,
+                task=self._task,
+                connection=self._connection,
+                play_context=self._play_context,
+                loader=self._loader,
+                templar=self._templar,
+                shared_loader_obj=self._shared_loader_obj,
+            )
 
-            if not fabric_manager.fabric_in_sync and params['fabric_type'] not in ['MSD', 'MCFG']:
-                fabric_manager.fabric_history_get()
-                results['msg'] = f"Fabric {fabric_manager.fabric_name} is out of sync after deployment."
-                results['fabric_history'] = fabric_manager.fabric_history
-                results['failed'] = True
+            if action_plugin is None:
+                display.warning(
+                    f"DEPLOY [{params['fabric_name']}] "
+                    f"Action plugin '{plugin_name}' not found — skipping msite_data acquisition"
+                )
+                return None
 
-        if params['operation'] in ['config_save']:
-            fabric_manager.fabric_config_save()
-            if not fabric_manager.fabric_save_succeeded:
-                results['failed'] = True
+            result = action_plugin.run(task_vars=params['task_vars'], tmp=params['tmp'])
+        finally:
+            self._task.args = original_args
+            self._task.action = original_action
 
-        if params['operation'] in ['config_deploy']:
-            fabric_manager.fabric_deploy()
-            if not fabric_manager.fabric_deploy_succeeded:
-                results['failed'] = True
+        if result.get('failed'):
+            return None
+        return result
 
-        if params['operation'] in ['check_sync']:
-            fabric_manager.fabric_check_sync()
-            if not fabric_manager.fabric_in_sync:
-                fabric_manager.fabric_history_get()
-                results['msg'] = f"Fabric {fabric_manager.fabric_name} is out of sync."
-                results['fabric_history'] = fabric_manager.fabric_history
-                results['failed'] = True
+    def _resolve_and_process_child_fabrics(self, results, params):
+        """Resolve multisite parameters from data_model/task_vars and process child fabrics."""
+        fabric_type = params['fabric_type']
 
-        return results
+        # Resolve data_model from task args (consolidated entry point)
+        # or fall back to individual args (legacy sub_main compatibility)
+        data_model = self._task.args.get("data_model")
 
-    def process_child_fabric_changes(self, results, params):
-        """Process child fabric changes for Multisite (MSD or MCFG) deployments."""
-
-        for key in ['fabric_type', 'run_map_diff_run', 'force_run_all', 'dm_child_fabrics', 'vrf_response_data', 'network_response_data']:
-            if params[key] is None:
-                results['failed'] = True
-                results['msg'] = f"Missing required parameter '{key}'"
-                return results
-
-        parent_fabric_type = params['fabric_type']
-
-        if parent_fabric_type == 'MCFG' and params['nd_major_minor_patch'] is None:
-            results['failed'] = True
-            results['msg'] = f"Missing required parameter '{key}'"
-            return results
-
-        changed_fabrics = []
-        if params['force_run_all'] or not params['run_map_diff_run']:
-            # Process all child fabrics
-            changed_fabrics = params['dm_child_fabrics']
+        if data_model:
+            # Consolidated path: resolve from data_model
+            child_fabrics = data_model.get('vxlan', {}).get('multisite', {}).get('child_fabrics', [])
         else:
-            # Process child fabric changes for VRFs and Networks
-            changed_fabrics = self._process_child_fabric_changes(params)
+            # Legacy path: passed directly as task arg
+            child_fabrics = self._task.args.get("data_model_child_fabrics", [])
 
-        # Manage child fabric deployments based on force_run_all/run_map_diff_run or detected changes in VRFs or Networks
+        if not child_fabrics:
+            return results
+
+        # Resolve VRF/Network response data from task_vars (registered facts from create role)
+        response_vars = MULTISITE_RESPONSE_VARS.get(fabric_type, {})
+        vrf_response_data = params['task_vars'].get(response_vars.get('vrf_result', ''), [])
+        network_response_data = params['task_vars'].get(response_vars.get('network_result', ''), [])
+
+        # Resolve force_run_all and run_map_diff_run
+        force_run_all = self._task.args.get("force_run_all", False)
+        run_map_diff_run = self._task.args.get("run_map_diff_run", True)
+
+        # MCFG requires ND version for API path routing
+        nd_major_minor_patch = None
+        if fabric_type == 'MCFG':
+            nd_version = self._task.args.get("nd_version", "")
+            match = re.match(r'^(\d+\.\d+\.\d+)([a-z])?$', nd_version)
+            if match:
+                nd_major_minor_patch = match.group(1)
+
+            if nd_major_minor_patch is None:
+                results['failed'] = True
+                results['msg'] = "Missing or invalid 'nd_version' parameter required for MCFG fabric deployment"
+                return results
+
+        params['nd_major_minor_patch'] = nd_major_minor_patch
+
+        # Detect which child fabrics need deployment
+        changed_fabrics = ChildFabricChangeDetector.detect(
+            force_run_all=force_run_all,
+            run_map_diff_run=run_map_diff_run,
+            child_fabrics=child_fabrics,
+            vrf_response_data=vrf_response_data,
+            network_response_data=network_response_data,
+        )
+
+        # Deploy changed child fabrics
         if changed_fabrics:
-            if parent_fabric_type == 'MSD':
-                params['fabric_type'] = "MSD_Child_Fabric"
-            elif parent_fabric_type == 'MCFG':
-                params['fabric_type'] = "MCFG_Child_Fabric"
+            child_fabric_type = f"{fabric_type}_Child_Fabric"
 
             for changed_fabric in changed_fabrics:
                 params['fabric_name'] = changed_fabric['name']
+                params['fabric_type'] = child_fabric_type
                 params['cluster_name'] = changed_fabric.get('cluster', None)
-                display.banner(f"Processing Child Fabric: {params['fabric_name']} Cluster: {params['cluster_name']}")
+                display.display(
+                    f"\n{'─' * display.columns}\n"
+                    f"DEPLOY [{params['fabric_name']}] "
+                    f"child_fabric (cluster={params['cluster_name']})\n"
+                    f"{'─' * display.columns}",
+                    color='dark gray',
+                )
 
                 results = self.manage_fabrics(results, params)
                 if results.get('failed'):
@@ -355,50 +718,195 @@ class ActionModule(ActionBase):
 
         return results
 
-    def _process_child_fabric_changes(self, params):
-        """Helper for processing child fabric changes for Multisite (MSD or MCFG) deployments."""
-        vrf_response_data = params['vrf_response_data']
-        network_response_data = params['network_response_data']
+    def _get_bgw_preview_serials(self, params, msite_data, fabric_manager):
+        """Return BGW serial numbers needing deployment via config-preview.
 
-        vrf_changed_fabrics = []
-        network_changed_fabrics = []
+        Extracts BGW serial numbers from msite_data, queries config-preview
+        against the parent fabric, and returns only those with Out-of-Sync
+        or Pending status. The caller merges these into the main deployable
+        list so they flow through the standard deploy → check → retry lifecycle.
+        """
+        fabric_name = params['fabric_name']
+        child_fabrics_data = msite_data.get('child_fabrics_data', {})
 
-        # Process VRF Changes
-        if vrf_response_data:
-            if vrf_response_data.get('child_fabrics'):
-                child_fabric_vrf_data = vrf_response_data['child_fabrics']
+        # Collect BGW serial numbers across all child fabrics
+        bgw_serials = []
+        for cf_name, cf_data in child_fabrics_data.items():
+            for switch in cf_data.get('switches', []):
+                if switch.get('role', '') in BGW_SWITCH_ROLES:
+                    bgw_serials.append(switch['serial_number'])
+                    display.v(
+                        f"DEPLOY [{fabric_name}] BGW switch: "
+                        f"{switch.get('hostname', 'unknown')} ({switch['serial_number']}) "
+                        f"role={switch['role']} fabric={cf_name}"
+                    )
 
-                # As part of VRF changes detected, get list of changed fabrics
-                vrf_changed_fabrics = [
-                    {
-                        'name': item['fabric'],
-                        'cluster': item.get('cluster')
-                    }
-                    for item in child_fabric_vrf_data
-                    if item.get('changed')
-                ]
+        if not bgw_serials:
+            return []
 
-        # Process Network Changes
-        if network_response_data:
-            if network_response_data.get('child_fabrics'):
-                child_fabric_network_data = network_response_data['child_fabrics']
+        # Query config-preview for BGW switches against parent fabric
+        serial_list = ','.join(bgw_serials)
+        response = fabric_manager._send_request(
+            "GET", fabric_manager.paths.config_preview(serial_list)
+        )
 
-                # As part of Network changes detected, exclude fabrics that have already been marked as changed due to VRF changes
-                network_changed_fabrics = [
-                    {
-                        'name': item['fabric_name'],
-                        'cluster': item.get('cluster_name')
-                    }
-                    for item in child_fabric_network_data
-                    if item.get('changed') and item['fabric_name'] not in vrf_changed_fabrics
-                ]
+        # Filter for switches needing deployment
+        DEPLOYABLE_STATUSES = ('Out-of-Sync', 'Pending')
+        deploy_serials = []
+        preview_data = response.get('DATA', response) if isinstance(response, dict) else response
+        if isinstance(preview_data, list):
+            for entry in preview_data:
+                status = entry.get('status', '')
+                switch_id = entry.get('switchId', '')
+                switch_name = entry.get('switchName', 'unknown')
+                if status in DEPLOYABLE_STATUSES:
+                    deploy_serials.append(switch_id)
+                    display.v(
+                        f"  BGW {switch_name} ({switch_id}): "
+                        f"status={status} — needs deployment"
+                    )
+                else:
+                    display.v(
+                        f"  BGW {switch_name} ({switch_id}): "
+                        f"status={status} — skipping"
+                    )
 
-        merged_fabric_changes = vrf_changed_fabrics + [
-            network_changed_fabric
-            for network_changed_fabric in network_changed_fabrics
-            if network_changed_fabric['name'] not in {
-                network_changed_fabric['name'] for network_changed_fabric in vrf_changed_fabrics
-            }
-        ]
+        return deploy_serials
 
-        return merged_fabric_changes
+    def manage_fabrics(self, results, params):
+        """Manage fabric deployments based on operation parameter."""
+        fabric_name = params['fabric_name']
+        operation = params['operation']
+
+        for key in ['fabric_type', 'fabric_name', 'operation']:
+            if params[key] is None:
+                results['failed'] = True
+                results['msg'] = f"Missing required parameter '{key}'"
+                return results
+
+        if operation not in ['all', 'config_save', 'fabric_deploy', 'switch_deploy', 'check_sync']:
+            results['failed'] = True
+            results['msg'] = "Parameter 'operation' must be one of: [all, config_save, fabric_deploy, switch_deploy, check_sync]"
+            return results
+
+        workflow_start = monotonic()
+        display.display(
+            f"\n{'═' * display.columns}\n"
+            f"DEPLOY [{fabric_name}] "
+            f"Workflow start — operation: {operation}\n"
+            f"{'═' * display.columns}",
+            color='dark gray',
+        )
+
+        fabric_manager = FabricDeployManager(params)
+
+        # Workflows
+        if operation == 'all':
+            # Switch-level deploy: query switches, deploy only those that need it
+            # Config-save is NOT part of this workflow — it is handled by the
+            # create pipeline's _config_save steps at the appropriate points.
+            msite_data = params.get('msite_data')
+            has_bgw_preview = msite_data and params['fabric_type'] in MULTISITE_FABRIC_TYPES
+
+            # When BGW preview is needed, defer the summary line so we can
+            # print a single combined result after merging BGW serials.
+            deploy_step_start = monotonic()
+            deployable = fabric_manager.get_deployable_switches(defer_summary=has_bgw_preview)
+
+            if has_bgw_preview:
+                bgw_serials = self._get_bgw_preview_serials(params, msite_data, fabric_manager)
+                if bgw_serials:
+                    existing = set(deployable)
+                    for serial in bgw_serials:
+                        if serial not in existing:
+                            deployable.append(serial)
+
+                # Print combined summary covering both queries
+                elapsed = monotonic() - deploy_step_start
+                total = fabric_manager.total_switch_count
+                if deployable:
+                    display.display(
+                        f"DEPLOY [{fabric_name}] "
+                        f"get_deployable_switches → ok "
+                        f"(changed={len(deployable)}/{total}) [{elapsed:.1f}s]",
+                        color='yellow',
+                    )
+                else:
+                    display.display(
+                        f"DEPLOY [{fabric_name}] "
+                        f"get_deployable_switches → ok "
+                        f"(changed=0/{total}) [{elapsed:.1f}s]",
+                        color='green',
+                    )
+
+            if deployable:
+                fabric_manager.switch_deploy(deployable)
+                fabric_manager.fabric_check_sync()
+
+                # For non-Multisite fabrics, retry if still out-of-sync
+                if not fabric_manager.fabric_in_sync and params['fabric_type'] not in MULTISITE_FABRIC_TYPES:
+                    fabric_manager.fabric_history_get()
+                    display.display(
+                        f"DEPLOY [{fabric_name}] "
+                        f"out of sync after initial deployment, retrying",
+                        color='yellow',
+                    )
+                    deployable = fabric_manager.get_deployable_switches()
+                    if deployable:
+                        fabric_manager.switch_deploy(deployable)
+                        fabric_manager.fabric_check_sync()
+
+                if not fabric_manager.fabric_in_sync and params['fabric_type'] not in MULTISITE_FABRIC_TYPES:
+                    fabric_manager.fabric_history_get()
+                    results['msg'] = f"Fabric {fabric_manager.fabric_name} is out of sync after deployment."
+                    results['fabric_history'] = fabric_manager.fabric_history
+                    results['failed'] = True
+            else:
+                display.display(
+                    f"DEPLOY [{fabric_name}] "
+                    f"all → skipped (no switches need deployment)",
+                    color='cyan',
+                )
+
+        if operation == 'config_save':
+            fabric_manager.fabric_config_save()
+            if not fabric_manager.fabric_save_succeeded:
+                results['failed'] = True
+
+        if operation == 'fabric_deploy':
+            fabric_manager.fabric_deploy()
+            if not fabric_manager.fabric_deploy_succeeded:
+                results['failed'] = True
+
+        if operation == 'switch_deploy':
+            deployable = fabric_manager.get_deployable_switches()
+            if deployable:
+                fabric_manager.switch_deploy(deployable)
+            else:
+                display.display(
+                    f"DEPLOY [{fabric_name}] "
+                    f"switch_deploy → skipped (no switches need deployment)",
+                    color='cyan',
+                )
+            if not fabric_manager.fabric_deploy_succeeded:
+                results['failed'] = True
+
+        if operation == 'check_sync':
+            fabric_manager.fabric_check_sync()
+            if not fabric_manager.fabric_in_sync:
+                fabric_manager.fabric_history_get()
+                results['msg'] = f"Fabric {fabric_manager.fabric_name} is out of sync."
+                results['fabric_history'] = fabric_manager.fabric_history
+                results['failed'] = True
+
+        workflow_elapsed = monotonic() - workflow_start
+        status_color = 'red' if results.get('failed') else 'dark gray'
+        display.display(
+            f"\n{'═' * display.columns}\n"
+            f"DEPLOY [{fabric_name}] "
+            f"Workflow complete — operation: {operation} [{workflow_elapsed:.1f}s]\n"
+            f"{'═' * display.columns}",
+            color=status_color,
+        )
+
+        return results

--- a/plugins/action/dtc/fabric_deploy_manager.py
+++ b/plugins/action/dtc/fabric_deploy_manager.py
@@ -337,6 +337,8 @@ class FabricDeployManager:
                 color='green',
             )
 
+        return response
+
     def fabric_deploy(self):
         """Deploy the fabric configuration (fabric-level)."""
         step_start = monotonic()
@@ -869,9 +871,14 @@ class ActionModule(ActionBase):
                 )
 
         if operation == 'config_save':
-            fabric_manager.fabric_config_save()
+            response = fabric_manager.fabric_config_save()
             if not fabric_manager.fabric_save_succeeded:
                 results['failed'] = True
+                # Propagate the raw NDFC response so callers (pipeline_base
+                # _config_save) can inspect RETURN_CODE and apply the
+                # non-fatal config-save policy. Without this, RETURN_CODE is
+                # lost and every config-save failure aborts the pipeline.
+                results['msg'] = response
 
         if operation == 'fabric_deploy':
             fabric_manager.fabric_deploy()

--- a/plugins/action/dtc/manage_resources.py
+++ b/plugins/action/dtc/manage_resources.py
@@ -1,0 +1,628 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Manage Resources — Consolidated creation pipeline for all fabric types.
+
+Replaces the dtc/create role's per-fabric-type sub_main_*.yml files and
+task files (~18 files, ~900 lines YAML) with a single data-driven plugin.
+
+Pipeline definitions are loaded from resources/create_resources.yml.
+
+Extends PipelineRunnerBase with create-specific behavior:
+  - _resolve_step_data: diff.updated preference (Recommendation #7)
+  - skip_diff: Pipeline field to bypass diff narrowing (e.g. vpc_fabric_peering_links)
+
+Shared infrastructure (module execution, pipeline skeleton, tag filtering,
+change flag guards, multisite methods, config-save) lives in plugin_utils/.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from ansible.utils.display import Display
+
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.pipeline_base import (
+    PipelineRunnerBase,
+)
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.dtc_action_base import (
+    DtcPipelineActionBase,
+)
+
+display = Display()
+
+
+class ResourceManager(PipelineRunnerBase):
+    """
+    Create pipeline runner.
+
+    Extends PipelineRunnerBase with create-specific data resolution
+    (diff.updated preference) and skip_diff support.
+    """
+
+    REGISTRY_KEY = 'create_resources'
+    OPERATION = 'create'
+
+    def __init__(self, params, executor, task_vars):
+        super().__init__(params, executor, task_vars)
+        self.nd_version = params.get('nd_version', '')
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Data Resolution (create-specific)
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _resolve_step_data(self, resource_name, step):
+        """
+        Resolve the data and state to send for a create step.
+
+        Recommendation #7: Uses explicit run_map_diff_run parameter to
+        gate the diff.updated preference instead of relying on cleanup cascade.
+
+        When diff_run is active and force_run_all is False:
+          - Prefers diff.updated (narrowed data set for changed items only)
+          - Falls back to full data if diff.updated is not available
+        When diff_run is disabled or force_run_all is True:
+          - Always uses full data (complete reconciliation)
+
+        Args:
+            resource_name: Logical name of the resource.
+            step: Pipeline step dict.
+
+        Returns:
+            Tuple of (data_list, state_string).
+        """
+        state = step.get('state')
+        skip_diff = step.get('skip_diff', False)
+        data = self._resolve_create_data(resource_name, skip_diff=skip_diff)
+        return (data, state)
+
+    def _resolve_create_data(self, resource_name, skip_diff=False):
+        """
+        Resolve the data to send for a create step.
+
+        Args:
+            resource_name: Logical name of the resource.
+            skip_diff: If True, always use raw data (bypass diff narrowing).
+
+        Returns:
+            Data list, or None/empty list if no data.
+        """
+        resource_entry = self.resource_data.get(resource_name, {})
+
+        if not isinstance(resource_entry, dict):
+            return resource_entry if resource_entry else []
+
+        # module_data is the authoritative data source set by build_resource_data.
+        # For most resources this equals the raw template data. For resources with
+        # post-hooks (e.g. inventory/get_credentials), this is the hook-transformed
+        # data ready for the NDFC module.
+        data = resource_entry.get('module_data', resource_entry.get('data', []))
+
+        # Recommendation #7: Only use diff.updated when diff_run is explicitly active
+        # skip_diff bypasses this for resources that must always send full data
+        # (e.g. vpc_fabric_peering_links)
+        if not skip_diff and self.run_map_diff_run and not self.force_run_all:
+            diff = resource_entry.get('diff')
+            if diff and isinstance(diff, dict):
+                diff_data = diff.get('updated')
+                if diff_data is not None:
+                    data = diff_data
+
+        return data
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Create-Specific Internal Methods
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _fabric_links_query_and_filter(self, resource_name, step):
+        """
+        Query NDFC for existing fabric links and filter via existing_links_check.
+
+        Replicates the pre-processing from roles/dtc/create/tasks/common/links.yml:
+          1. Resolve fabric_links data (respecting diff_run)
+          2. Query existing links from NDFC (dcnm_links state: query)
+          3. Run existing_links_check action plugin to filter/transform
+          4. Update self.resource_data['fabric_links'] with filtered result
+
+        The subsequent dcnm_links step picks up the filtered data via
+        _resolve_step_data naturally.
+        """
+        # Step 1: Resolve the fabric_links data (respecting diff_run)
+        data, _state = self._resolve_step_data(resource_name, step)
+        if not data:
+            return {'changed': False, 'msg': 'No fabric links data to filter'}
+
+        # Step 2: Query existing links from NDFC
+        query_result = self.executor.execute(
+            module_name="cisco.dcnm.dcnm_links",
+            state="query",
+            config=[{"dst_fabric": self.fabric_name}],
+            fabric_name=self.fabric_name,
+            fabric_param="src_fabric",
+        )
+
+        existing_links = query_result.get('response', [])
+        if not existing_links:
+            # No existing links — all configured links are new/required
+            return {'changed': False, 'msg': 'No existing links on controller'}
+
+        # Step 3: Filter via existing_links_check action plugin
+        switches = (
+            self.data_model.get('vxlan', {})
+            .get('topology', {})
+            .get('switches', [])
+        )
+
+        filter_result = self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.existing_links_check",
+            module_args={
+                "existing_links": existing_links,
+                "fabric_links": data,
+                "switch_data_model": switches,
+            },
+        )
+
+        if filter_result.get('failed'):
+            return {
+                'failed': True,
+                'msg': (
+                    f"existing_links_check failed: "
+                    f"{filter_result.get('msg', 'unknown error')}"
+                ),
+            }
+
+        # Step 4: Update resource_data so the next step picks up filtered links
+        required_links = filter_result.get('required_links', [])
+
+        resource_entry = self.resource_data.get('fabric_links', {})
+        if isinstance(resource_entry, dict):
+            resource_entry['module_data'] = required_links
+        else:
+            self.resource_data['fabric_links'] = {'module_data': required_links}
+
+        display.v(
+            f"CREATE [{self.fabric_name}] fabric_links: "
+            f"{len(data)} configured → {len(required_links)} after filter"
+        )
+
+        return {'changed': False}
+
+    def _underlay_ip_remote_diff(self, resource_name, step):
+        """
+        Remote diff: reconcile underlay IP data model against controller state.
+
+        This method implements Phase 2 of the two-phase comparison:
+
+        Phase 1 - Local YAML Comparison (handled by common/files):
+            Compares the previous and current rendered YAML
+            (ndfc_underlay_ip_address.yml) to detect local data model changes.
+            Output: diff.updated entries for changed resources.
+
+            Example: user changes loopback0 ipv4 from 10.1.0.1/32
+            to 10.1.0.2/32 in the data model -> Phase 1 detects the diff.
+
+        Phase 2 - Controller Reconciliation (this method):
+            Queries the controller (ND) pool resources via
+            underlay_ip_manual_allocation_filter and compares against the desired config.
+            Reduces module_data to only entries needing controller updates.
+
+            Example: 5 switches in data model, but 2 already have the
+            correct pool allocation on the controller -> filtered_config
+            returns only the 3 that need updates.
+
+        In diff_run mode the local YAML diff (Phase 1) already narrows scope,
+        so Phase 2 is skipped to avoid redundant controller queries.
+
+        Args:
+            resource_name: Resource identifier (e.g. underlay_ip_address).
+            step: Pipeline step dict from create_resources.yml.
+
+        Returns:
+            dict with changed and optionally failed/msg keys.
+        """
+
+        data, _meta = self._resolve_step_data(resource_name, step)
+
+        if not data:
+            return {"changed": False, "msg": "No underlay_ip_address data to audit"}
+
+        if self.run_map_diff_run:
+            return {
+                "changed": False,
+                "msg": "Diff run active; skipping underlay IP audit",
+            }
+
+        module_args = {
+            "fabric": self.fabric_name,
+            "desired_config": data,
+        }
+
+        audit_result = self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.underlay_ip_manual_allocation_filter",
+            module_args=module_args,
+        )
+
+        if audit_result.get("failed"):
+            return {
+                "failed": True,
+                "msg": audit_result.get(
+                    "msg", "underlay_ip_manual_allocation_filter failed"
+                ),
+            }
+
+        filtered_config = audit_result.get("filtered_config", [])
+        resource_entry = self.resource_data.get(resource_name, {})
+        if isinstance(resource_entry, dict):
+            resource_entry["module_data"] = filtered_config
+        else:
+            self.resource_data[resource_name] = {
+                "module_data": filtered_config,
+            }
+
+        display.v(
+            f"CREATE [{self.fabric_name}] underlay_ip_address: "
+            f"{len(data)} configured → {len(filtered_config)} after audit"
+        )
+        if display.verbosity >= 2:
+            matched = audit_result.get("matched_total", 0)
+            display.vv(
+                f"CREATE [{self.fabric_name}] underlay_ip_address: "
+                f"{matched} matched controller, {len(filtered_config)} need update"
+            )
+        if display.verbosity >= 3:
+            for entry in audit_result.get("missing_or_mismatch", []):
+                display.vvv(
+                    f"  [{self.fabric_name}] {entry.get('reason')}: "
+                    f"entity={entry.get('entity')} expected={entry.get('expected')} "
+                    f"actual={entry.get('actual')}"
+                )
+        return {"changed": False}
+
+    def _policy_remote_diff(self, resource_name, step):
+        """
+        Two-phase policy diff: reduce policies sent to dcnm_policy module.
+
+        Phase 1 - Local YAML Comparison (diff_run=true):
+            Compares previous and current rendered ndfc_policy.yml.
+            Only policies that changed locally are forwarded.
+
+            Example: user adds nac_ntp to leaf-201 -> only leaf-201
+            switch block is sent to dcnm_policy.
+
+        Phase 2 - Controller Reconciliation (diff_run=false):
+            Queries NDFC per-switch API for all nac_ policies on the
+            managed switches and compares against desired rendered config.
+
+            Example: 200 total policies, 180 match controller
+            -> only 20 sent to dcnm_policy.
+
+        Comparison key: (switch_ip, policy_description)
+        Compared fields: template name, priority, policy_vars vs nvPairs
+
+        Args:
+            resource_name: Resource identifier (policy).
+            step: Pipeline step dict from create_resources.yml.
+
+        Returns:
+            dict with changed and optionally failed/msg keys.
+        """
+        data, _state = self._resolve_step_data(resource_name, step)
+        if not data:
+            return {'changed': False, 'msg': 'No policy data to filter'}
+
+        if self.run_map_diff_run:
+            # Phase 1 handled by diff_compare in build phase.
+            # _resolve_step_data already narrowed to diff.updated.
+            # No controller query needed — skip.
+            return {'changed': False, 'status': 'skipped', 'reason': 'local diff handled by diff_compare'}
+
+        return self._policy_controller_diff(resource_name, data)
+
+    def _get_ip_to_serial_map(self):
+        """
+        Build a mapping of switch IP address to serial number.
+
+        Uses the centralized fabric_switches fact if available, otherwise
+        queries the controller inventory API.
+
+        Returns:
+            Dict mapping ipAddress -> serialNumber.
+        """
+        switches = self.task_vars.get("fabric_switches", [])
+        if switches and isinstance(switches, list):
+            ip_map = {}
+            for sw in switches:
+                ip = sw.get("ipAddress", "")
+                serial = sw.get("serialNumber", "")
+                if ip and serial:
+                    ip_map[ip] = serial
+            if ip_map:
+                display.vvv(
+                    f"CREATE [{self.fabric_name}] ip_to_serial from "
+                    f"fabric_switches fact: {len(ip_map)} switches"
+                )
+                return ip_map
+
+        # Fall back to querying the controller
+        result = self.executor.execute_rest(
+            "GET",
+            "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control"
+            f"/fabrics/{self.fabric_name}/inventory/switchesByFabric",
+        )
+
+        ip_map = {}
+        try:
+            data = result.get("response", {}).get("DATA", [])
+            if isinstance(data, list):
+                for sw in data:
+                    ip = sw.get("ipAddress", "")
+                    serial = sw.get("serialNumber", "")
+                    if ip and serial:
+                        ip_map[ip] = serial
+        except (KeyError, TypeError, AttributeError):
+            pass
+
+        display.vvv(
+            f"CREATE [{self.fabric_name}] ip_to_serial from "
+            f"controller query: {len(ip_map)} switches"
+        )
+        return ip_map
+
+    def _fetch_policies_by_serials(self, serial_numbers):
+        """
+        Fetch policies for specific switches via per-switch API.
+
+        API: GET /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/
+             policies/switches?serialNumber=<comma-separated>
+
+        Chunks serial numbers into groups of 20 to avoid URL length issues.
+
+        Args:
+            serial_numbers: List of switch serial number strings.
+
+        Returns:
+            List of policy dicts from the controller.
+        """
+        chunk_size = 20
+        all_policies = []
+
+        for i in range(0, len(serial_numbers), chunk_size):
+            chunk = serial_numbers[i : i + chunk_size]
+            serials_param = ",".join(chunk)
+            api_path = (
+                "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control"
+                f"/policies/switches?serialNumber={serials_param}"
+            )
+
+            display.vvv(
+                f"CREATE [{self.fabric_name}] fetching policies for "
+                f"{len(chunk)} switches (chunk {i // chunk_size + 1})"
+            )
+
+            result = self.executor.execute_rest("GET", api_path)
+            if result.get("failed"):
+                display.warning(
+                    f"Per-switch policy query failed for chunk: "
+                    f"{result.get('msg', 'unknown')}"
+                )
+                continue
+
+            policies = self._parse_policy_response(result)
+            all_policies.extend(policies)
+
+        display.vvv(
+            f"CREATE [{self.fabric_name}] fetched {len(all_policies)} "
+            f"policies for {len(serial_numbers)} switches"
+        )
+        return all_policies
+
+    def _parse_policy_response(self, query_result):
+        """
+        Parse REST response into a list of policy dicts.
+
+        Handles string, dict (with DATA key), and list response formats.
+
+        Args:
+            query_result: Raw result from execute_rest.
+
+        Returns:
+            List of policy dicts.
+        """
+        response_data = query_result.get("response", {})
+        if isinstance(response_data, str):
+            try:
+                response_data = json.loads(response_data)
+            except (json.JSONDecodeError, TypeError):
+                return []
+
+        if isinstance(response_data, dict):
+            return response_data.get("DATA", [])
+        elif isinstance(response_data, list):
+            return response_data
+        return []
+
+    def _policy_controller_diff(self, resource_name, desired_config):
+        """
+        Phase 2: Compare desired policies against NDFC controller state.
+
+        Queries per-switch API using serial numbers resolved from
+        desired_config switch IPs. Bounds the diff to only the switches
+        NAC is managing.
+
+        If no serial numbers can be resolved (unexpected), logs a warning
+        and returns early — the full config will be sent to dcnm_policy
+        without pre-filtering.
+
+        Comparison:
+            Key: (switch_ip, description)
+            Fields: template name (name vs templateName),
+                    priority, policy_vars vs nvPairs
+
+        Args:
+            resource_name: Resource identifier (policy).
+            desired_config: Current rendered policy config.
+
+        Returns:
+            dict with changed and optionally failed/msg keys.
+        """
+        # Extract unique switch IPs from desired config
+        target_ips = set()
+        for switch_block in desired_config:
+            for sw in switch_block.get('switch', []):
+                ip = sw.get('ip', '')
+                if ip:
+                    target_ips.add(ip)
+
+        # Resolve IPs to serial numbers for per-switch query
+        ip_serial_map = self._get_ip_to_serial_map()
+        target_serials = [ip_serial_map[ip] for ip in target_ips if ip in ip_serial_map]
+
+        if not target_serials:
+            display.warning(
+                f"CREATE [{self.fabric_name}] policy controller diff: "
+                f"no serial numbers resolved for {len(target_ips)} switch IPs. "
+                f"Skipping pre-filter — full config will be sent to dcnm_policy."
+            )
+            return {'changed': False}
+
+        display.vvv(
+            f"CREATE [{self.fabric_name}] policy diff using per-switch API "
+            f"for {len(target_serials)} switches"
+        )
+        controller_policies = self._fetch_policies_by_serials(target_serials)
+
+        # Build lookup: {(ipAddress, description): controller_policy}
+        # Only nac_ managed policies with empty source (user-created)
+        ctrl_lookup = {}
+        for cpol in controller_policies:
+            desc = cpol.get('description', '')
+            if (desc.startswith('nac_') or desc.startswith('nace_')) and cpol.get('source', '') == '':
+                ip = cpol.get('ipAddress', '')
+                ctrl_lookup[(ip, desc)] = cpol
+
+        # Filter desired config to new or changed policies only
+        filtered_config = []
+        total_policies = 0
+        diff_policies = 0
+
+        for switch_block in desired_config:
+            filtered_switches = []
+            for sw in switch_block.get('switch', []):
+                ip = sw.get('ip', '')
+                diff_pols = []
+                for pol in sw.get('policies', []):
+                    total_policies += 1
+                    desc = pol.get('description', '')
+                    ctrl_pol = ctrl_lookup.get((ip, desc))
+
+                    if ctrl_pol is None or self._policy_differs_from_controller(pol, ctrl_pol):
+                        diff_pols.append(pol)
+                        diff_policies += 1
+
+                if diff_pols:
+                    filtered_switches.append({
+                        'ip': ip,
+                        'policies': diff_pols,
+                    })
+
+            if filtered_switches:
+                filtered_config.append({'switch': filtered_switches})
+
+        self._update_policy_resource_data(resource_name, filtered_config)
+
+        display.v(
+            f"CREATE [{self.fabric_name}] policy controller diff: "
+            f"{total_policies} desired, {len(ctrl_lookup)} on controller "
+            f"-> {diff_policies} to push"
+        )
+        return {'changed': False}
+
+    def _policy_differs_from_controller(self, desired, controller):
+        """
+        Compare desired policy against controller policy from API.
+
+        Field mapping:
+            desired.name         <-> controller.templateName
+            desired.priority     <-> controller.priority
+            desired.policy_vars  <-> controller.nvPairs (filtered)
+
+        Returns True if desired state differs from controller.
+        """
+        desc = desired.get('description', '?')
+
+        if desired.get('name') != controller.get('templateName'):
+            display.vvv(
+                f"POLICY DIFF [{desc}]: template name "
+                f"desired={desired.get('name')} vs ctrl={controller.get('templateName')}"
+            )
+            return True
+
+        desired_priority = desired.get('priority')
+        ctrl_priority = controller.get('priority')
+        if desired_priority is not None and ctrl_priority is not None:
+            if int(desired_priority) != int(ctrl_priority):
+                display.vvv(
+                    f"POLICY DIFF [{desc}]: priority "
+                    f"desired={desired_priority} vs ctrl={ctrl_priority}"
+                )
+                return True
+
+        desired_vars = desired.get('policy_vars') or {}
+        ctrl_nv = controller.get('nvPairs', {})
+
+        # Desired vars must match controller
+        for key, val in desired_vars.items():
+            ctrl_val = ctrl_nv.get(key)
+            if ctrl_val is None or str(val).strip() != str(ctrl_val).strip():
+                display.vvv(
+                    f"POLICY DIFF [{desc}]: var {key} "
+                    f"desired={repr(str(val).strip()[:80])} vs "
+                    f"ctrl={repr(str(ctrl_val).strip()[:80] if ctrl_val is not None else None)}"
+                )
+                return True
+
+        return False
+
+    def _update_policy_resource_data(self, resource_name, filtered_config):
+        """Update resource_data with filtered policy config."""
+        resource_entry = self.resource_data.get(resource_name, {})
+        if isinstance(resource_entry, dict):
+            resource_entry['module_data'] = filtered_config
+        else:
+            self.resource_data[resource_name] = {
+                'module_data': filtered_config,
+            }
+
+
+class ActionModule(DtcPipelineActionBase):
+    """
+    Ansible ActionBase wrapper for manage_resources.
+
+    Delegates to ResourceManager via the DtcPipelineActionBase framework.
+    """
+
+    OPERATION_LABEL = 'Manage resources'
+
+    def _create_runner(self, params, executor, task_vars):
+        return ResourceManager(params, executor, task_vars)

--- a/plugins/action/dtc/prepare_msite_child_fabrics_data.py
+++ b/plugins/action/dtc/prepare_msite_child_fabrics_data.py
@@ -78,9 +78,35 @@ class ActionModule(ActionBase):
             path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations"
             multisite_fabric_associations = self._get_child_fabrics_membership(path)
 
+            if multisite_fabric_associations.get('failed'):
+                results['failed'] = True
+                results['msg'] = (
+                    f"Failed to get MSD fabric associations for '{parent_fabric}': "
+                    f"{multisite_fabric_associations.get('msg', 'Unknown error')}"
+                )
+                return results
+
+            response = multisite_fabric_associations.get('response')
+            if response is None:
+                results['failed'] = True
+                results['msg'] = (
+                    f"No response from MSD fabric associations API for '{parent_fabric}'. "
+                    f"Result keys: {list(multisite_fabric_associations.keys())}"
+                )
+                return results
+
+            data = response.get('DATA')
+            if data is None:
+                results['failed'] = True
+                results['msg'] = (
+                    f"No DATA in MSD fabric associations response for '{parent_fabric}'. "
+                    f"Response: {response}"
+                )
+                return results
+
             # Build a list of child fabrics that are associated with the parent fabric (MSD)
             associated_child_fabrics = []
-            for fabric in multisite_fabric_associations.get('response').get('DATA'):
+            for fabric in data:
                 if fabric.get('fabricParent') == parent_fabric:
                     associated_child_fabrics.append(
                         {
@@ -93,15 +119,66 @@ class ActionModule(ActionBase):
             path = f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/fabrics/{parent_fabric}"
             multisite_fabric_associations = self._get_child_fabrics_membership(path)
 
-            # Build a list of child fabrics that are associated with the parent fabric (MCFG)
-            associated_child_fabrics = []
-            for fabric in multisite_fabric_associations.get('response').get('DATA').get('members'):
-                associated_child_fabrics.append(
-                    {
-                        'name': fabric['fabricName'],
-                        'cluster': fabric['clusterName'],
-                    }
-                )
+            # The onemanage fabrics API returns 400 "fabric not found" when the
+            # MCFG fabric has just been created by dcnm_fabric_group but is not
+            # yet registered in onemanage.  Treat this as "no current members"
+            # so all desired child fabrics land in to_be_added.
+            if multisite_fabric_associations.get('failed'):
+                return_code = None
+                msg_data = multisite_fabric_associations.get('msg')
+                if isinstance(msg_data, dict):
+                    return_code = msg_data.get('RETURN_CODE')
+
+                if return_code == 400:
+                    display.v(
+                        f"MCFG fabric '{parent_fabric}' not yet registered in onemanage "
+                        f"(HTTP 400) — treating as no current members"
+                    )
+                    associated_child_fabrics = []
+                else:
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"Failed to get MCFG fabric associations for '{parent_fabric}': "
+                        f"{multisite_fabric_associations.get('msg', 'Unknown error')}"
+                    )
+                    return results
+            else:
+                response = multisite_fabric_associations.get('response')
+                if response is None:
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"No response from MCFG fabric associations API for '{parent_fabric}'. "
+                        f"Result keys: {list(multisite_fabric_associations.keys())}"
+                    )
+                    return results
+
+                data = response.get('DATA')
+                if data is None:
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"No DATA in MCFG fabric associations response for '{parent_fabric}'. "
+                        f"Response: {response}"
+                    )
+                    return results
+
+                members = data.get('members')
+                if members is None:
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"No members in MCFG fabric associations DATA for '{parent_fabric}'. "
+                        f"DATA: {data}"
+                    )
+                    return results
+
+                # Build a list of child fabrics that are associated with the parent fabric (MCFG)
+                associated_child_fabrics = []
+                for fabric in members:
+                    associated_child_fabrics.append(
+                        {
+                            'name': fabric['fabricName'],
+                            'cluster': fabric['clusterName'],
+                        }
+                    )
 
         else:
             results['failed'] = True

--- a/plugins/action/dtc/prepare_msite_data.py
+++ b/plugins/action/dtc/prepare_msite_data.py
@@ -96,6 +96,14 @@ class ActionModule(ActionBase):
             # Need to query the parent MCFG fabric to get the associated child fabrics which also contains each child fabric's fabric setting attributes
             # Additionally, need to query each child fabric's switches separately using the child fabric's cluster name and proxy path based on ND version
 
+            if nd_major_minor_patch is None:
+                results['failed'] = True
+                results['msg'] = (
+                    f"Missing or invalid 'nd_version' parameter '{nd_version}' for MCFG fabric '{parent_fabric}'. "
+                    f"Expected format: 'major.minor.patch' (e.g., '3.2.2' or '4.1.1a')."
+                )
+                return results
+
             mcfg_fabric_associations = self._execute_module(
                 module_name="cisco.dcnm.dcnm_rest",
                 module_args={
@@ -106,10 +114,26 @@ class ActionModule(ActionBase):
                 tmp=tmp
             )
 
+            if mcfg_fabric_associations.get('failed'):
+                results['failed'] = True
+                results['msg'] = (
+                    f"Failed to query MCFG fabric associations for '{parent_fabric}': "
+                    f"{mcfg_fabric_associations.get('msg', 'Unknown error')}"
+                )
+                return results
+
+            members = (mcfg_fabric_associations.get('response', {}).get('DATA', {}) or {}).get('members')
+            if not members:
+                results['failed'] = True
+                results['msg'] = (
+                    f"No child fabric members found for MCFG fabric '{parent_fabric}'. "
+                    f"Verify the fabric exists and has associated member fabrics."
+                )
+                return results
+
             # Build child fabrics data set that are associated with the parent fabric (MCFG)
             child_fabrics_data = {}
-            for fabric in mcfg_fabric_associations.get('response').get('DATA').get('members'):
-                # associated_child_fabrics.append(fabric.get('fabricName'))
+            for fabric in members:
                 fabric_name = fabric.get('fabricName')
                 fabric_cluster = fabric.get('clusterName')
 
@@ -137,8 +161,17 @@ class ActionModule(ActionBase):
                     tmp=tmp
                 )
 
+                if mcfg_child_fabric_switches.get('failed'):
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"Failed to query switches for MCFG child fabric '{fabric_name}' "
+                        f"(cluster: '{fabric_cluster}'): {mcfg_child_fabric_switches.get('msg', 'Unknown error')}"
+                    )
+                    return results
+
                 fabric_switches = []
-                for fabric_switch in mcfg_child_fabric_switches['response']['DATA']:
+                switch_data = (mcfg_child_fabric_switches.get('response', {}).get('DATA') or [])
+                for fabric_switch in switch_data:
                     if 'logicalName' in fabric_switch:
                         fabric_switches.append(
                             {
@@ -249,9 +282,20 @@ class ActionModule(ActionBase):
                         # When switch is in preprovision, sw['hostname'] is None.
                         if sw.get('hostname') is not None:
                             # Compare switches with regex to catch hostname when ip domain-name is configured
-                            regex_pattern = f"^{switch['hostname']}$|^{switch['hostname']}\\..*$"
-                            if re.search(regex_pattern, sw['hostname']):
+                            # Check both directions: data model name vs NDFC name and vice versa
+                            fwd_pattern = f"^{re.escape(switch['hostname'])}$|^{re.escape(switch['hostname'])}\\..*$"
+                            rev_pattern = f"^{re.escape(sw['hostname'])}$|^{re.escape(sw['hostname'])}\\..*$"
+                            if re.search(fwd_pattern, sw['hostname']) or re.search(rev_pattern, switch['hostname']):
                                 switch['mgmt_ip_address'] = sw['mgmt_ip_address']
+
+                if 'mgmt_ip_address' not in switch:
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"Unable to resolve management IP for switch '{switch['hostname']}' "
+                        f"in VRF attach group '{grp['name']}'. "
+                        f"Verify the hostname matches a discovered switch in a child fabric of '{parent_fabric}'."
+                    )
+                    return results
 
                 # Append switch to a flat list of switches for cross comparison later when we query the
                 # MSD fabric information.  We need to stop execution if the list returned by the MSD query
@@ -286,16 +330,29 @@ class ActionModule(ActionBase):
                 for child_fabric in child_fabrics_data.keys():
                     for sw in child_fabrics_data[child_fabric]['switches']:
                         if sw.get('hostname') is not None:
-                            regex_pattern = f"^{switch['hostname']}$|^{switch['hostname']}\\..*$"
-                            if re.search(regex_pattern, sw['hostname']):
+                            # Check both directions: data model name vs NDFC name and vice versa
+                            fwd_pattern = f"^{re.escape(switch['hostname'])}$|^{re.escape(switch['hostname'])}\\..*$"
+                            rev_pattern = f"^{re.escape(sw['hostname'])}$|^{re.escape(sw['hostname'])}\\..*$"
+                            if re.search(fwd_pattern, sw['hostname']) or re.search(rev_pattern, switch['hostname']):
                                 switch['mgmt_ip_address'] = sw['mgmt_ip_address']
-                # Process nested TOR entries and resolve their management IPs
+
+                    # Process nested TOR entries and resolve their management IPs
                     if 'tors' in switch and switch['tors']:
                         for tor in switch['tors']:
                             tor_hostname = tor.get('hostname')
                             if tor_hostname and any(sw['name'] == tor_hostname for sw in child_fabrics_data[child_fabric]['switches']):
                                 found_tor = next((item for item in child_fabrics_data[child_fabric]['switches'] if item["name"] == tor_hostname))
                                 tor['mgmt_ip_address'] = found_tor['mgmt_ip_address']
+
+                if 'mgmt_ip_address' not in switch:
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"Unable to resolve management IP for switch '{switch['hostname']}' "
+                        f"in network attach group '{grp['name']}'. "
+                        f"Verify the hostname matches a discovered switch in a child fabric of '{parent_fabric}'."
+                    )
+                    return results
+
                 # Append switch to a flat list of switches for cross comparison later when we query the
                 # MSD fabric information.  We need to stop execution if the list returned by the MSD query
                 # does not include one of these switches.

--- a/plugins/action/dtc/process_tor_pairing.py
+++ b/plugins/action/dtc/process_tor_pairing.py
@@ -474,374 +474,150 @@ class TorRemovalProcessor:
 
 
 # =============================================================================
-# Unified Action Module
+# Action Module
 # =============================================================================
 
 class ActionModule(ActionBase):
     """
-    Unified Ansible action plugin for TOR pairing operations.
+    Ansible action plugin for TOR pairing create/remove operations.
 
-    This plugin handles both data processing and NDFC API execution for TOR
-    pairing operations. It can operate in two modes:
+    Two operations, each with two modes:
 
-    1. **Prepare mode** (execute_api=false, default for backwards compatibility):
-       Only prepares the operations and returns them for external execution.
+    **Direct mode** — pre-computed items passed via ``pairings``:
 
-    2. **Execute mode** (execute_api=true):
-       Prepares AND executes the NDFC API calls directly.
-
-    Operations:
-        - discover_and_diff: Query NDFC and compute diff against desired state
-        - diff: Compare current and previous pairings (file-based, no NDFC query)
-        - create: Create TOR pairings via POST
-        - remove: Delete TOR pairings via DELETE
-
-    Usage Examples:
-
-        # Discover and Diff - Query NDFC then compute diff against desired state
-        - name: Discover and diff TOR pairings
-          cisco.nac_dc_vxlan.dtc.process_tor_pairing:
-            operation: discover_and_diff
-            fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
-            leaf_serial_number: "{{ leaf_switches_for_query[0].serial_number }}"
-            current_pairings: "{{ vars_common_local.tor_pairing }}"
-          register: tor_diff_result
-          # Returns: discovered_pairings, discovery_count, added, removed, unchanged, stats
-
-        # Create - Execute API calls directly
-        - name: Create TOR pairings in NDFC
+        - name: Create TOR pairings (diff run active)
           cisco.nac_dc_vxlan.dtc.process_tor_pairing:
             operation: create
-            tor_pairing: "{{ vars_common_local.tor_pairing }}"
-            fabric_name: "{{ MD_Extended.vxlan.fabric.name }}"
-            execute_api: true
-          register: tor_create_result
+            pairings: "{{ diff_items }}"
+            fabric_name: "{{ fabric }}"
 
-        # Remove - Execute API calls directly
-        - name: Remove TOR pairings from NDFC
+        - name: Remove TOR pairings (diff run active)
           cisco.nac_dc_vxlan.dtc.process_tor_pairing:
             operation: remove
-            tor_pairing_removed: "{{ vars_common_local.tor_pairing_removed }}"
-            fabric_name: "{{ MD_Extended.vxlan.fabric.name }}"
-            execute_api: true
-          register: tor_remove_result
+            pairings: "{{ diff_items }}"
+            fabric_name: "{{ fabric }}"
+
+    **Discovery mode** — discover from NDFC, diff, then execute:
+
+        - name: Create TOR pairings (diff run disabled)
+          cisco.nac_dc_vxlan.dtc.process_tor_pairing:
+            operation: create
+            fabric_name: "{{ fabric }}"
+            leaf_serial_number: "{{ leaf_sn }}"
+            current_pairings: "{{ desired_pairings }}"
+
+        - name: Remove TOR pairings (diff run disabled)
+          cisco.nac_dc_vxlan.dtc.process_tor_pairing:
+            operation: remove
+            fabric_name: "{{ fabric }}"
+            leaf_serial_number: "{{ leaf_sn }}"
+            current_pairings: "{{ desired_pairings }}"
+
+    Parameters:
+        operation (str):          Required. 'create' or 'remove'.
+        fabric_name (str):        Required. Target NDFC fabric name.
+        pairings (list):          Direct mode — pre-computed pairing dicts.
+        leaf_serial_number (str): Discovery mode — triggers NDFC query + diff.
+        current_pairings (list):  Discovery mode — desired state to diff against.
     """
 
-    def _detect_operation(self, task_vars):
-        """
-        Detect the operation type from explicit parameter or role path.
-
-        Args:
-            task_vars: Ansible task variables
-
-        Returns:
-            str: Operation type ('discover_and_diff', 'diff', 'create', 'remove') or None
-        """
-        # Check for explicit operation parameter first
-        explicit_op = self._task.args.get("operation")
-        if explicit_op and explicit_op in (
-            "discover_and_diff",
-            "diff",
-            "create",
-            "remove",
-        ):
-            return explicit_op
-
-        # Try to detect from role path
-        role_path = task_vars.get('role_path', '') if task_vars else ''
-
-        if 'dtc/remove' in role_path:
-            return 'remove'
-        elif 'dtc/create' in role_path:
-            if self._task.args.get('tor_pairing'):
-                return 'create'
-        elif 'dtc/common' in role_path:
-            if self._task.args.get('current_pairings') is not None:
-                return 'diff'
-
-        # Fallback: detect based on which parameters are provided
-        if self._task.args.get('current_pairings') is not None:
-            return 'diff'
-        elif self._task.args.get("tor_pairing"):
-            return "create"
-        elif self._task.args.get("tor_pairing_removed"):
-            return "remove"
-
-        return None
+    # ─── NDFC REST helper ─────────────────────────────────────────────
 
     def _execute_ndfc_rest(
         self, method, path, json_data=None, task_vars=None, tmp=None
     ):
-        """
-        Execute an NDFC REST API call using cisco.dcnm.dcnm_rest module.
-
-        Args:
-            method: HTTP method (GET, POST, DELETE)
-            path: API path
-            json_data: Optional JSON payload for POST requests
-            task_vars: Ansible task variables
-            tmp: Temporary directory
-
-        Returns:
-            dict: Module execution result
-        """
-        module_args = {
-            "method": method,
-            "path": path,
-        }
-
-        # Use 'data' instead of 'json_data' for dcnm_rest module
-        # This is the primary parameter name, json_data is just an alias
+        """Execute an NDFC REST API call via cisco.dcnm.dcnm_rest."""
+        module_args = {"method": method, "path": path}
         if json_data is not None:
             module_args["data"] = json_data
-
-        result = self._execute_module(
+        return self._execute_module(
             module_name="cisco.dcnm.dcnm_rest",
             module_args=module_args,
             task_vars=task_vars,
-            tmp=tmp
+            tmp=tmp,
         )
 
-        return result
+    # ─── Discovery ────────────────────────────────────────────────────
 
-    def _run_discovery(self, task_vars, tmp):
+    def _discover_pairings(self, fabric_name, leaf_serial_number, task_vars, tmp):
         """
-        Execute TOR pairing discovery operation.
-
-        If leaf_serial_number is provided, queries NDFC first.
-        If discovery_response is provided, processes it directly.
+        Query NDFC for existing TOR pairings and parse the response.
 
         Returns:
-            dict: Results with discovered_pairings
+            dict with 'discovered_pairings' list and 'failed' status.
         """
-        results = {
-            'failed': False,
-            'operation': 'discovery',
-            'discovered_pairings': [],
-            'count': 0
-        }
+        api_path = (
+            f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/tor/"
+            f"fabrics/{fabric_name}/switches/{leaf_serial_number}"
+        )
+        display.v(f"TOR Discovery: Querying NDFC at {api_path}")
 
-        fabric_name = self._task.args.get('fabric_name', '')
-        leaf_serial_number = self._task.args.get('leaf_serial_number', '')
-        discovery_response = self._task.args.get('discovery_response')
+        ndfc_result = self._execute_ndfc_rest(
+            method="GET", path=api_path, task_vars=task_vars, tmp=tmp
+        )
 
-        # If leaf_serial_number provided, query NDFC first
-        if leaf_serial_number and fabric_name:
-            api_path = (
-                f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/tor/"
-                f"fabrics/{fabric_name}/switches/{leaf_serial_number}"
-            )
+        if ndfc_result.get('failed'):
+            return {
+                'failed': False,
+                'discovered_pairings': [],
+                'msg': f"NDFC query returned: {ndfc_result.get('msg', 'unknown error')}",
+            }
 
-            display.v(f"TOR Discovery: Querying NDFC at {api_path}")
-
-            ndfc_result = self._execute_ndfc_rest(
-                method="GET",
-                path=api_path,
-                task_vars=task_vars,
-                tmp=tmp
-            )
-
-            # Check for failure - but don't fail on expected errors
-            if ndfc_result.get('failed'):
-                # If the API returns an error, treat as no pairings found
-                results['msg'] = f"NDFC query returned: {ndfc_result.get('msg', 'unknown error')}"
-                results['ndfc_response'] = ndfc_result
-                return results
-
-            discovery_response = ndfc_result.get('response', {})
-            results['ndfc_response'] = ndfc_result
-
-        # Process the discovery response
+        discovery_response = ndfc_result.get('response', {})
         if not discovery_response:
-            results['msg'] = 'No discovery response to process'
-            return results
+            return {
+                'failed': False,
+                'discovered_pairings': [],
+                'msg': 'No discovery response to process',
+            }
 
         processor = TorDiscoveryProcessor({'discovery_response': discovery_response})
-        processor_results = processor.process()
-        results.update(processor_results)
+        result = processor.process()
+        return {'failed': False, **result}
 
-        return results
+    # ─── Execution helpers ────────────────────────────────────────────
 
-    def _run_diff(self, task_vars, tmp):
-        """
-        Compare current and previous TOR pairings (file-based, no NDFC query).
-
-        Returns:
-            dict: Results with removed, added, unchanged pairings and stats
-        """
-        results = {
+    def _execute_create_operations(self, pairings, fabric_name, task_vars, tmp):
+        """Build and execute TOR pairing create operations via NDFC POST."""
+        result = {
             'failed': False,
-            'operation': 'diff',
-            'removed': [],
-            'added': [],
-            'unchanged': [],
-            'stats': {}
-        }
-
-        current_pairings = self._task.args.get('current_pairings', [])
-        previous_pairings = self._task.args.get('previous_pairings', [])
-
-        # Handle None values
-        if current_pairings is None:
-            current_pairings = []
-        if previous_pairings is None:
-            previous_pairings = []
-
-        processor = TorDiffProcessor({
-            'current_pairings': current_pairings,
-            'previous_pairings': previous_pairings
-        })
-        diff_results = processor.compute_diff()
-
-        results['removed'] = diff_results['removed']
-        results['added'] = diff_results['added']
-        results['unchanged'] = diff_results['unchanged']
-        results['stats'] = diff_results['stats']
-        results['msg'] = (
-            f"Diff complete: {len(diff_results['added'])} added, "
-            f"{len(diff_results['removed'])} removed, "
-            f"{len(diff_results['unchanged'])} unchanged"
-        )
-
-        display.v(f"TOR Diff: {results['msg']}")
-
-        return results
-
-    def _run_discover_and_diff(self, task_vars, tmp):
-        """
-        Execute discovery followed by diff in a single operation.
-
-        Queries NDFC for existing TOR pairings, then computes the diff
-        between the desired (current) pairings and the discovered pairings.
-
-        Returns:
-            dict: Results with discovered_pairings plus diff results
-                  (added, removed, unchanged, stats)
-        """
-        results = {
-            "failed": False,
-            "operation": "discover_and_diff",
-            "discovered_pairings": [],
-            "discovery_count": 0,
-            "removed": [],
-            "added": [],
-            "unchanged": [],
-            "stats": {},
-        }
-
-        # Step 1: Run discovery
-        discovery_results = self._run_discovery(task_vars, tmp)
-
-        if discovery_results.get("failed"):
-            results["failed"] = True
-            results["msg"] = discovery_results.get("msg", "Discovery failed")
-            results["ndfc_response"] = discovery_results.get("ndfc_response")
-            return results
-
-        discovered_pairings = discovery_results.get("discovered_pairings", [])
-        results["discovered_pairings"] = discovered_pairings
-        results["discovery_count"] = len(discovered_pairings)
-        if "ndfc_response" in discovery_results:
-            results["ndfc_response"] = discovery_results["ndfc_response"]
-
-        # Step 2: Run diff using discovered pairings as previous state
-        current_pairings = self._task.args.get("current_pairings", [])
-        if current_pairings is None:
-            current_pairings = []
-
-        processor = TorDiffProcessor(
-            {
-                "current_pairings": current_pairings,
-                "previous_pairings": discovered_pairings,
-            }
-        )
-        diff_results = processor.compute_diff()
-
-        results["removed"] = diff_results["removed"]
-        results["added"] = diff_results["added"]
-        results["unchanged"] = diff_results["unchanged"]
-        results["stats"] = diff_results["stats"]
-        results["msg"] = (
-            f"Discover and diff complete: {len(discovered_pairings)} discovered, "
-            f"{len(diff_results['added'])} added, "
-            f"{len(diff_results['removed'])} removed, "
-            f"{len(diff_results['unchanged'])} unchanged"
-        )
-
-        display.v(f"TOR Discover and Diff: {results['msg']}")
-
-        return results
-
-    def _run_create(self, task_vars, tmp):
-        """
-        Execute TOR pairing create operation.
-
-        Returns:
-            dict: Results with create operations and API results
-        """
-        results = {
-            'failed': False,
-            'operation': 'create',
-            'create_operations': [],
             'api_results': [],
             'count': 0,
             'success_count': 0,
-            'failure_count': 0
+            'failure_count': 0,
         }
 
-        tor_pairing = self._task.args.get('tor_pairing', [])
-        fabric_name = self._task.args.get('fabric_name', '')
-        execute_api = self._task.args.get('execute_api', False)
-
-        if not fabric_name:
-            results['failed'] = True
-            results['msg'] = 'Missing required parameter: fabric_name'
-            return results
-
-        if not tor_pairing:
-            results['msg'] = 'No TOR pairings to create'
-            return results
-
-        # Build operations
         processor = TorCreateProcessor({
-            'tor_pairing': tor_pairing,
-            'fabric_name': fabric_name
+            'tor_pairing': pairings,
+            'fabric_name': fabric_name,
         })
-        create_operations = processor.build_operations()
-        results['create_operations'] = create_operations
-        results['count'] = len(create_operations)
+        operations = processor.build_operations()
+        result['count'] = len(operations)
 
-        if not execute_api:
-            results['msg'] = f'Prepared {len(create_operations)} TOR pairing create operation(s)'
-            return results
+        if not operations:
+            result['msg'] = 'No valid TOR pairing create operations to execute'
+            return result
 
-        # Execute API calls
-        display.v(f"TOR Create: Executing {len(create_operations)} POST operations")
+        display.v(f"TOR Create: Executing {len(operations)} POST operations")
 
-        for op in create_operations:
+        for op in operations:
             pairing_id = op['pairing_id']
-            api_path = op['path']
-            payload = op['payload']
-
             display.v(f"TOR Create: Creating pairing {pairing_id}")
 
             api_result = self._execute_ndfc_rest(
                 method="POST",
-                path=api_path,
-                json_data=json.dumps(payload),
+                path=op['path'],
+                json_data=json.dumps(op['payload']),
                 task_vars=task_vars,
-                tmp=tmp
+                tmp=tmp,
             )
 
-            # Extract error message - handle both string and dict formats from dcnm_rest
             raw_msg = api_result.get('msg', '')
             if isinstance(raw_msg, dict):
-                # dcnm_rest returns errors as dict with RETURN_CODE, MESSAGE, DATA
                 error_msg = json.dumps(raw_msg)
             else:
                 error_msg = str(raw_msg) if raw_msg else ''
 
-            # Capture MODULE FAILURE details from stdout/stderr
             if api_result.get('failed') and 'MODULE FAILURE' in str(error_msg).upper():
                 stdout = api_result.get('module_stdout', api_result.get('stdout', ''))
                 stderr = api_result.get('module_stderr', api_result.get('stderr', ''))
@@ -850,112 +626,83 @@ class ActionModule(ActionBase):
 
             op_result = {
                 'pairing_id': pairing_id,
-                'path': api_path,
+                'path': op['path'],
                 'success': not api_result.get('failed', False),
                 'response': api_result.get('response'),
                 'msg': error_msg,
-                'raw_result': api_result  # Include full result for debugging
+                'raw_result': api_result,
             }
-
-            results['api_results'].append(op_result)
+            result['api_results'].append(op_result)
 
             if op_result['success']:
-                results['success_count'] += 1
+                result['success_count'] += 1
             else:
-                results['failure_count'] += 1
-                display.warning(f"TOR Create: Failed to create pairing {pairing_id}: {op_result['msg']}")
+                result['failure_count'] += 1
+                display.warning(
+                    f"TOR Create: Failed to create pairing {pairing_id}: {op_result['msg']}"
+                )
 
-        # Set overall status
-        if results['failure_count'] > 0 and results['success_count'] == 0:
-            results['failed'] = True
-            results['msg'] = f"All {results['failure_count']} TOR pairing create(s) failed"
-        elif results['failure_count'] > 0:
-            results['msg'] = (
-                f"Created {results['success_count']} TOR pairing(s), "
-                f"{results['failure_count']} failed"
+        if result['failure_count'] > 0 and result['success_count'] == 0:
+            result['failed'] = True
+            result['msg'] = f"All {result['failure_count']} TOR pairing create(s) failed"
+        elif result['failure_count'] > 0:
+            result['msg'] = (
+                f"Created {result['success_count']} TOR pairing(s), "
+                f"{result['failure_count']} failed"
             )
         else:
-            results['msg'] = f"Successfully created {results['success_count']} TOR pairing(s)"
+            result['msg'] = f"Successfully created {result['success_count']} TOR pairing(s)"
 
-        return results
+        return result
 
-    def _run_remove(self, task_vars, tmp):
-        """
-        Execute TOR pairing removal operation.
-
-        Returns:
-            dict: Results with removal operations and API results
-        """
-        results = {
+    def _execute_remove_operations(self, pairings, fabric_name, task_vars, tmp):
+        """Build and execute TOR pairing remove operations via NDFC DELETE."""
+        result = {
             'failed': False,
-            'operation': 'remove',
-            'removal_operations': [],
             'api_results': [],
             'count': 0,
             'success_count': 0,
-            'failure_count': 0
+            'failure_count': 0,
         }
 
-        tor_pairing_removed = self._task.args.get('tor_pairing_removed', [])
-        fabric_name = self._task.args.get('fabric_name', '')
-        execute_api = self._task.args.get('execute_api', False)
-
-        if not fabric_name:
-            results['failed'] = True
-            results['msg'] = 'Missing required parameter: fabric_name'
-            return results
-
-        if not tor_pairing_removed:
-            results['msg'] = 'No TOR pairings to remove'
-            return results
-
-        # Build operations
         processor = TorRemovalProcessor(
-            {"tor_pairing_removed": tor_pairing_removed, "fabric_name": fabric_name}
+            {"tor_pairing_removed": pairings, "fabric_name": fabric_name}
         )
-        removal_operations = processor.build_operations()
-        results['removal_operations'] = removal_operations
-        results['count'] = len(removal_operations)
+        operations = processor.build_operations()
+        result['count'] = len(operations)
 
-        if not execute_api:
-            results["msg"] = (
-                f"Prepared {len(removal_operations)} TOR pairing removal operation(s)"
-            )
-            return results
+        if not operations:
+            result['msg'] = 'No valid TOR pairing removal operations to execute'
+            return result
 
-        # Execute API calls
-        display.v(f"TOR Remove: Executing {len(removal_operations)} DELETE operations")
+        display.v(f"TOR Remove: Executing {len(operations)} DELETE operations")
 
-        for op in removal_operations:
+        for op in operations:
             pairing_id = op['pairing_id']
-            api_path = op['path']
-
             display.v(f"TOR Remove: Removing pairing {pairing_id}")
 
             api_result = self._execute_ndfc_rest(
                 method="DELETE",
-                path=api_path,
+                path=op['path'],
                 task_vars=task_vars,
-                tmp=tmp
+                tmp=tmp,
             )
 
-            # Extract error message - handle both string and dict formats from dcnm_rest
             raw_msg = api_result.get('msg', '')
             if isinstance(raw_msg, dict):
-                # dcnm_rest returns errors as dict with RETURN_CODE, MESSAGE, DATA
-                error_msg_str = str(raw_msg.get('DATA', '')) + ' ' + str(raw_msg.get('MESSAGE', ''))
+                error_msg_str = (
+                    str(raw_msg.get('DATA', '')) + ' ' + str(raw_msg.get('MESSAGE', ''))
+                )
                 full_error_msg = json.dumps(raw_msg)
             else:
                 error_msg_str = str(raw_msg) if raw_msg else ''
                 full_error_msg = error_msg_str
 
-            # Check for acceptable "not found" errors
             is_not_found_error = False
             error_msg_lower = error_msg_str.lower()
             if 'not found' in error_msg_lower or 'does not exist' in error_msg_lower:
                 is_not_found_error = True
 
-            # Capture MODULE FAILURE details from stdout/stderr
             if api_result.get('failed') and 'MODULE FAILURE' in full_error_msg.upper():
                 stdout = api_result.get('module_stdout', api_result.get('stdout', ''))
                 stderr = api_result.get('module_stderr', api_result.get('stderr', ''))
@@ -964,75 +711,163 @@ class ActionModule(ActionBase):
 
             op_result = {
                 'pairing_id': pairing_id,
-                'path': api_path,
+                'path': op['path'],
                 'success': not api_result.get('failed', False) or is_not_found_error,
                 'response': api_result.get('response'),
                 'msg': full_error_msg,
                 'already_removed': is_not_found_error,
-                'raw_result': api_result  # Include full result for debugging
+                'raw_result': api_result,
             }
-
-            results['api_results'].append(op_result)
+            result['api_results'].append(op_result)
 
             if op_result['success']:
-                results['success_count'] += 1
+                result['success_count'] += 1
                 if is_not_found_error:
-                    display.v(f"TOR Remove: Pairing {pairing_id} already removed or not found")
+                    display.v(
+                        f"TOR Remove: Pairing {pairing_id} already removed or not found"
+                    )
             else:
-                results['failure_count'] += 1
-                display.warning(f"TOR Remove: Failed to remove pairing {pairing_id}: {op_result['msg']}")
+                result['failure_count'] += 1
+                display.warning(
+                    f"TOR Remove: Failed to remove pairing {pairing_id}: {op_result['msg']}"
+                )
 
-        # Set overall status
-        if results['failure_count'] > 0 and results['success_count'] == 0:
-            results['failed'] = True
-            results['msg'] = f"All {results['failure_count']} TOR pairing removal(s) failed"
-        elif results['failure_count'] > 0:
-            results['msg'] = (
-                f"Removed {results['success_count']} TOR pairing(s), "
-                f"{results['failure_count']} failed"
+        if result['failure_count'] > 0 and result['success_count'] == 0:
+            result['failed'] = True
+            result['msg'] = f"All {result['failure_count']} TOR pairing removal(s) failed"
+        elif result['failure_count'] > 0:
+            result['msg'] = (
+                f"Removed {result['success_count']} TOR pairing(s), "
+                f"{result['failure_count']} failed"
             )
         else:
-            results['msg'] = f"Successfully removed {results['success_count']} TOR pairing(s)"
+            result['msg'] = f"Successfully removed {result['success_count']} TOR pairing(s)"
 
-        return results
+        return result
+
+    # ─── Mode dispatch ────────────────────────────────────────────────
+
+    def _execute_direct(self, operation, pairings, fabric_name, task_vars, tmp):
+        """Direct mode: execute on pre-computed pairing items."""
+        display.v(
+            f"TOR {operation.title()}: Direct mode — "
+            f"{len(pairings)} pairing(s) to {operation}"
+        )
+        if operation == 'create':
+            result = self._execute_create_operations(
+                pairings, fabric_name, task_vars, tmp
+            )
+        else:
+            result = self._execute_remove_operations(
+                pairings, fabric_name, task_vars, tmp
+            )
+        result['operation'] = operation
+        return result
+
+    def _execute_with_discovery(self, operation, fabric_name, task_vars, tmp):
+        """Discovery mode: query NDFC, diff against desired state, then execute."""
+        leaf_serial_number = self._task.args.get('leaf_serial_number', '')
+        current_pairings = self._task.args.get('current_pairings', []) or []
+
+        # Step 1: Discover existing pairings from NDFC
+        discovery = self._discover_pairings(
+            fabric_name, leaf_serial_number, task_vars, tmp
+        )
+        if discovery.get('failed'):
+            discovery['operation'] = operation
+            return discovery
+
+        discovered = discovery.get('discovered_pairings', [])
+
+        # Step 2: Diff discovered (NDFC state) against desired (current_pairings)
+        diff = TorDiffProcessor({
+            'current_pairings': current_pairings,
+            'previous_pairings': discovered,
+        }).compute_diff()
+
+        # Pick the relevant diff key for this operation
+        items = diff.get('added', []) if operation == 'create' else diff.get('removed', [])
+
+        display.v(
+            f"TOR {operation.title()}: Discovery mode — "
+            f"{len(discovered)} discovered, {len(items)} to {operation}"
+        )
+
+        if not items:
+            return {
+                'failed': False,
+                'operation': operation,
+                'discovered_count': len(discovered),
+                'diff_stats': diff.get('stats', {}),
+                'msg': f"No TOR pairings to {operation} after discovery diff",
+            }
+
+        # Step 3: Execute
+        if operation == 'create':
+            result = self._execute_create_operations(
+                items, fabric_name, task_vars, tmp
+            )
+        else:
+            result = self._execute_remove_operations(
+                items, fabric_name, task_vars, tmp
+            )
+
+        result['operation'] = operation
+        result['discovered_count'] = len(discovered)
+        result['diff_stats'] = diff.get('stats', {})
+        return result
+
+    # ─── Entry point ──────────────────────────────────────────────────
 
     def run(self, tmp=None, task_vars=None):
         """
         Execute the action plugin.
 
-        Detects the operation type and delegates to the appropriate handler.
-
-        Returns:
-            dict: Results from the operation
+        Routes to direct mode (pairings provided) or discovery mode
+        (leaf_serial_number provided) based on parameters.
         """
         results = super(ActionModule, self).run(tmp, task_vars)
-        results['failed'] = False
 
-        # Detect operation type
-        operation = self._detect_operation(task_vars)
-        if not operation:
+        operation = self._task.args.get('operation')
+        fabric_name = self._task.args.get('fabric_name', '')
+        pairings = self._task.args.get('pairings', [])
+        leaf_serial_number = self._task.args.get('leaf_serial_number', '')
+
+        if operation not in ('create', 'remove'):
             results['failed'] = True
             results['msg'] = (
-                "Could not detect operation type. Provide 'operation' parameter "
-                "(discover_and_diff, diff, create, remove) or ensure appropriate input parameters "
-                "(current_pairings, tor_pairing, tor_pairing_removed) are set."
+                "operation must be 'create' or 'remove', "
+                f"got: {operation!r}"
             )
             return results
 
-        # Execute the appropriate operation
+        if not fabric_name:
+            results['failed'] = True
+            results['msg'] = 'Missing required parameter: fabric_name'
+            return results
+
         try:
-            if operation == "discover_and_diff":
-                return self._run_discover_and_diff(task_vars, tmp)
-            elif operation == 'diff':
-                return self._run_diff(task_vars, tmp)
-            elif operation == "create":
-                return self._run_create(task_vars, tmp)
-            elif operation == 'remove':
-                return self._run_remove(task_vars, tmp)
+            # Direct mode: pre-computed items
+            if pairings:
+                return self._execute_direct(
+                    operation, pairings, fabric_name, task_vars, tmp
+                )
+
+            # Discovery mode: query NDFC, diff, execute
+            if leaf_serial_number:
+                return self._execute_with_discovery(
+                    operation, fabric_name, task_vars, tmp
+                )
+
+            # Nothing to do
+            results['operation'] = operation
+            results['msg'] = (
+                'No pairings or leaf_serial_number provided — skipped'
+            )
+            return results
+
         except Exception as e:
             results['failed'] = True
             results['msg'] = f'Failed to execute TOR {operation}: {str(e)}'
             results['operation'] = operation
             return results
-
-        return results

--- a/plugins/action/dtc/remove_resources.py
+++ b/plugins/action/dtc/remove_resources.py
@@ -1,0 +1,740 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Remove Resources — Consolidated removal pipeline for all fabric types.
+
+Replaces the dtc/remove role's per-fabric-type sub_main_*.yml files and
+task files (~16 files, ~800 lines YAML) with a single data-driven plugin.
+
+Pipeline definitions are loaded from resources/remove_resources.yml.
+
+Extends PipelineRunnerBase with remove-specific behavior:
+  - delete_mode_guard safety flags per step
+  - state_full_run: Dual-state removal (deleted for diff_run, overridden for full)
+  - skip_if_child_fabric: Guard for VRFs/networks on active MSD child fabrics
+
+Shared infrastructure (module execution, pipeline skeleton, tag filtering,
+change flag guards, multisite methods) lives in plugin_utils/.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.utils.display import Display
+
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.pipeline_base import (
+    PipelineRunnerBase,
+)
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.dtc_action_base import (
+    DtcPipelineActionBase,
+)
+
+display = Display()
+
+
+class ResourceRemover(PipelineRunnerBase):
+    """
+    Remove pipeline runner.
+
+    Extends PipelineRunnerBase with remove-specific data resolution
+    (diff.removed with dual-state), additional guards (delete_mode,
+    child_fabric), and controller query helpers.
+    """
+
+    REGISTRY_KEY = 'remove_resources'
+    OPERATION = 'remove'
+
+    def __init__(self, params, executor, task_vars):
+        super().__init__(params, executor, task_vars)
+        self.stage_remove = params.get('stage_remove', False)
+
+        # Recommendation #2: delete_mode_guard support
+        # Read delete mode flags from task_vars (user-configurable via group_vars/host_vars)
+        self.delete_modes = {
+            'interface_delete_mode': task_vars.get('interface_delete_mode', False),
+            'vrf_delete_mode': task_vars.get('vrf_delete_mode', False),
+            'network_delete_mode': task_vars.get('network_delete_mode', False),
+            'vpc_delete_mode': task_vars.get('vpc_delete_mode', False),
+            'inventory_delete_mode': task_vars.get('inventory_delete_mode', False),
+            'edge_connections_delete_mode': task_vars.get('edge_connections_delete_mode', False),
+            'policy_delete_mode': task_vars.get('policy_delete_mode', False),
+            'tor_pairing_delete_mode': task_vars.get('tor_pairing_delete_mode', False),
+            'link_fabric_delete_mode': task_vars.get('link_fabric_delete_mode', False),
+            'link_vpc_delete_mode': task_vars.get('link_vpc_delete_mode', False),
+            'multisite_vrf_delete_mode': task_vars.get('multisite_vrf_delete_mode', False),
+            'multisite_network_delete_mode': task_vars.get('multisite_network_delete_mode', False),
+            'multisite_child_fabric_delete_mode': task_vars.get('multisite_child_fabric_delete_mode', False),
+        }
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Pipeline Hooks (remove-specific overrides)
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _pre_pipeline_setup(self):
+        """Pre-fetch fabric switch list for guards and internal methods."""
+        self.fabric_switch_list = self._get_fabric_switches()
+        return {'switch_list': self.fabric_switch_list}
+
+    def _check_additional_guards(self, step, context):
+        """
+        Remove-specific guards: delete_mode, child_fabric.
+
+        Checked before the shared change_flag_guard in the base class.
+        """
+        resource_name = step['resource_name']
+        module = step['module']
+
+        # ── Guard 1: delete_mode_guard (Recommendation #2) ────────────
+        if not self._check_delete_mode(step):
+            display.v(
+                f"REMOVE [{self.fabric_name}] Skipping {resource_name}: "
+                f"delete_mode_guard '{step.get('delete_mode_guard')}' is disabled"
+            )
+            return {
+                'resource_name': resource_name,
+                'module': module,
+                'status': 'skipped',
+                'reason': (
+                    f"delete_mode_guard '{step.get('delete_mode_guard')}' "
+                    f"is disabled"
+                ),
+            }
+
+        # ── Guard 2: skip_if_child_fabric ─────────────────────────────
+        if step.get('skip_if_child_fabric') and self._is_active_child_fabric():
+            display.v(
+                f"REMOVE [{self.fabric_name}] Skipping {resource_name}: "
+                f"fabric is an active MSD child"
+            )
+            return {
+                'resource_name': resource_name,
+                'module': module,
+                'status': 'skipped',
+                'reason': 'active child fabric — skipping to prevent MSD conflict',
+            }
+
+        return None  # All guards passed
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Data Resolution (remove-specific)
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _resolve_step_data(self, resource_name, step):
+        """
+        Determine the data set and module state for resource removal.
+
+        When diff_run is active and force_run_all is False:
+          - Uses diff.removed list with the default 'state' (typically 'deleted')
+        When diff_run is disabled or force_run_all is True:
+          - If full_run_strategy is 'controller_diff': queries NDFC for live
+            state, diffs against the data model, and returns only items on the
+            controller that are NOT in the data model, with state 'deleted'.
+          - If full_run_strategy is 'overridden': sends full resource data
+            with state 'overridden' for full reconciliation against NDFC.
+          - Otherwise uses full resource data with 'state_full_run' if declared
+            (typically 'overridden'), falling back to 'state'.
+
+        Args:
+            resource_name: Logical name of the resource.
+            step: Pipeline step dict from remove_resources.yml.
+
+        Returns:
+            Tuple of (data_list, resolved_state_string).
+        """
+        resource_entry = self.resource_data.get(resource_name, {})
+        default_state = step.get('state')
+        full_run_state = step.get('state_full_run')
+        data_key_full_run = step.get('data_key_full_run', 'data')
+        full_run_override_key = step.get('data_key_overridden')
+
+        if not isinstance(resource_entry, dict):
+            return (resource_entry if resource_entry else [], default_state)
+
+        # Some remove steps are intentionally always full-reconciliation and
+        # never diff-narrowed (for example switch inventory removal, which
+        # always uses state=overridden in the original role).
+        if default_state == 'overridden':
+            data_key = full_run_override_key or data_key_full_run
+            if data_key == 'data' and 'module_data' in resource_entry:
+                data_key = 'module_data'
+            data = resource_entry.get(data_key, [])
+            return (data, default_state)
+
+        # Diff-based run: use diff.removed with default state (deleted)
+        if self.run_map_diff_run and not self.force_run_all:
+            diff = resource_entry.get('diff')
+            if diff and isinstance(diff, dict):
+                removed = diff.get('removed', [])
+                if removed:
+                    return (removed, default_state)
+            return ([], default_state)
+
+        # Full run with controller_diff strategy: query NDFC, diff, return
+        # only items on the controller that are absent from the data model.
+        full_run_strategy = step.get('full_run_strategy')
+
+        if full_run_strategy == 'controller_diff':
+            method_name = f"_controller_diff_{resource_name}"
+            method = getattr(self, method_name, None)
+            if method is None:
+                display.warning(
+                    f"REMOVE [{self.fabric_name}] No controller diff method "
+                    f"'{method_name}' found for {resource_name} — skipping"
+                )
+                return ([], default_state)
+            data = resource_entry.get('data', [])
+            items_to_delete = method(data)
+            return (items_to_delete, default_state)
+
+        # Full run with overridden strategy: send full data with state overridden
+        # for full reconciliation against the controller.
+        if full_run_strategy == 'overridden':
+            data_key = (
+                full_run_override_key
+                or step.get('data_key_full_run')
+                or ('data_remove_overridden' if 'data_remove_overridden' in resource_entry else None)
+                or ('module_data' if 'module_data' in resource_entry else 'data')
+            )
+            data = resource_entry.get(data_key, [])
+            return (data, 'overridden')
+
+        # Full run (legacy): use full data with full_run_state if declared
+        resolved_state = full_run_state if full_run_state else default_state
+        if data_key_full_run == 'data' and 'module_data' in resource_entry:
+            data_key_full_run = 'module_data'
+        data = resource_entry.get(data_key_full_run, [])
+        return (data, resolved_state)
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Remove-Specific Guard Helpers
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _check_delete_mode(self, step):
+        """
+        Check if the user-configurable delete mode flag allows this step.
+
+        Recommendation #2: Each pipeline step can declare a delete_mode_guard
+        field. If present, the corresponding user variable must be truthy
+        for the step to execute. If absent, the step always executes.
+
+        Args:
+            step: Pipeline step dict.
+
+        Returns:
+            True if the step should execute, False if it should be skipped.
+        """
+        delete_mode_flag = step.get('delete_mode_guard')
+        if not delete_mode_flag:
+            return True  # No guard configured — always execute
+        return bool(self.delete_modes.get(delete_mode_flag, False))
+
+    def _is_active_child_fabric(self):
+        """
+        Check if the current fabric is an active child in an MSD deployment.
+
+        Caches the result as an instance variable after the first API call,
+        since multiple pipeline steps may check this within a single execution.
+
+        Returns:
+            True if the fabric is an active MSD child, False otherwise.
+        """
+        if hasattr(self, '_cached_child_fabric_result'):
+            return self._cached_child_fabric_result
+
+        # If centralized controller discovery has already set this fact,
+        # use it directly from task_vars
+        if 'is_active_child_fabric' in self.task_vars:
+            self._cached_child_fabric_result = bool(
+                self.task_vars['is_active_child_fabric']
+            )
+            return self._cached_child_fabric_result
+
+        # Fall back to querying the controller
+        result = self.executor.execute_rest(
+            "GET",
+            "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control"
+            "/fabrics/msd/fabric-associations",
+        )
+
+        is_child = False
+        try:
+            associations = result.get('response', {}).get('DATA', [])
+            if isinstance(associations, list):
+                for assoc in associations:
+                    if (assoc.get('fabricName') == self.fabric_name and
+                            assoc.get('fabricParent', 'None') != 'None'):
+                        is_child = True
+                        break
+        except (KeyError, TypeError, IndexError):
+            pass
+
+        self._cached_child_fabric_result = is_child
+        return is_child
+
+    def _get_fabric_switches(self):
+        """
+        Get the list of switches in the current fabric from NDFC.
+
+        If centralized controller discovery has set the fabric_switches fact,
+        uses that directly. Otherwise queries the controller.
+
+        Returns:
+            List of switch dicts, or empty list if no switches.
+        """
+        # Use centralized fact if available (Recommendation #3)
+        if 'fabric_switches' in self.task_vars:
+            switches = self.task_vars['fabric_switches']
+            return switches if isinstance(switches, list) else []
+
+        # Fall back to querying the controller
+        result = self.executor.execute_rest(
+            "GET",
+            f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control"
+            f"/fabrics/{self.fabric_name}/inventory/switchesByFabric",
+        )
+
+        try:
+            data = result.get('response', {}).get('DATA', [])
+            return data if isinstance(data, list) else []
+        except (KeyError, TypeError):
+            return []
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Remove-Specific Internal Methods
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _fabric_links_query_and_remove(self, resource_name, step):
+        """
+        Query NDFC for existing fabric links and identify unmanaged links for removal.
+
+        Replicates the pre-processing from roles/dtc/remove/tasks/common/links.yml:
+          1. Query existing links from NDFC (dcnm_links state: query)
+          2. Run links_filter_and_remove action plugin to identify unmanaged links
+          3. Update self.resource_data['fabric_links'] with links to remove
+
+        The subsequent dcnm_links step picks up the filtered data via
+        _resolve_step_data naturally.
+        """
+        # Step 1: Query existing links from NDFC
+        query_result = self.executor.execute(
+            module_name="cisco.dcnm.dcnm_links",
+            state="query",
+            config=[{"dst_fabric": self.fabric_name}],
+            fabric_name=self.fabric_name,
+            fabric_param="src_fabric",
+        )
+
+        existing_links = query_result.get('response', [])
+        if not existing_links:
+            # No existing links — nothing to remove
+            resource_entry = self.resource_data.get('fabric_links', {})
+            if isinstance(resource_entry, dict):
+                resource_entry['module_data'] = []
+            else:
+                self.resource_data['fabric_links'] = {'module_data': []}
+            return {'changed': False, 'msg': 'No existing links on controller'}
+
+        # Step 2: Get the full configured fabric_links data (not diff-narrowed)
+        resource_entry = self.resource_data.get('fabric_links', {})
+        if isinstance(resource_entry, dict):
+            fabric_links_data = resource_entry.get('data', [])
+        else:
+            fabric_links_data = resource_entry if resource_entry else []
+
+        switches = (
+            self.data_model.get('vxlan', {})
+            .get('topology', {})
+            .get('switches', [])
+        )
+
+        # Step 3: Filter via links_filter_and_remove action plugin
+        filter_result = self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.links_filter_and_remove",
+            module_args={
+                "existing_links": existing_links,
+                "fabric_links": fabric_links_data,
+                "switch_data_model": switches,
+            },
+        )
+
+        if filter_result.get('failed'):
+            return {
+                'failed': True,
+                'msg': (
+                    f"links_filter_and_remove failed: "
+                    f"{filter_result.get('msg', 'unknown error')}"
+                ),
+            }
+
+        # Step 4: Update resource_data so the next step picks up links to remove
+        links_to_remove = filter_result.get('links_to_be_removed', [])
+
+        resource_entry = self.resource_data.get('fabric_links', {})
+        if isinstance(resource_entry, dict):
+            resource_entry['module_data'] = links_to_remove
+        else:
+            self.resource_data['fabric_links'] = {'module_data': links_to_remove}
+
+        display.v(
+            f"REMOVE [{self.fabric_name}] fabric_links: "
+            f"{len(existing_links)} on controller → {len(links_to_remove)} to remove"
+        )
+
+        return {'changed': False}
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Controller Diff — Query NDFC, diff against data model, return deletions
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _get_fabric_id(self):
+        """
+        Get the numeric fabric ID from NDFC for the current fabric.
+
+        Caches the result on the instance after the first API call.
+
+        Returns:
+            Integer fabric ID, or None if the query fails.
+        """
+        if hasattr(self, '_cached_fabric_id'):
+            return self._cached_fabric_id
+
+        result = self.executor.execute_rest(
+            "GET",
+            f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control"
+            f"/fabrics/{self.fabric_name}",
+        )
+
+        fabric_id = None
+        try:
+            response = result.get('response', {})
+            data = response.get('DATA', response)
+            if isinstance(data, str):
+                import json
+                data = json.loads(data)
+            fabric_id = data.get('id')
+        except (KeyError, TypeError, ValueError):
+            pass
+
+        self._cached_fabric_id = fabric_id
+        return fabric_id
+
+    def _build_switch_serial_map(self):
+        """
+        Build a mapping of switch serial numbers to management IP addresses.
+
+        Uses the switch list already fetched in _pre_pipeline_setup().
+        Caches the result on the instance.
+
+        Returns:
+            Dict mapping serialNumber → ipAddress (management IP).
+        """
+        if hasattr(self, '_cached_serial_to_ip'):
+            return self._cached_serial_to_ip
+
+        serial_to_ip = {}
+        for switch in self.fabric_switch_list:
+            serial = switch.get('serialNumber')
+            ip = switch.get('ipAddress')
+            if serial and ip:
+                serial_to_ip[serial] = ip
+
+        self._cached_serial_to_ip = serial_to_ip
+        return serial_to_ip
+
+    # ── Interface type mapping ────────────────────────────────────────────
+    # Map NDFC underlayPoliciesStr template names to dcnm_interface types.
+    # Interfaces without a recognized template are skipped (discovered-only).
+    NDFC_POLICY_TO_INTERFACE_TYPE = {
+        'int_trunk_host': 'eth',
+        'int_routed_host': 'eth',
+        'int_access_host': 'eth',
+        'int_dot1q': 'sub_int',
+        'int_routed_host_sub': 'sub_int',
+        'int_port_channel_trunk_host': 'pc',
+        'int_port_channel_access_host': 'pc',
+        'int_port_channel_routed_host': 'pc',
+        'int_vpc_trunk_host': 'vpc',
+        'int_vpc_access_host': 'vpc',
+        'int_loopback': 'lo',
+        'int_fabric_loopback_11_1': 'lo',
+        'int_pre_provision_intra_fabric_link': 'eth',
+        'int_intra_fabric_num_link': 'eth',
+        'int_intra_fabric_unnum_link': 'eth',
+    }
+
+    # Map NDFC ifType values to dcnm_interface types as a fallback.
+    NDFC_IFTYPE_TO_INTERFACE_TYPE = {
+        'INTERFACE_ETHERNET': 'eth',
+        'INTERFACE_PORT_CHANNEL': 'pc',
+        'INTERFACE_VPC': 'vpc',
+        'INTERFACE_LOOPBACK': 'lo',
+        'INTERFACE_VLAN': 'eth',
+        'SUBINTERFACE': 'sub_int',
+    }
+
+    def _controller_diff_interface_all(self, data_model_list):
+        """
+        Query NDFC for all managed interfaces and return those not in the data model.
+
+        Strategy:
+          1. Get fabric ID → query globalInterface API
+          2. Filter to policy-managed interfaces only
+          3. Build sets keyed on (interface_name, switch_ip) for O(n) diffing
+          4. Return items on controller but absent from data model
+
+        Args:
+            data_model_list: List of interface dicts from the rendered data model.
+
+        Returns:
+            List of interface dicts formatted for dcnm_interface state: deleted.
+        """
+        fabric_id = self._get_fabric_id()
+        if fabric_id is None:
+            display.warning(
+                f"REMOVE [{self.fabric_name}] Could not retrieve fabric ID "
+                f"— skipping controller diff for interfaces"
+            )
+            return []
+
+        result = self.executor.execute_rest(
+            "GET",
+            f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest"
+            f"/globalInterface?navId={fabric_id}",
+        )
+
+        controller_interfaces = []
+        try:
+            response = result.get('response', {})
+            data = response.get('DATA', response)
+            if isinstance(data, str):
+                import json
+                data = json.loads(data)
+            if isinstance(data, list):
+                controller_interfaces = data
+        except (KeyError, TypeError, ValueError):
+            display.warning(
+                f"REMOVE [{self.fabric_name}] Failed to parse globalInterface "
+                f"response — skipping controller diff for interfaces"
+            )
+            return []
+
+        serial_to_ip = self._build_switch_serial_map()
+
+        # Build data model set: (interface_name, switch_ip)
+        dm_keys = set()
+        for iface in data_model_list:
+            name = iface.get('name', '')
+            switches = iface.get('switch', [])
+            if isinstance(switches, list):
+                for sw_ip in switches:
+                    dm_keys.add((name, sw_ip))
+            elif isinstance(switches, str):
+                dm_keys.add((name, switches))
+
+        # Filter controller interfaces to policy-managed only and diff
+        items_to_delete = []
+        for ctrl_iface in controller_interfaces:
+            # Skip interfaces without NDFC-managed policies
+            underlay_policies = ctrl_iface.get('underlayPolicies')
+            overlay_str = ctrl_iface.get('overlayPoliciesStr', 'NA')
+            if not underlay_policies and overlay_str == 'NA':
+                continue
+
+            # Skip mgmt interfaces — never managed by the data model
+            if_type = ctrl_iface.get('ifType', '')
+            if if_type == 'INTERFACE_MGMT':
+                continue
+
+            # Skip discovered-only interfaces not managed through policies
+            if ctrl_iface.get('discovered') and not ctrl_iface.get('policyName'):
+                underlay_str = ctrl_iface.get('underlayPoliciesStr', '')
+                if not underlay_str or underlay_str == 'int_mgmt':
+                    continue
+
+            if_name = ctrl_iface.get('ifName', '')
+            serial_no = ctrl_iface.get('serialNo', '')
+            switch_ip = serial_to_ip.get(serial_no, '')
+
+            if not switch_ip:
+                continue
+
+            ctrl_key = (if_name, switch_ip)
+            if ctrl_key not in dm_keys:
+                # Resolve interface type from policy template or ifType
+                iface_type = None
+                if underlay_policies and isinstance(underlay_policies, list):
+                    template = underlay_policies[0].get('templateName', '')
+                    iface_type = self.NDFC_POLICY_TO_INTERFACE_TYPE.get(template)
+                if not iface_type:
+                    iface_type = self.NDFC_IFTYPE_TO_INTERFACE_TYPE.get(if_type)
+                if not iface_type:
+                    continue  # Unknown type — skip
+
+                items_to_delete.append({
+                    'name': if_name,
+                    'type': iface_type,
+                    'switch': [switch_ip],
+                    'deploy': False,
+                })
+
+        display.v(
+            f"REMOVE [{self.fabric_name}] Controller diff for interfaces: "
+            f"{len(controller_interfaces)} on controller, "
+            f"{len(dm_keys)} in data model, "
+            f"{len(items_to_delete)} to delete"
+        )
+
+        return items_to_delete
+
+    def _controller_diff_vrfs(self, data_model_list):
+        """
+        Query NDFC for all VRFs and return those not in the data model.
+
+        Strategy:
+          1. Query top-down VRF API for current fabric
+          2. Build set of VRF names from data model
+          3. Return controller VRFs absent from data model
+
+        Args:
+            data_model_list: List of VRF dicts from the rendered data model.
+
+        Returns:
+            List of VRF dicts formatted for dcnm_vrf state: deleted.
+        """
+        result = self.executor.execute_rest(
+            "GET",
+            f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2"
+            f"/fabrics/{self.fabric_name}/vrfs",
+        )
+
+        controller_vrfs = []
+        try:
+            response = result.get('response', {})
+            data = response.get('DATA', response)
+            if isinstance(data, str):
+                import json
+                data = json.loads(data)
+            if isinstance(data, list):
+                controller_vrfs = data
+        except (KeyError, TypeError, ValueError):
+            display.warning(
+                f"REMOVE [{self.fabric_name}] Failed to parse VRF response "
+                f"— skipping controller diff for VRFs"
+            )
+            return []
+
+        # Build data model set of VRF names
+        dm_vrf_names = frozenset(
+            vrf.get('vrf_name', '') for vrf in data_model_list if vrf.get('vrf_name')
+        )
+
+        # Diff: controller VRFs not in data model
+        items_to_delete = []
+        for ctrl_vrf in controller_vrfs:
+            vrf_name = ctrl_vrf.get('vrfName', '')
+            if vrf_name and vrf_name not in dm_vrf_names:
+                items_to_delete.append({
+                    'vrf_name': vrf_name,
+                })
+
+        display.v(
+            f"REMOVE [{self.fabric_name}] Controller diff for VRFs: "
+            f"{len(controller_vrfs)} on controller, "
+            f"{len(dm_vrf_names)} in data model, "
+            f"{len(items_to_delete)} to delete"
+        )
+
+        return items_to_delete
+
+    def _controller_diff_networks(self, data_model_list):
+        """
+        Query NDFC for all networks and return those not in the data model.
+
+        Strategy:
+          1. Query top-down network API for current fabric
+          2. Build set of network names from data model
+          3. Return controller networks absent from data model
+
+        Args:
+            data_model_list: List of network dicts from the rendered data model.
+
+        Returns:
+            List of network dicts formatted for dcnm_network state: deleted.
+        """
+        result = self.executor.execute_rest(
+            "GET",
+            f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2"
+            f"/fabrics/{self.fabric_name}/networks",
+        )
+
+        controller_networks = []
+        try:
+            response = result.get('response', {})
+            data = response.get('DATA', response)
+            if isinstance(data, str):
+                import json
+                data = json.loads(data)
+            if isinstance(data, list):
+                controller_networks = data
+        except (KeyError, TypeError, ValueError):
+            display.warning(
+                f"REMOVE [{self.fabric_name}] Failed to parse network response "
+                f"— skipping controller diff for networks"
+            )
+            return []
+
+        # Build data model set of network names
+        dm_net_names = frozenset(
+            net.get('net_name', '') for net in data_model_list if net.get('net_name')
+        )
+
+        # Diff: controller networks not in data model
+        items_to_delete = []
+        for ctrl_net in controller_networks:
+            net_name = ctrl_net.get('networkName', '')
+            if net_name and net_name not in dm_net_names:
+                items_to_delete.append({
+                    'net_name': net_name,
+                })
+
+        display.v(
+            f"REMOVE [{self.fabric_name}] Controller diff for networks: "
+            f"{len(controller_networks)} on controller, "
+            f"{len(dm_net_names)} in data model, "
+            f"{len(items_to_delete)} to delete"
+        )
+
+        return items_to_delete
+
+
+class ActionModule(DtcPipelineActionBase):
+    """
+    Ansible ActionBase wrapper for remove_resources.
+
+    Delegates to ResourceRemover via the DtcPipelineActionBase framework.
+    """
+
+    OPERATION_LABEL = 'Remove resources'
+
+    def _create_runner(self, params, executor, task_vars):
+        return ResourceRemover(params, executor, task_vars)

--- a/plugins/action/dtc/underlay_ip_manual_allocation_filter.py
+++ b/plugins/action/dtc/underlay_ip_manual_allocation_filter.py
@@ -1,0 +1,456 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Phase 2 remote diff filter for underlay IP manual allocations.
+
+Underlay IP Manual Allocation Filter (Phase 2 - Controller Reconciliation).
+
+Queries the NDFC controller to determine which desired IP pool allocations
+already exist and match expected values. Filters out allocations that are
+already correct, returning only those needing controller updates.
+
+Part of a two-phase comparison:
+  Phase 1 (local YAML diff via common/files): detects data model changes
+  Phase 2 (this plugin): reconciles desired state against controller state
+
+The desired_config contains four allocation types:
+
+  1. Routing Loopback IPs (device_interface scope, per-switch):
+     entity_name: "<serial>~loopback0"       pool: LOOPBACK0_IP_POOL
+     entity_name: "<serial>~loopback1"       pool: LOOPBACK1_IP_POOL
+
+  2. VTEP Secondary IPs (device_interface scope, vPC pair):
+     entity_name: "<serial1>~<serial2>~loopback1"  pool: LOOPBACK1_IP_POOL
+
+  3. P2P / Backup Link Subnets (link scope, bidirectional):
+     entity_name: "<serial1>~Vlan3600~<serial2>~Vlan3600"  pool: SUBNET
+     Note: endpoint order may vary; _canonicalize_link_entity handles this.
+
+  4. Per-endpoint IPs within a link subnet (device_interface scope):
+     entity_name: "<serial>~Vlan3600"    pool: "10.4.1.0/31"
+     The pool_name IS the allocated subnet from type 3 above.
+
+Matching strategy (two-tier):
+  Tier 1: Exact entity_name + pool_name match
+  Tier 2: Canonical link match for bidirectional links (sorted endpoints)
+
+Pools are auto-detected from desired_config pool_name values, or can be
+explicitly overridden via the query_pools argument.
+
+Returns:
+  filtered_config: allocations needing controller updates (used by caller)
+  missing_or_mismatch: observability log of what matched/mismatched
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+display = Display()
+
+
+def _get_field(item, *keys, nested_path=None):
+    """Try multiple field names, with optional nested dict fallback."""
+    for key in keys:
+        val = item.get(key)
+        if val is not None:
+            return val
+    if nested_path:
+        obj = item
+        for part in nested_path:
+            if isinstance(obj, dict):
+                obj = obj.get(part)
+            else:
+                return None
+        return obj
+    return None
+
+
+def _norm_text(value, lower=False):
+    # Normalize text: strip whitespace, optionally lowercase. Handles None gracefully.
+    if value is None:
+        return ""
+    text = str(value).strip()
+    return text.lower() if lower else text
+
+
+def _norm_entity(value):
+    # Normalize entity names to lowercase for case-insensitive comparison.
+    return _norm_text(value, lower=True)
+
+
+def _norm_pool(value):
+    # Normalize pool names to lowercase for case-insensitive comparison.
+    return _norm_text(value, lower=True)
+
+
+def _norm_scope(value):
+    # NDFC uses varying scope type names (deviceinterface vs device_interface).
+    # Canonicalize to match desired_config expectations.
+    v = _norm_text(value, lower=True)
+    if v in ["deviceinterface", "device_interface"]:
+        return "deviceinterface"
+    if v == "link":
+        return "link"
+    return v
+
+
+def _parse_scope_filter(value):
+    if value is None:
+        return set()
+
+    if isinstance(value, (list, tuple, set)):
+        raw_values = list(value)
+    else:
+        text = _norm_text(value)
+        if not text:
+            return set()
+        raw_values = [part.strip() for part in text.split(",") if part.strip()]
+
+    scopes = set()
+    for raw in raw_values:
+        normalized = _norm_scope(raw)
+        if normalized in ["", "all", "any", "*"]:
+            return set()
+        if normalized:
+            scopes.add(normalized)
+
+    return scopes
+
+
+def _norm_resource(value):
+    # Strip whitespace from resource values (IPs, subnets) for comparison.
+    return _norm_text(value)
+
+
+def _canonicalize_link_entity(entity):
+    """
+    Canonicalize link entity format: tilde-separated endpoints (e.g., "device1~eth1~device2~eth2").
+    Sort endpoints to handle bidirectional links consistently (link A-B == link B-A).
+    """
+    e = _norm_entity(entity)
+    if not e:
+        return ""
+
+    parts = e.split("~")
+    if len(parts) != 4:
+        return e
+
+    endpoint1 = parts[0] + "~" + parts[1]
+    endpoint2 = parts[2] + "~" + parts[3]
+    ordered = sorted([endpoint1, endpoint2])
+    return ordered[0] + "~" + ordered[1]
+
+
+def _extract_resource_items(data):
+    """
+    Recursively unwrap NDFC response envelopes to extract resource items.
+    NDFC wraps resources in varying structures (DATA, data, resourceList, etc.);
+    this function flattens them into a list of normalized items.
+    """
+    items = []
+
+    if isinstance(data, list):
+        for entry in data:
+            items.extend(_extract_resource_items(entry))
+        return items
+
+    if not isinstance(data, dict):
+        return items
+
+    has_entity = any(k in data for k in ["entityName", "entity_name"])
+    has_resource = any(
+        k in data for k in ["resourceName", "resource", "value", "allocatedIp"]
+    )
+    if has_entity and has_resource:
+        items.append(dict(data))
+
+    for key in [
+        "DATA",
+        "data",
+        "resourceList",
+        "resources",
+        "items",
+        "allocations",
+        "result",
+    ]:
+        nested = data.get(key)
+        if nested is not None:
+            items.extend(_extract_resource_items(nested))
+
+    return items
+
+
+class ActionModule(ActionBase):
+    def _execute_ndfc_rest(self, method, path, task_vars, tmp):
+        return self._execute_module(
+            module_name="cisco.dcnm.dcnm_rest",
+            module_args={
+                "method": method,
+                "path": path,
+            },
+            task_vars=task_vars,
+            tmp=tmp,
+        )
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        # === INPUT PARSING AND VALIDATION ===
+        desired_config = self._task.args.get("desired_config", []) or []
+        fabric = self._task.args.get("fabric")
+        query_pools = self._task.args.get("query_pools")
+        scope_filter_arg = self._task.args.get("scope_filter", "all")
+        allowed_scopes = _parse_scope_filter(scope_filter_arg)
+
+        if not isinstance(desired_config, list):
+            desired_config = []
+
+        if not fabric:
+            result.update({"failed": True, "msg": "fabric is required"})
+            return result
+
+        # === DETERMINE WHICH POOLS TO FILTER ===
+        # If query_pools is explicitly provided, use it. Otherwise auto-detect
+        # from desired_config pool_name values. No hardcoded defaults needed:
+        # the data model already declares the exact pools it cares about.
+        if query_pools:
+            pools = {_norm_pool(pool) for pool in query_pools if _norm_text(pool)}
+        else:
+            pools = {
+                _norm_pool(item.get("pool_name"))
+                for item in desired_config
+                if isinstance(item, dict) and item.get("pool_name") is not None
+            }
+            pools.discard("")
+
+        # === BULK QUERY: SINGLE REST CALL FOR ALL FABRIC RESOURCES ===
+        # Fetch all allocations in one call rather than per-pool queries to minimize
+        # controller load and round-trip latency. Filtering happens client-side.
+        path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/resource-manager/fabrics/{}".format(
+            fabric
+        )
+        all_result = self._execute_ndfc_rest("GET", path, task_vars, tmp)
+
+        query_errors = []
+        if all_result.get("failed"):
+            query_errors.append({"path": path, "msg": all_result.get("msg")})
+
+        # === SINGLE-PASS: EXTRACT, FILTER, AND INDEX IN ONE TRAVERSAL ===
+        # Combines _extract_resource_items flattening, pool/scope filtering,
+        # and index building into one pass to avoid intermediate lists.
+        existing_map = {}
+        existing_link_map = {}
+        total_fetched = 0
+        total_filtered = 0
+
+        if not query_errors:
+            response = all_result.get("response", {})
+            for item in _extract_resource_items(response):
+                total_fetched += 1
+
+                # Pool filter
+                pool_name = _get_field(
+                    item,
+                    "poolName",
+                    "pool_name",
+                    "pool",
+                    nested_path=["resourcePool", "poolName"],
+                )
+                normalized_pool = _norm_pool(pool_name)
+                if pools and normalized_pool not in pools:
+                    continue
+
+                # Scope filter
+                scope_type = _get_field(item, "scopeType", "scope_type", "entityType")
+                normalized_scope = _norm_scope(scope_type)
+                if (
+                    allowed_scopes
+                    and normalized_scope
+                    and normalized_scope not in allowed_scopes
+                ):
+                    continue
+
+                # Entity is required for indexing
+                entity_name = _get_field(item, "entityName", "entity_name")
+                if entity_name is None:
+                    continue
+
+                total_filtered += 1
+
+                resource_value = _get_field(
+                    item, "resourceName", "resource", "value", "allocatedIp"
+                )
+
+                normalized_entity = _norm_entity(entity_name)
+                normalized_resource = _norm_resource(resource_value)
+
+                key = (normalized_entity, normalized_pool)
+
+                existing_map[key] = {
+                    "entity": _norm_text(entity_name),
+                    "pool": _norm_text(pool_name),
+                    "resource": normalized_resource,
+                    "scope": normalized_scope,
+                    "raw_resource": _norm_text(resource_value),
+                }
+
+                if normalized_scope == "link":
+                    link_key = (_canonicalize_link_entity(entity_name), normalized_pool)
+                    existing_link_map[link_key] = existing_map[key]
+
+        display.vv(
+            f"underlay_ip_filter [{fabric}]: fetched {total_fetched} "
+            f"items from controller, {total_filtered} after pool/scope filter"
+        )
+        display.vvv(f"underlay_ip_filter [{fabric}]: query pools={list(pools)}")
+
+        # === DESIRED VS EXISTING COMPARISON ===
+        # Two-tier matching: (1) exact entity+pool, (2) canonical link for bidirectional links.
+        # Only items missing or mismatched are added to filtered_config for update.
+        filtered_config = []
+        missing_or_mismatch = []
+        matched_count = 0
+
+        for item in desired_config:
+            if not isinstance(item, dict):
+                continue
+
+            entity_name = item.get("entity_name")
+            if entity_name is None:
+                entity_name = item.get("entityName")
+            pool_name = item.get("pool_name")
+            scope_type = item.get("scope_type")
+
+            expected_resource = _norm_resource(item.get("resource"))
+            normalized_pool = _norm_pool(pool_name)
+            normalized_entity = _norm_entity(entity_name)
+            normalized_scope = _norm_scope(scope_type)
+
+            if pools and normalized_pool not in pools:
+                continue
+
+            if (
+                allowed_scopes
+                and normalized_scope
+                and normalized_scope not in allowed_scopes
+            ):
+                continue
+
+            if not entity_name or not pool_name:
+                filtered_config.append(item)
+                missing_or_mismatch.append(
+                    {
+                        "reason": "missing_required_fields",
+                        "entity": _norm_text(entity_name),
+                        "pool": _norm_text(pool_name),
+                        "scope": _norm_text(scope_type),
+                        "expected": expected_resource,
+                        "actual": "__unknown__",
+                    }
+                )
+                continue
+
+            # Tier 1: Exact entity+pool match
+            existing = existing_map.get((normalized_entity, normalized_pool))
+            matched_by = "exact"
+
+            # Tier 2: Canonical link match for bidirectional links
+            if existing is None and normalized_scope == "link":
+                existing = existing_link_map.get(
+                    (_canonicalize_link_entity(entity_name), normalized_pool)
+                )
+                if existing is not None:
+                    matched_by = "canonical_link"
+
+            if existing is None:
+                filtered_config.append(item)
+                missing_or_mismatch.append(
+                    {
+                        "reason": "missing_in_nd",
+                        "entity": _norm_text(entity_name),
+                        "pool": _norm_text(pool_name),
+                        "scope": _norm_text(scope_type),
+                        "expected": expected_resource,
+                        "actual": "__missing__",
+                    }
+                )
+                continue
+
+            actual_resource = existing.get("resource", "")
+            if actual_resource != expected_resource:
+                filtered_config.append(item)
+                missing_or_mismatch.append(
+                    {
+                        "reason": "resource_mismatch",
+                        "entity": _norm_text(entity_name),
+                        "pool": _norm_text(pool_name),
+                        "scope": _norm_text(scope_type),
+                        "expected": expected_resource,
+                        "actual": actual_resource,
+                        "actual_raw": existing.get("raw_resource", ""),
+                        "matched_by": matched_by,
+                    }
+                )
+                continue
+
+            matched_count += 1
+
+        # === VERBOSE LOGGING ===
+        display.v(
+            f"underlay_ip_filter [{fabric}]: "
+            f"{matched_count} matched, {len(filtered_config)} need update"
+        )
+        if display.verbosity >= 3:
+            for entry in missing_or_mismatch:
+                display.vvv(
+                    f"  [{fabric}] {entry['reason']}: entity={entry['entity']} "
+                    f"expected={entry['expected']} actual={entry['actual']}"
+                )
+
+        # === RESULT ASSEMBLY ===
+        if query_errors:
+            result.update(
+                {
+                    "failed": True,
+                    "msg": "Underlay all-resource query failed. Check ND_HOST/credentials and connectivity.",
+                    "query_errors": query_errors,
+                }
+            )
+            return result
+
+        result.update(
+            {
+                "changed": False,
+                "filtered_config": filtered_config,
+                "missing_or_mismatch": missing_or_mismatch,
+                "query_errors": query_errors,
+                "matched_total": matched_count,
+                "filtered_total": len(filtered_config),
+                "desired_total": len(desired_config),
+            }
+        )
+
+        return result

--- a/plugins/action/dtc/unmanaged_edge_connections.py
+++ b/plugins/action/dtc/unmanaged_edge_connections.py
@@ -36,6 +36,7 @@ class ActionModule(ActionBase):
 
         # List of switch serial numbes obtained directly from NDFC
         ndfc_sw_data = self._task.args["switch_data"]
+        fabric_name = self._task.args["fabric_name"]
         # Data from data model
         edge_connections = self._task.args["edge_connections"]
         if edge_connections:
@@ -49,16 +50,6 @@ class ActionModule(ActionBase):
                 "switch": []
             }
         ]
-        # Iterate over each item in the data list
-        # for item in edge_connections:
-        #     ip = item['ip']
-        #     # If the IP is not already a key in the dictionary, add it with an empty list
-        #     if ip not in restructured_edge_connections:
-        #         restructured_edge_connections[ip] = []
-        #     # Iterate over each policy and collect the descriptions
-        #     for policy in item['policies']:
-        #         description = policy['description']
-        #         restructured_edge_connections[ip].append(description)
 
         for switch in ndfc_sw_data:
             ip = switch['ipAddress']
@@ -69,9 +60,6 @@ class ActionModule(ActionBase):
                     for policy in item['policies']:
                         description = policy['description']
                         restructured_edge_connections[ip].append(description)
-
-        # Print the resulting dictionary
-        # print(restructured_edge_connections)
 
         for ndfc_sw in ndfc_sw_data:
 
@@ -163,7 +151,25 @@ class ActionModule(ActionBase):
                         # ]
 
         # Store the unmanaged policy payload for return and usage in the NDFC policy module to delete from NDFC
-        # print(unmanaged_edge_connections)
+
         results['unmanaged_edge_connections'] = unmanaged_edge_connections
+        if unmanaged_edge_connections[0]["switch"]:
+            policy_result = self._execute_module(
+                module_name="cisco.dcnm.dcnm_policy",
+                module_args={
+                    "fabric": fabric_name,
+                    "use_desc_as_key": True,
+                    "config": unmanaged_edge_connections,
+                    "deploy": False,
+                    "state": "deleted",
+                },
+                task_vars=task_vars,
+                tmp=tmp,
+            )
+            if policy_result.get('failed'):
+                results['failed'] = True
+                results['msg'] = policy_result.get('msg', 'dcnm_policy deletion failed')
+            elif policy_result.get('changed'):
+                results['changed'] = True
 
         return results

--- a/plugins/action/dtc/unmanaged_policy.py
+++ b/plugins/action/dtc/unmanaged_policy.py
@@ -34,10 +34,14 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         results['changed'] = False
 
-        # List of switch serial numbes obtained directly from NDFC
+        # List of switch serial numbers obtained directly from NDFC
         ndfc_sw_serial_numbers = self._task.args["switch_serial_numbers"]
         # Data from data model
         data_model = self._task.args["data_model"]
+        # Fabric name for the dcnm_policy deletion call
+        fabric_name = self._task.args["fabric_name"]
+        # Deploy flag (default False to match old role behavior)
+        deploy = self._task.args.get("deploy", False)
 
         # Switches list from data model
         dm_topology_switches = data_model["vxlan"]["topology"]["switches"]
@@ -193,5 +197,25 @@ class ActionModule(ActionBase):
 
         # Store the unmanaged policy payload for return and usage in the NDFC policy module to delete from NDFC
         results['unmanaged_policies'] = unmanaged_policies
+
+        # Execute dcnm_policy deletion if unmanaged policies were found
+        if unmanaged_policies[0]["switch"]:
+            policy_result = self._execute_module(
+                module_name="cisco.dcnm.dcnm_policy",
+                module_args={
+                    "fabric": fabric_name,
+                    "use_desc_as_key": True,
+                    "config": unmanaged_policies,
+                    "deploy": deploy,
+                    "state": "deleted",
+                },
+                task_vars=task_vars,
+                tmp=tmp,
+            )
+            if policy_result.get('failed'):
+                results['failed'] = True
+                results['msg'] = policy_result.get('msg', 'dcnm_policy deletion failed')
+            elif policy_result.get('changed'):
+                results['changed'] = True
 
         return results

--- a/plugins/action/dtc/update_switch_hostname_policy.py
+++ b/plugins/action/dtc/update_switch_hostname_policy.py
@@ -28,6 +28,7 @@ import json
 
 from ansible.plugins.action import ActionBase
 from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import (
+    NdfcBulkPolicyApiUnavailable,
     ndfc_get_fabric_policies_by_template,
     ndfc_get_switch_policy_using_template
 )
@@ -73,8 +74,8 @@ class ActionModule(ActionBase):
                 )
                 # If successful, return the bulk result
                 return policies_dict, True
-            except Exception as e:
-                # Bulk API not available or failed, mark it and fall back
+            except NdfcBulkPolicyApiUnavailable:
+                # Bulk API not available, mark it and fall back
                 self.bulk_api_available = False
 
         # Fallback: Query each switch individually

--- a/plugins/action/dtc/update_switch_hostname_policy.py
+++ b/plugins/action/dtc/update_switch_hostname_policy.py
@@ -27,7 +27,10 @@ __metaclass__ = type
 import json
 
 from ansible.plugins.action import ActionBase
-from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import ndfc_get_switch_policy_using_template
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import (
+    ndfc_get_fabric_policies_by_template,
+    ndfc_get_switch_policy_using_template
+)
 
 
 class ActionModule(ActionBase):
@@ -44,21 +47,49 @@ class ActionModule(ActionBase):
         self.results = {}
         self.results['failed'] = False
         self.results['changed'] = False
-        # self.policy_add = {}
         self.policy_update = {}
+        self.bulk_api_available = True  # Track if bulk API is available
 
-    def _get_switch_policy(self, switch_serial_number, template_name):
+    def _get_policies_with_fallback(self, fabric_name, template_name, switch_serial_numbers):
         """
-        Get switch hostname policy from Nexus Dashboard using
-        template name (host_11_1) and switch serial number.
+        Get switch policies using bulk API if available, fallback to per-switch queries.
+
+        Returns:
+            tuple: (policies_dict, used_bulk_api)
+                - policies_dict: Dictionary mapping serial_number to policy data (or None if not found)
+                - used_bulk_api: Boolean indicating if bulk API was used
         """
-        return ndfc_get_switch_policy_using_template(
-            self=self,
-            task_vars=self.task_vars,
-            tmp=self.tmp,
-            switch_serial_number=switch_serial_number,
-            template_name=template_name
-        )
+        policies_dict = {}
+
+        # Try bulk API first (only if not already marked as unavailable)
+        if self.bulk_api_available:
+            try:
+                policies_dict = ndfc_get_fabric_policies_by_template(
+                    self=self,
+                    task_vars=self.task_vars,
+                    tmp=self.tmp,
+                    fabric_name=fabric_name,
+                    template_name=template_name
+                )
+                # If successful, return the bulk result
+                return policies_dict, True
+            except Exception as e:
+                # Bulk API not available or failed, mark it and fall back
+                self.bulk_api_available = False
+
+        # Fallback: Query each switch individually
+        # Note: ndfc_get_switch_policy_using_template handles the host_11_1 special case
+        for switch_serial_number in switch_serial_numbers:
+            policy = ndfc_get_switch_policy_using_template(
+                self=self,
+                task_vars=self.task_vars,
+                tmp=self.tmp,
+                switch_serial_number=switch_serial_number,
+                template_name=template_name
+            )
+            policies_dict[switch_serial_number] = policy
+
+        return policies_dict, False
 
     def nd_policy_add(self, switch_name, switch_serial_number):
         """
@@ -146,12 +177,31 @@ class ActionModule(ActionBase):
             dm_switches = data_model["vxlan"]["topology"]["switches"]
             switch_serial_numbers = [dm_switch['serial_number'] for dm_switch in dm_switches]
 
+        # Get policies using bulk API with fallback to per-switch queries
+        fabric_name = data_model["vxlan"]["fabric"]["name"]
+        policies_dict, used_bulk_api = self._get_policies_with_fallback(
+            fabric_name=fabric_name,
+            template_name=template_name,
+            switch_serial_numbers=switch_serial_numbers
+        )
+
         for switch_serial_number in switch_serial_numbers:
-            policy_match = self._get_switch_policy(switch_serial_number, template_name)
+            # Look up policy from the dictionary (bulk or per-switch query)
+            policy_match = policies_dict.get(switch_serial_number)
 
             switch_match = next((item for item in dm_switches if item["serial_number"] == switch_serial_number))
 
             if not policy_match:
+                # If bulk API was used and policy not found for non-host_11_1 template, raise error
+                # (per-switch method already handles this via exception in helper function)
+                if used_bulk_api and template_name != "host_11_1":
+                    err_msg = f"Policy for template {template_name} and switch {switch_serial_number} not found!"
+                    err_msg += f" Please ensure switch with serial number {switch_serial_number} is part of the fabric."
+                    results['failed'] = True
+                    results['msg'] = err_msg
+                    return results
+
+                # Policy not found - create it (only for host_11_1 template)
                 self.nd_policy_add(
                     switch_name=switch_match['name'],
                     switch_serial_number=switch_serial_number

--- a/plugins/filter/dedent.py
+++ b/plugins/filter/dedent.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+DOCUMENTATION = r"""
+  name: dedent
+  version_added: "0.8.0"
+  short_description: Remove common leading whitespace from text
+  description:
+    - Remove common leading whitespace from every line in the input text.
+    - Useful for normalizing multiline strings defined with YAML block scalars (|2, |, etc.).
+  positional: text
+  options:
+    text:
+      description: The text to dedent.
+      type: str
+      required: true
+"""
+
+EXAMPLES = r"""
+
+# Basic usage - remove common leading whitespace
+dedented_text: "{{ my_multiline_var | cisco.nac_dc_vxlan.dedent }}"
+
+# Combine with indent to normalize and re-indent
+normalized_config: "{{ ibgp_template | cisco.nac_dc_vxlan.dedent | indent(6, true) }}"
+"""
+
+RETURN = r"""
+  _value:
+    description:
+      - The dedented string with common leading whitespace removed.
+    type: str
+"""
+
+import textwrap
+
+from ansible.module_utils.six import string_types
+from ansible.errors import AnsibleFilterError, AnsibleFilterTypeError
+from ansible.module_utils.common.text.converters import to_native
+from jinja2.runtime import Undefined
+from jinja2.exceptions import UndefinedError
+
+
+def dedent(text):
+    """
+    Remove common leading whitespace from every line in text.
+    Args:
+        text (str): The text string to dedent.
+    Returns:
+        str: The dedented text.
+    Raises:
+        AnsibleFilterTypeError: If the text argument is not a string.
+        AnsibleFilterError: If the dedent operation fails.
+    """
+    if isinstance(text, Undefined):
+        return text
+
+    if text is None:
+        return ""
+
+    if not isinstance(text, string_types):
+        raise AnsibleFilterTypeError(f"dedent requires a string, got: {type(text)}")
+
+    if not text:
+        return text
+
+    try:
+        return textwrap.dedent(text)
+    except UndefinedError:
+        raise
+    except Exception as e:
+        raise AnsibleFilterError("Unable to dedent text: %s" % to_native(e), orig_exc=e)
+
+
+# ---- Ansible filters ----
+class FilterModule(object):
+    """ Dedent filter - remove common leading whitespace """
+
+    def filters(self):
+        return {
+            "dedent": dedent
+        }

--- a/plugins/plugin_utils/dtc_action_base.py
+++ b/plugins/plugin_utils/dtc_action_base.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+DTC Pipeline Action Base — Shared ActionBase for pipeline-driven DTC plugins.
+
+Provides the common Ansible ActionBase wrapper used by both manage_resources
+and remove_resources. Handles parameter validation, verbose registry
+validation, error handling, and changed aggregation.
+
+Concrete subclasses implement _create_runner() to return the appropriate
+pipeline runner (Factory Method pattern).
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from abc import abstractmethod
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.registry_loader import (
+    RegistryLoader,
+)
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.ndfc_executor import (
+    NdfcModuleExecutor,
+)
+
+display = Display()
+
+
+class DtcPipelineActionBase(ActionBase):
+    """
+    Shared ActionBase for pipeline-driven DTC plugins.
+
+    Handles parameter validation, verbose registry validation,
+    error handling, and changed aggregation. Concrete subclasses
+    implement _create_runner() to produce the appropriate pipeline runner.
+    """
+
+    REQUIRED_PARAMS = [
+        'fabric_type', 'fabric_name', 'data_model', 'resource_data', 'change_flags',
+    ]
+
+    # Subclasses set this for error messages (e.g., 'Manage resources', 'Remove resources')
+    OPERATION_LABEL = None
+
+    @abstractmethod
+    def _create_runner(self, params, executor, task_vars):
+        """
+        Factory method: return the concrete PipelineRunnerBase subclass.
+
+        Args:
+            params: Dict of task args from the role task YAML.
+            executor: NdfcModuleExecutor instance.
+            task_vars: Ansible task variables.
+
+        Returns:
+            A PipelineRunnerBase subclass instance.
+        """
+
+    def run(self, tmp=None, task_vars=None):
+        results = super(DtcPipelineActionBase, self).run(tmp, task_vars)
+        task_vars = task_vars or {}
+
+        # Validate required parameters
+        params = self._task.args
+
+        missing = [p for p in self.REQUIRED_PARAMS if p not in params]
+        if missing:
+            results['failed'] = True
+            results['msg'] = f"Missing required parameters: {missing}"
+            return results
+
+        # Run registry validation at verbose level
+        if display.verbosity >= 3:
+            collection_path = RegistryLoader.get_collection_path()
+            validation = RegistryLoader.validate_all(collection_path)
+            if not validation['valid']:
+                display.warning(
+                    f"Registry validation errors: {validation['errors']}"
+                )
+            if validation['warnings']:
+                display.warning(
+                    f"Registry validation warnings: {validation['warnings']}"
+                )
+
+        try:
+            executor = NdfcModuleExecutor(self, task_vars, tmp)
+            runner = self._create_runner(params, executor, task_vars)
+            result = runner.run_pipeline()
+
+            results.update(result)
+            if result.get('failed'):
+                results['failed'] = True
+            else:
+                # Set changed if any step reported changes
+                results['changed'] = any(
+                    r.get('changed', False) for r in result.get('results', [])
+                )
+
+        except Exception as e:
+            results['failed'] = True
+            results['msg'] = f"{self.OPERATION_LABEL} failed: {str(e)}"
+
+        return results

--- a/plugins/plugin_utils/helper_functions.py
+++ b/plugins/plugin_utils/helper_functions.py
@@ -340,3 +340,39 @@ def restructure_leaf_tor_data(switches_list, topology_switches, tor_peers):
             leaf_entries.append(tor_entry)
 
     return leaf_entries
+
+
+def ndfc_get_fabric_policies_by_template(self, task_vars, tmp, fabric_name, template_name):
+    """
+    Get all NDFC policies for a given fabric and template name in bulk.
+
+    :Parameters:
+        :self: Ansible action plugin instance object.
+        :task_vars (dict): Ansible task vars.
+        :tmp (None, optional): Ansible tmp object. Defaults to None via Action Plugin.
+        :fabric_name (str): The name of the fabric.
+        :template_name (str): The name of the NDFC template.
+
+    :Returns:
+        :policies_dict: Dictionary mapping serial_number to policy data.
+
+    :Raises:
+        N/A
+    """
+    policy_response = self._execute_module(
+        module_name="cisco.dcnm.dcnm_rest",
+        module_args={
+            "method": "GET",
+            "path": f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/{fabric_name}/policy?templateName={template_name}"
+        },
+        task_vars=task_vars,
+        tmp=tmp
+    )
+
+    # Build a dictionary mapping serial number to policy
+    policies_dict = {}
+    if policy_response.get('response') and policy_response['response'].get('DATA'):
+        for policy in policy_response['response']['DATA']:
+            policies_dict[policy['serialNumber']] = policy
+
+    return policies_dict

--- a/plugins/plugin_utils/helper_functions.py
+++ b/plugins/plugin_utils/helper_functions.py
@@ -25,6 +25,29 @@
 # For example in prepare_serice_model.py we can do the following:
 #  from ..helper_functions import do_something
 
+
+class NdfcBulkPolicyApiUnavailable(Exception):
+    """
+    Raised when the NDFC bulk policy lookup API is not available.
+    """
+
+
+class NdfcDuplicatePolicyError(Exception):
+    """
+    Raised when NDFC has duplicate policies for a switch/template pair.
+    """
+
+
+def _ndfc_policy_id_list(policies):
+    """
+    Return a comma-separated policyId/id list for error messages.
+    """
+    policy_ids = []
+    for policy in policies:
+        policy_ids.append(str(policy.get("policyId") or policy.get("id") or "unknown"))
+    return ", ".join(policy_ids)
+
+
 def data_model_key_check(tested_object, keys):
     """
     Check if key(s) are found and exist in the data model.
@@ -127,17 +150,32 @@ def ndfc_get_switch_policy_using_template(self, task_vars, tmp, switch_serial_nu
     """
     policy_data = ndfc_get_switch_policy(self, task_vars, tmp, switch_serial_number)
 
-    try:
-        policy_match = next(
-            (item for item in policy_data["response"]["DATA"] if item["templateName"] == template_name and item['serialNumber'] == switch_serial_number)
+    policy_response = policy_data.get("response") or policy_data.get("msg") or {}
+    return_code = policy_response.get("RETURN_CODE")
+    if return_code != 200:
+        raise Exception(f"Policy lookup failed for switch {switch_serial_number}: {policy_response}")
+
+    policy_matches = [
+        item for item in policy_response.get("DATA", [])
+        if item["templateName"] == template_name and item['serialNumber'] == switch_serial_number
+    ]
+
+    if len(policy_matches) > 1 and template_name == "host_11_1":
+        raise NdfcDuplicatePolicyError(
+            f"Duplicate host_11_1 policies found for switch serial {switch_serial_number}. "
+            f"Policy IDs: {_ndfc_policy_id_list(policy_matches)}. "
+            "Duplicate hostname policies are controller drift and must be reconciled before continuing."
         )
-    except StopIteration:
+
+    if not policy_matches:
         if template_name == "host_11_1":
             policy_match = None
         else:
             err_msg = f"Policy for template {template_name} and switch {switch_serial_number} not found!"
             err_msg += f" Please ensure switch with serial number {switch_serial_number} is part of the fabric."
             raise Exception(err_msg)
+    else:
+        policy_match = policy_matches[0]
 
     return policy_match
 
@@ -357,7 +395,9 @@ def ndfc_get_fabric_policies_by_template(self, task_vars, tmp, fabric_name, temp
         :policies_dict: Dictionary mapping serial_number to policy data.
 
     :Raises:
-        N/A
+        NdfcBulkPolicyApiUnavailable: If the bulk policy lookup API is not installed.
+        NdfcDuplicatePolicyError: If duplicate host_11_1 policies are found for a switch serial.
+        Exception: If the bulk policy lookup fails for another reason.
     """
     policy_response = self._execute_module(
         module_name="cisco.dcnm.dcnm_rest",
@@ -369,10 +409,38 @@ def ndfc_get_fabric_policies_by_template(self, task_vars, tmp, fabric_name, temp
         tmp=tmp
     )
 
+    policy_result = policy_response.get("response") or policy_response.get("msg") or {}
+    return_code = policy_result.get("RETURN_CODE")
+
+    if return_code == 404:
+        raise NdfcBulkPolicyApiUnavailable(
+            f"Bulk policy lookup API is unavailable for fabric {fabric_name} and template {template_name}."
+        )
+
+    if return_code != 200:
+        raise Exception(
+            f"Bulk policy lookup failed for fabric {fabric_name} and template {template_name}: {policy_result}"
+        )
+
     # Build a dictionary mapping serial number to policy
     policies_dict = {}
-    if policy_response.get('response') and policy_response['response'].get('DATA'):
-        for policy in policy_response['response']['DATA']:
-            policies_dict[policy['serialNumber']] = policy
+    duplicate_check = {}
+    for policy in policy_result.get('DATA') or []:
+        serial_number = policy['serialNumber']
+        policies_dict[serial_number] = policy
+        duplicate_check.setdefault(serial_number, []).append(policy)
+
+    if template_name == "host_11_1":
+        duplicate_details = [
+            f"{serial_number}: {_ndfc_policy_id_list(policies)}"
+            for serial_number, policies in duplicate_check.items()
+            if len(policies) > 1
+        ]
+        if duplicate_details:
+            raise NdfcDuplicatePolicyError(
+                "Duplicate host_11_1 policies found. "
+                f"Serial/policy IDs: {'; '.join(duplicate_details)}. "
+                "Duplicate hostname policies are controller drift and must be reconciled before continuing."
+            )
 
     return policies_dict

--- a/plugins/plugin_utils/ndfc_executor.py
+++ b/plugins/plugin_utils/ndfc_executor.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+NDFC Module Executor — Shared module execution service for DTC pipeline plugins.
+
+Encapsulates all NDFC module execution logic including direct module calls,
+action plugin routing for modules with companion action plugins (dcnm_vrf,
+dcnm_network), REST API calls, and arbitrary plugin execution.
+
+Used by both manage_resources (create pipeline) and remove_resources (remove
+pipeline) via constructor injection.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.utils.display import Display
+
+display = Display()
+
+
+class NdfcModuleExecutor:
+    """
+    Encapsulates all NDFC module execution logic.
+
+    Handles direct module execution and action plugin routing
+    for modules with companion action plugins (dcnm_vrf, dcnm_network).
+    """
+
+    # Modules with companion action plugins that must be invoked to replicate
+    # native Ansible task execution (e.g. fabric discovery, metadata injection).
+    MODULES_WITH_ACTION_PLUGINS = frozenset({
+        'cisco.dcnm.dcnm_vrf',
+        'cisco.dcnm.dcnm_network',
+    })
+
+    def __init__(self, action_module, task_vars, tmp=None):
+        """
+        Initialize the executor.
+
+        Args:
+            action_module: Reference to the ActionModule instance for _execute_module.
+            task_vars: Ansible task variables.
+            tmp: Temporary directory (Ansible internal).
+        """
+        self.action_module = action_module
+        self.task_vars = task_vars
+        self.tmp = tmp
+
+    def execute(self, module_name, state, config, fabric_name, save=None, deploy=None, fabric_param='fabric', skip_validation=None):
+        """
+        Execute an NDFC Ansible module.
+
+        Supports configurable fabric parameter name to handle both
+        standard modules (fabric:) and dcnm_vpc_pair/dcnm_links (src_fabric:).
+        When fabric_param is None, no fabric parameter is added (e.g. dcnm_fabric
+        embeds the fabric name inside config).
+
+        For modules with companion action plugins (dcnm_vrf, dcnm_network),
+        delegates to the action plugin via action_loader so execution matches
+        native Ansible task behavior.
+
+        Args:
+            module_name: Fully qualified module name (e.g. 'cisco.dcnm.dcnm_vrf').
+            state: Module state parameter.
+            config: Configuration data to send.
+            fabric_name: Fabric name for fabric parameter.
+            deploy: Whether to deploy (None = omit parameter).
+            fabric_param: Fabric parameter name ('fabric', 'src_fabric', or None).
+
+        Returns:
+            Module result dict.
+        """
+        # Strip omit placeholders from config before passing to modules.
+        # Ansible's TaskExecutor calls remove_omit() on module_args for native
+        # YAML tasks, but our programmatic invocation bypasses that path.
+        config = self._remove_omit_placeholders(config)
+
+        module_args = {
+            'state': state,
+            'config': config,
+        }
+        if fabric_param is not None:
+            module_args[fabric_param] = fabric_name
+        if save is not None:
+            module_args['save'] = save
+        if deploy is not None:
+            module_args['deploy'] = deploy
+        if skip_validation is not None:
+            module_args['skip_validation'] = skip_validation
+
+        if module_name == 'cisco.dcnm.dcnm_policy':
+            module_args['use_desc_as_key'] = True
+
+        if module_name in self.MODULES_WITH_ACTION_PLUGINS:
+            return self._execute_via_action_plugin(module_name, module_args)
+
+        return self.action_module._execute_module(
+            module_name=module_name,
+            module_args=module_args,
+            task_vars=self.task_vars,
+            tmp=self.tmp,
+        )
+
+    def execute_rest(self, method, path, json_data=None):
+        """
+        Execute a dcnm_rest API call.
+
+        Args:
+            method: HTTP method (GET, POST, etc.).
+            path: NDFC API path.
+            json_data: Optional JSON string for request body (POST/PUT).
+
+        Returns:
+            Module result dict.
+        """
+        module_args = {"method": method, "path": path}
+        if json_data is not None:
+            module_args["json_data"] = json_data
+        return self.action_module._execute_module(
+            module_name="cisco.dcnm.dcnm_rest",
+            module_args=module_args,
+            task_vars=self.task_vars,
+            tmp=self.tmp,
+        )
+
+    def execute_plugin(self, module_name, module_args):
+        """
+        Execute an arbitrary action plugin by FQCN.
+
+        Delegates to _execute_via_action_plugin which handles action_loader
+        dispatch, task state save/restore, and plugin invocation.
+
+        Args:
+            module_name: Fully qualified action plugin name
+                         (e.g. 'cisco.nac_dc_vxlan.dtc.prepare_msite_data').
+            module_args: Dict of plugin arguments.
+
+        Returns:
+            Plugin result dict.
+        """
+        return self._execute_via_action_plugin(module_name, module_args)
+
+    @staticmethod
+    def _remove_omit_placeholders(data):
+        """Recursively remove dict entries whose values contain '__omit_place_holder__'.
+
+        Replicates the behaviour of Ansible's TaskExecutor.remove_omit() which
+        strips omit sentinel values from module_args before module invocation.
+        When modules are called programmatically via _execute_via_action_plugin,
+        that native stripping is bypassed — this method fills the gap.
+        """
+        if isinstance(data, list):
+            return [NdfcModuleExecutor._remove_omit_placeholders(item) for item in data]
+        if isinstance(data, dict):
+            cleaned = {}
+            for key, value in data.items():
+                if isinstance(value, str) and '__omit_place_holder__' in value:
+                    continue
+                cleaned[key] = NdfcModuleExecutor._remove_omit_placeholders(value)
+            return cleaned
+        return data
+
+    def _execute_via_action_plugin(self, module_name, module_args):
+        """
+        Execute an NDFC module through its companion action plugin.
+
+        Some NDFC modules (dcnm_vrf, dcnm_network) have action plugins that
+        perform fabric discovery and inject metadata before running the module.
+        Ansible's task executor invokes these automatically for native tasks.
+        This method replicates that routing for programmatic calls.
+
+        Args:
+            module_name: Fully qualified module name (e.g. 'cisco.dcnm.dcnm_vrf').
+            module_args: Dict of module arguments (fabric, state, config, etc.).
+
+        Returns:
+            Module result dict.
+        """
+        original_args = self.action_module._task.args
+        original_action = self.action_module._task.action
+
+        try:
+            self.action_module._task.args = module_args
+            self.action_module._task.action = module_name
+
+            action_plugin = self.action_module._shared_loader_obj.action_loader.get(
+                module_name,
+                task=self.action_module._task,
+                connection=self.action_module._connection,
+                play_context=self.action_module._play_context,
+                loader=self.action_module._loader,
+                templar=self.action_module._templar,
+                shared_loader_obj=self.action_module._shared_loader_obj,
+            )
+
+            if action_plugin is None:
+                return {
+                    'failed': True,
+                    'msg': f"Action plugin '{module_name}' not found via action_loader",
+                }
+
+            return action_plugin.run(task_vars=self.task_vars, tmp=self.tmp)
+        finally:
+            self.action_module._task.args = original_args
+            self.action_module._task.action = original_action

--- a/plugins/plugin_utils/pipeline_base.py
+++ b/plugins/plugin_utils/pipeline_base.py
@@ -1,0 +1,966 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Pipeline Base — Abstract base class for data-driven NDFC pipeline execution.
+
+Provides the shared pipeline iteration skeleton using the Template Method
+pattern. Concrete subclasses (ResourceManager, ResourceRemover) implement
+data resolution strategy and any additional guard logic.
+
+Shared infrastructure includes:
+  - Pipeline lookup and tag filtering
+  - Change flag guard checking
+  - Internal method dispatch (module names starting with '_')
+  - NDFC module execution delegation to NdfcModuleExecutor
+  - Shared internal methods:
+      _update_switch_hostname_policy — hostname policy management
+      _prepare_msite_data — multisite data preparation
+      _manage_child_fabrics — child fabric association management
+      _vrf_loopback_attach — VRF loopback attachment via REST
+      _tor_pairing — ToR pairing create/remove (direct or discovery mode)
+      _unmanaged_policy — discover and remove unmanaged policies from NDFC
+      _config_save — delegates to fabric_deploy_manager (operation: config_save)
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+import os
+import time
+from abc import ABC, abstractmethod
+
+from ansible.utils.display import Display
+
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.registry_loader import (
+    RegistryLoader,
+)
+
+display = Display()
+
+
+class PipelineRunnerBase(ABC):
+    """
+    Abstract base for data-driven NDFC pipeline execution.
+
+    Provides the shared pipeline iteration skeleton. Concrete subclasses
+    implement data resolution strategy and any additional guard logic.
+
+    Class Attributes:
+        REGISTRY_KEY: Registry file key ('create_resources' or 'remove_resources').
+        OPERATION: Operation name ('create' or 'remove') for logging and msite dispatch.
+    """
+
+    # Subclasses must set these
+    REGISTRY_KEY = None
+    OPERATION = None
+
+    def __init__(self, params, executor, task_vars):
+        """
+        Initialize the pipeline runner.
+
+        Args:
+            params: Dict of task args from the role task YAML.
+            executor: NdfcModuleExecutor instance (injected).
+            task_vars: Ansible task variables.
+        """
+        self.fabric_type = params['fabric_type']
+        self.fabric_name = params['fabric_name']
+        self.data_model = params['data_model']
+        self.resource_data = params['resource_data']
+        self.change_flags = params['change_flags']
+        self.run_map_diff_run = params.get('run_map_diff_run', True)
+        self.force_run_all = params.get('force_run_all', False)
+        self.executor = executor
+        self.task_vars = task_vars
+
+        # Load pipeline from registry
+        collection_path = RegistryLoader.get_collection_path()
+        registry = RegistryLoader.load(collection_path, self.REGISTRY_KEY)
+        pipelines = registry.get(self.REGISTRY_KEY, {})
+
+        # Extract role-level bypass tag (e.g., role_create, role_remove)
+        # Use .get() — don't mutate the cached registry dict
+        self.role_tag = pipelines.get('role_tag')
+        self.pipelines = {k: v for k, v in pipelines.items() if k != 'role_tag'}
+
+    def run_pipeline(self):
+        """
+        Execute the ordered pipeline for the current fabric type.
+
+        Template method: filter → iterate → guard → dispatch → execute.
+
+        Returns:
+            dict with:
+              - 'results': List of per-step result dicts
+              - 'failed': Boolean — True if any step failed
+              - 'msg': Summary message
+        """
+        pipeline = self.pipelines.get(self.fabric_type)
+        if pipeline is None:
+            return {
+                'results': [],
+                'failed': True,
+                'msg': (
+                    f"No {self.OPERATION} pipeline defined for "
+                    f"fabric type: {self.fabric_type}"
+                ),
+            }
+
+        # Filter by tags if needed
+        ansible_run_tags = self.task_vars.get('ansible_run_tags', [])
+        pipeline = RegistryLoader.filter_pipeline_by_tags(
+            pipeline, ansible_run_tags, self.role_tag
+        )
+
+        # Hook: subclass pre-pipeline setup (e.g., pre-fetch switch list)
+        context = self._pre_pipeline_setup()
+
+        step_results = []
+        total_steps = len(pipeline)
+        pipeline_start = time.monotonic()
+
+        for step_index, step in enumerate(pipeline, 1):
+            resource_name = step['resource_name']
+            module = step['module']
+            flag_name = step.get('change_flag_guard')
+            step_start = time.monotonic()
+            op_label = self.OPERATION.upper()
+
+            display.display(
+                f"\n{'─' * display.columns}\n"
+                f"{op_label} [{self.fabric_name}] "
+                f"Step {step_index}/{total_steps}: {resource_name} ({module})\n"
+                f"{'─' * display.columns}",
+                color='dark gray',
+            )
+
+            # ── Hook: subclass-specific additional guards ─────────────────
+            guard_result = self._check_additional_guards(step, context)
+            if guard_result is not None:
+                step_results.append(guard_result)
+                elapsed = time.monotonic() - step_start
+                reason = guard_result.get('reason', 'guard')
+                display.display(
+                    f"{op_label} [{self.fabric_name}] "
+                    f"{resource_name} → skipped ({reason}) [{elapsed:.1f}s]",
+                    color='cyan',
+                )
+                continue
+
+            # ── Guard: data_model_guard ───────────────────────────────────
+            dm_guard = step.get('data_model_guard')
+            if dm_guard:
+                guards = dm_guard if isinstance(dm_guard, list) else [dm_guard]
+                failed = next(
+                    (g for g in guards if not self._evaluate_data_model_guard(g)),
+                    None,
+                )
+                if failed is not None:
+                    step_results.append({
+                        'resource_name': resource_name,
+                        'module': module,
+                        'status': 'skipped',
+                        'reason': f"data_model_guard '{failed}' resolved to falsy",
+                    })
+                    elapsed = time.monotonic() - step_start
+                    display.display(
+                        f"{op_label} [{self.fabric_name}] "
+                        f"{resource_name} → skipped (data_model_guard) [{elapsed:.1f}s]",
+                        color='cyan',
+                    )
+                    continue
+
+            # ── Guard: change_flag_guard ──────────────────────────────────
+            # Bypass change_flag_guard for controller_diff steps in full-run
+            # mode — the controller query itself determines if work is needed.
+            has_controller_diff = step.get('full_run_strategy') == 'controller_diff'
+            in_full_run = not self.run_map_diff_run or self.force_run_all
+            bypass_change_flag = has_controller_diff and in_full_run
+
+            if flag_name and not bypass_change_flag and not self.change_flags.get(flag_name, False):
+                step_results.append({
+                    'resource_name': resource_name,
+                    'module': module,
+                    'status': 'skipped',
+                    'reason': f"change flag '{flag_name}' is False",
+                })
+                elapsed = time.monotonic() - step_start
+                display.display(
+                    f"{op_label} [{self.fabric_name}] "
+                    f"{resource_name} → skipped (no changes) [{elapsed:.1f}s]",
+                    color='cyan',
+                )
+                continue
+
+            # ── Guard: runtime_change_refs ────────────────────────────────
+            # Skip this step if none of the referenced prior steps actually
+            # changed anything at runtime (i.e., NDFC module returned
+            # changed=true).  This avoids unnecessary operations like
+            # config-save when prior modules were idempotent.
+            runtime_refs = step.get('runtime_change_refs')
+            if runtime_refs:
+                prior_changed = any(
+                    sr.get('changed', False)
+                    for sr in step_results
+                    if sr.get('resource_name') in runtime_refs
+                )
+                if not prior_changed:
+                    step_results.append({
+                        'resource_name': resource_name,
+                        'module': module,
+                        'status': 'skipped',
+                        'reason': (
+                            f"runtime_change_refs {runtime_refs} — "
+                            f"no prior steps changed"
+                        ),
+                    })
+                    elapsed = time.monotonic() - step_start
+                    display.display(
+                        f"{op_label} [{self.fabric_name}] "
+                        f"{resource_name} → skipped (no runtime changes) "
+                        f"[{elapsed:.1f}s]",
+                        color='cyan',
+                    )
+                    continue
+
+            # ── Internal method dispatch ──────────────────────────────────
+            if isinstance(module, str) and module.startswith('_'):
+                result = self._dispatch_internal_method(resource_name, module, step)
+                step_results.append(result)
+                elapsed = time.monotonic() - step_start
+                status = result.get('status', 'ok')
+                changed = result.get('changed', False)
+                display.display(
+                    f"{op_label} [{self.fabric_name}] "
+                    f"{resource_name} → {status} (changed={changed}) [{elapsed:.1f}s]",
+                    color='yellow' if changed else ('green' if status != 'failed' else 'red'),
+                )
+                if status == 'failed':
+                    return {
+                        'results': step_results,
+                        'failed': True,
+                        'msg': result.get('reason', f"Internal method '{module}' failed"),
+                    }
+                continue
+
+            # ── Hook: subclass data resolution ────────────────────────────
+            data, resolved_state = self._resolve_step_data(resource_name, step)
+
+            if not data and resolved_state == 'overridden':
+                # If the data set is empty we still want to send it to the module
+                # for state overridden
+                pass
+            elif not data:
+                step_results.append({
+                    'resource_name': resource_name,
+                    'module': module,
+                    'status': 'skipped',
+                    'reason': 'no data available',
+                })
+                elapsed = time.monotonic() - step_start
+                display.display(
+                    f"{op_label} [{self.fabric_name}] "
+                    f"{resource_name} → skipped (no diff) [{elapsed:.1f}s]",
+                    color='cyan',
+                )
+                continue
+
+            # ── Fabric parameter resolution ───────────────────────────────
+            fabric_param = step.get('fabric_param', 'fabric')
+
+            # ── Execute NDFC module ───────────────────────────────────────
+            save = step.get('save')
+            deploy = step.get('deploy')
+            skip_validation = step.get('skip_validation')
+
+            display.v(
+                f"{op_label} [{self.fabric_name}] Executing {module} for "
+                f"{resource_name} with state={resolved_state}, save={save}, deploy={deploy}, "
+                f"items={len(data) if isinstance(data, list) else '?'}"
+            )
+
+            result = self.executor.execute(
+                module_name=f"cisco.dcnm.{module}",
+                state=resolved_state,
+                config=data,
+                fabric_name=self.fabric_name,
+                save=save,
+                deploy=deploy,
+                fabric_param=fabric_param,
+                skip_validation=skip_validation,
+            )
+
+            elapsed = time.monotonic() - step_start
+
+            if result.get('failed'):
+                display.display(
+                    f"{op_label} [{self.fabric_name}] "
+                    f"{resource_name} → failed [{elapsed:.1f}s]",
+                    color='red',
+                )
+                step_results.append({
+                    'resource_name': resource_name,
+                    'module': module,
+                    'status': 'failed',
+                    'result': result,
+                })
+                return {
+                    'results': step_results,
+                    'failed': True,
+                    'msg': (
+                        f"{self.OPERATION.title()} pipeline failed at step "
+                        f"'{resource_name}' ({module}): "
+                        f"{result.get('msg', 'unknown error')}"
+                    ),
+                }
+
+            changed = result.get('changed', False)
+            display.display(
+                f"{op_label} [{self.fabric_name}] "
+                f"{resource_name} → ok (changed={changed}) [{elapsed:.1f}s]",
+                color='yellow' if changed else 'green',
+            )
+
+            step_results.append({
+                'resource_name': resource_name,
+                'module': module,
+                'status': 'ok',
+                'changed': changed,
+                'result': result,
+            })
+
+        pipeline_elapsed = time.monotonic() - pipeline_start
+        display.display(
+            f"\n{'═' * display.columns}\n"
+            f"{self.OPERATION.upper()} [{self.fabric_name}] "
+            f"Pipeline complete — {total_steps} steps in {pipeline_elapsed:.1f}s\n"
+            f"{'═' * display.columns}",
+            color='dark gray',
+        )
+
+        return {
+            'results': step_results,
+            'failed': False,
+            'msite_data': getattr(self, 'msite_data', None),
+            'msg': (
+                f"{self.OPERATION.title()} pipeline completed for "
+                f"{self.fabric_type} fabric '{self.fabric_name}'"
+            ),
+        }
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Subclass Hooks
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _pre_pipeline_setup(self):
+        """
+        Hook for subclass pre-pipeline initialization.
+
+        Called once before the pipeline loop begins. Override to perform
+        setup like pre-fetching switch lists.
+
+        Returns:
+            Context dict passed to _check_additional_guards for each step.
+        """
+        return {}
+
+    def _check_additional_guards(self, step, context):
+        """
+        Hook for subclass-specific guards beyond change_flag_guard.
+
+        Called for each step before the change_flag_guard check. Override
+        to add guards like delete_mode_guard, skip_if_child_fabric, etc.
+
+        Args:
+            step: Pipeline step dict.
+            context: Dict returned by _pre_pipeline_setup.
+
+        Returns:
+            A skip result dict to append to step_results if the step should
+            be skipped, or None to proceed with the step.
+        """
+        return None
+
+    @abstractmethod
+    def _resolve_step_data(self, resource_name, step):
+        """
+        Resolve data and state for a pipeline step.
+
+        Create resolves diff.updated preference; remove resolves diff.removed
+        with dual-state (deleted vs overridden).
+
+        Args:
+            resource_name: Logical name of the resource.
+            step: Pipeline step dict from the YAML registry.
+
+        Returns:
+            Tuple of (data_list, resolved_state_string).
+        """
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Shared Infrastructure
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _dispatch_internal_method(self, resource_name, module, step):
+        """
+        Dispatch to an internal method by name.
+
+        Internal methods are pipeline steps where module starts with '_'.
+        They are resolved via getattr on the runner class hierarchy.
+
+        Args:
+            resource_name: Logical name of the resource.
+            module: Internal method name (e.g. '_config_save').
+            step: Pipeline step dict.
+
+        Returns:
+            Step result dict with status 'ok' or 'failed'.
+        """
+        try:
+            method = getattr(self, module)
+            result = method(resource_name, step)
+            entry = {
+                'resource_name': resource_name,
+                'module': module,
+                'status': 'ok',
+                'changed': result.get('changed', False) if isinstance(result, dict) else False,
+                'result': result,
+            }
+            # Internal methods can signal failure
+            if isinstance(result, dict) and result.get('failed'):
+                entry['status'] = 'failed'
+                entry['reason'] = result.get('msg', f"Internal method '{module}' failed")
+            return entry
+        except AttributeError:
+            return {
+                'resource_name': resource_name,
+                'module': module,
+                'status': 'failed',
+                'reason': f"Internal method '{module}' not found on {self.__class__.__name__}",
+            }
+
+    def _evaluate_data_model_guard(self, dotpath):
+        """
+        Traverse the data model by dotpath and return the resolved value.
+
+        Used by the data_model_guard pipeline field. The caller checks
+        truthiness of the returned value to decide whether to skip the step.
+
+        Args:
+            dotpath: Dot-separated path into the data model
+                     (e.g. 'vxlan.overlay.vrfs').
+
+        Returns:
+            The resolved value, or None if any key in the path is missing.
+        """
+        obj = self.data_model
+        for key in dotpath.split('.'):
+            if not isinstance(obj, dict):
+                return None
+            obj = obj.get(key)
+            if obj is None:
+                return None
+        return obj
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Shared Internal Methods (called from pipeline via '_' prefix)
+    # ══════════════════════════════════════════════════════════════════════════
+
+    def _update_switch_hostname_policy(self, resource_name, step):
+        """
+        Manage hostname policy on switches
+
+        Delegates to the existing update_switch_hostname_policy action plugin.
+        """
+        return self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.update_switch_hostname_policy",
+            module_args={
+                "data_model": self.data_model,
+                "template_name": "host_11_1",
+            },
+        )
+
+    def _prepare_msite_data(self, resource_name, step):
+        """
+        Prepare multisite data for MSD/MCFG operations.
+
+        Delegates to the existing prepare_msite_data action plugin.
+        Stores the result in task_vars under the fabric-type-specific
+        variable name (runtime_msd_data_model or runtime_mcfg_data_model)
+        so that downstream Jinja2 templates can access it during deferred
+        overlay rendering via _msite_build_overlay.
+        """
+        result = self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.prepare_msite_data",
+            module_args={
+                "data_model": self.data_model,
+                "parent_fabric": self.fabric_name,
+                "parent_fabric_type": self.fabric_type,
+                "nd_version": self.task_vars.get('nd_version', ''),
+            },
+        )
+
+        # Store for Jinja2 template access under the fabric-type-specific name
+        # that MSD/MCFG templates already reference
+        var_name = f"runtime_{self.fabric_type.lower()}_data_model"
+        self.task_vars[var_name] = result
+        self.msite_data = result
+
+        return result
+
+    def _prepare_child_fabrics_data(self, resource_name, step):
+        """
+        Prepare child fabric association data at pipeline execution time.
+
+        Used by MCFG pipelines where the fabric group must be created by
+        dcnm_fabric_group before the onemanage API can return member data.
+        Delegates to prepare_msite_child_fabrics_data and populates
+        self.resource_data['child_fabrics'] for downstream _manage_child_fabrics.
+
+        Also sets the changes_detected_child_fabrics flag when there are
+        child fabrics to add or remove.
+        """
+        child_fabrics = (
+            self.data_model.get('vxlan', {})
+            .get('multisite', {})
+            .get('child_fabrics', [])
+        )
+
+        if not child_fabrics:
+            child_fabrics = []
+
+        result = self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.prepare_msite_child_fabrics_data",
+            module_args={
+                "parent_fabric": self.fabric_name,
+                "parent_fabric_type": self.fabric_type,
+                "child_fabrics": child_fabrics,
+            },
+        )
+
+        if isinstance(result, dict) and result.get('failed'):
+            return result
+
+        self.resource_data['child_fabrics'] = {
+            'data': result,
+            'var_name': 'child_fabrics',
+        }
+
+        to_be_added = result.get('to_be_added', [])
+        to_be_removed = result.get('to_be_removed', [])
+        if to_be_added or to_be_removed:
+            self.change_flags['changes_detected_child_fabrics'] = True
+            display.v(
+                f"{self.OPERATION.upper()} [{self.fabric_name}] "
+                f"Child fabric changes detected: "
+                f"to_add={len(to_be_added)}, to_remove={len(to_be_removed)}"
+            )
+
+        return result
+
+    def _msite_build_overlay(self, resource_name, step):
+        """
+        Deferred overlay build for MSD/MCFG fabric types.
+
+        MSD and MCFG VRF/network templates depend on runtime_msd_data_model
+        or runtime_mcfg_data_model (populated by _prepare_msite_data), which
+        is only available after querying the controller for child fabric state.
+        This method performs the Template→Render→Diff→Flag cycle for overlay
+        resources at pipeline execution time, after _prepare_msite_data has run.
+
+        Invokes build_resource_data with a resource_filter to process only
+        the overlay resources (vrfs, vrf_loopback_attach, networks), bypassing
+        the normal fabric_types filtering that would exclude MSD/MCFG.
+
+        Uses a file-based cache to prevent the stale re-render problem: when
+        both CREATE and REMOVE pipelines call this method in the same playbook
+        run, the first call renders and caches the results. The second call
+        loads from cache, preserving the correct diff (updated/removed) from
+        the first render. Without caching, the second render would compare
+        against the first render's output (instead of the previous run's
+        output), producing an empty diff.
+
+        The cache file is cleaned up at the start of each common-phase build
+        by _detect_msite_overlay_changes in build_resource_data.py.
+
+        Merges the resulting resource_data and change_flags back into the
+        pipeline runner's state so downstream steps work unchanged.
+        """
+        role_path = self.task_vars.get('common_role_path', '')
+        if not role_path:
+            return {
+                'failed': True,
+                'msg': "common_role_path not found in task_vars — "
+                       "ensure the common role has run before create/remove",
+            }
+
+        # Determine output path for the cache file
+        collection_path = RegistryLoader.get_collection_path()
+        fabric_types = RegistryLoader.load(collection_path, 'fabric_types').get('fabric_types', {})
+        file_subdir = fabric_types.get(self.fabric_type, {}).get('file_subdir', '')
+        output_path = os.path.join(role_path, 'files', file_subdir, self.fabric_name)
+        cache_file = os.path.join(output_path, '_msite_overlay_cache.json')
+
+        # Check for cached results from a prior pipeline in this playbook run.
+        # When CREATE runs first, it caches the render results (including
+        # diff.removed). REMOVE then loads from cache instead of re-rendering,
+        # which would produce a stale empty diff.
+        if os.path.exists(cache_file):
+            try:
+                with open(cache_file) as f:
+                    cached = json.load(f)
+                cached_resource_data = cached.get('resource_data', {})
+                cached_flags = cached.get('change_flags', {})
+                self.resource_data.update(cached_resource_data)
+                self.change_flags.update(cached_flags)
+                if any(cached_flags.values()):
+                    self.change_flags['changes_detected_any'] = True
+                display.v(
+                    f"{self.OPERATION.upper()} [{self.fabric_name}] "
+                    f"Deferred overlay loaded from cache: "
+                    f"resources={list(cached_resource_data.keys())}, "
+                    f"flags={cached_flags}"
+                )
+                return {'failed': False, 'changed': any(cached_flags.values())}
+            except (json.JSONDecodeError, IOError) as e:
+                display.warning(
+                    f"{self.OPERATION.upper()} [{self.fabric_name}] "
+                    f"Failed to load overlay cache, re-rendering: {e}"
+                )
+
+        check_roles = self.task_vars.get('check_roles', {})
+
+        overlay = self.data_model.get('vxlan', {}).get('multisite', {}).get('overlay', {})
+
+        resource_filter = []
+        if overlay and overlay.get('vrfs'):
+            resource_filter.extend(["vrfs", "vrf_loopback_attach"])
+        if overlay and overlay.get('networks'):
+            resource_filter.extend(["networks"])
+
+        if resource_filter:
+            result = self.executor.execute_plugin(
+                module_name="cisco.nac_dc_vxlan.dtc.build_resource_data",
+                module_args={
+                    "fabric_type": self.fabric_type,
+                    "fabric_name": self.fabric_name,
+                    "data_model": self.data_model,
+                    "role_path": role_path,
+                    "run_map_diff_run": self.run_map_diff_run,
+                    "force_run_all": self.force_run_all,
+                    "check_roles": check_roles,
+                    "resource_filter": resource_filter,
+                },
+            )
+
+            if result.get('failed'):
+                return result
+
+            # Merge resource_data into pipeline runner state
+            new_resource_data = result.get('resource_data', {})
+            self.resource_data.update(new_resource_data)
+
+            # Merge change_flags into pipeline runner state
+            new_change_flags = result.get('change_flags', {})
+            self.change_flags.update(new_change_flags)
+
+            # Update aggregate flag
+            if any(new_change_flags.values()):
+                self.change_flags['changes_detected_any'] = True
+
+            # Merge diff_results if present
+            new_diff_results = result.get('diff_results', {})
+            if hasattr(self, 'diff_results'):
+                self.diff_results.update(new_diff_results)
+
+            # Cache results for the next pipeline (CREATE → REMOVE) in this
+            # playbook run. Serializes resource_data and change_flags to JSON.
+            try:
+                os.makedirs(output_path, exist_ok=True)
+                cache_data = {
+                    'resource_data': self._make_json_safe(new_resource_data),
+                    'change_flags': dict(new_change_flags),
+                }
+                with open(cache_file, 'w') as f:
+                    json.dump(cache_data, f)
+            except (TypeError, IOError) as e:
+                display.warning(
+                    f"{self.OPERATION.upper()} [{self.fabric_name}] "
+                    f"Failed to cache overlay results: {e}"
+                )
+
+            display.v(
+                f"{self.OPERATION.upper()} [{self.fabric_name}] "
+                f"Deferred overlay build complete: "
+                f"resources={list(new_resource_data.keys())}, "
+                f"flags={new_change_flags}"
+            )
+
+            return {'failed': False, 'changed': any(new_change_flags.values())}
+
+        return {'failed': False, 'changed': False, 'msg': 'No overlay resources to build — skipped'}
+
+    @staticmethod
+    def _make_json_safe(obj):
+        """
+        Recursively convert Ansible-specific types to plain Python types
+        for JSON serialization.
+        """
+        if isinstance(obj, dict):
+            return {str(k): PipelineRunnerBase._make_json_safe(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [PipelineRunnerBase._make_json_safe(item) for item in obj]
+        if isinstance(obj, bool):
+            return obj
+        if isinstance(obj, int):
+            return obj
+        if isinstance(obj, float):
+            return obj
+        if obj is None:
+            return obj
+        return str(obj)
+
+    def _manage_child_fabrics(self, resource_name, step):
+        """
+        Manage child fabric associations for MSD/MCFG operations.
+
+        Delegates to the existing manage_child_fabrics action plugin.
+        Operation type is determined by the OPERATION class attribute.
+        """
+        child_fabrics_data = self.resource_data.get('child_fabrics', {}).get('data', {})
+
+        if self.OPERATION == 'create':
+            child_fabrics_list = child_fabrics_data.get('to_be_added', [])
+            state = 'present'
+        else:
+            child_fabrics_list = child_fabrics_data.get('to_be_removed', [])
+            state = 'absent'
+
+        if not child_fabrics_list:
+            return {'changed': False, 'failed': False}
+
+        return self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.manage_child_fabrics",
+            module_args={
+                "parent_fabric": self.fabric_name,
+                "parent_fabric_type": self.fabric_type,
+                "child_fabrics": child_fabrics_list,
+                "state": state,
+            },
+        )
+
+    def _vrf_loopback_attach(self, resource_name, step):
+        """
+        Attach loopbacks to VRFs via NDFC REST API.
+
+        Resolves the correct REST endpoint per fabric type:
+          - MCFG: /onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/fabrics/{fabric}/vrfs/attachments
+          - All others: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2/fabrics/{fabric}/vrfs/attachments
+        """
+        import json
+
+        resource_entry = self.resource_data.get('vrf_loopback_attach', {})
+        data = resource_entry.get('module_data', resource_entry.get('data', []))
+
+        data = [d for d in data if d.get('lanAttachList')]
+
+        if not data:
+            return {'failed': False, 'msg': 'No VRF loopback attach data — skipped'}
+
+        if self.fabric_type == 'MCFG':
+            path = (
+                f"/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down"
+                f"/fabrics/{self.fabric_name}/vrfs/attachments"
+            )
+        else:
+            path = (
+                f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2"
+                f"/fabrics/{self.fabric_name}/vrfs/attachments"
+            )
+
+        display.v(
+            f"{self.OPERATION.upper()} [{self.fabric_name}] Attaching loopbacks to VRFs "
+            f"via REST POST ({len(data) if isinstance(data, list) else '?'} items)"
+        )
+
+        result = self.executor.execute_rest("POST", path, json_data=json.dumps(data))
+
+        # dcnm_rest is a raw REST client and does not set changed=True.
+        # A successful POST to the attachments endpoint is state-modifying.
+        if isinstance(result, dict) and not result.get('failed'):
+            result['changed'] = True
+
+        return result
+
+    def _tor_pairing(self, resource_name, step):
+        """
+        Create or remove ToR pairings in NDFC.
+
+        Direction is determined by self.OPERATION ('create' or 'remove'):
+          - create: Uses diff.updated from build_resource_data
+          - remove: Uses diff.removed from build_resource_data
+
+        Diff run active:  Passes pre-computed diff items via 'pairings' param
+                          (direct mode).
+        Diff run disabled: Passes leaf_serial_number + current_pairings and lets
+                          the plugin discover, diff, and execute (discovery mode).
+        """
+        # diff_compare returns 'updated' (new/changed) and 'removed' keys
+        diff_key = 'updated' if self.OPERATION == 'create' else 'removed'
+        op_label = self.OPERATION.upper()
+
+        resource_entry = self.resource_data.get('tor_pairing', {})
+        tor_pairing_data = resource_entry.get('module_data', resource_entry.get('data', []))
+
+        # For create: skip if no pairing data at all
+        # For remove: still need to proceed when diff_run is disabled (NDFC may have stale pairings)
+        if not tor_pairing_data:
+            if self.OPERATION == 'create' or (self.run_map_diff_run and not self.force_run_all):
+                return {'failed': False, 'msg': 'No ToR pairing data — skipped'}
+
+        if self.run_map_diff_run and not self.force_run_all:
+            # Diff run active — items pre-computed by build_resource_data (direct mode)
+            diff = resource_entry.get('diff')
+            items = diff.get(diff_key, []) if diff and isinstance(diff, dict) else []
+
+            if not items:
+                display.v(
+                    f"{op_label} [{self.fabric_name}] No ToR pairings to "
+                    f"{self.OPERATION} — skipped"
+                )
+                return {'failed': False, 'msg': f'No ToR pairings to {self.OPERATION}'}
+
+            display.v(
+                f"{op_label} [{self.fabric_name}] {self.OPERATION.title()}ing "
+                f"{len(items)} ToR pairing(s)"
+            )
+
+            return self.executor.execute_plugin(
+                module_name="cisco.nac_dc_vxlan.dtc.process_tor_pairing",
+                module_args={
+                    "operation": self.OPERATION,
+                    "pairings": items,
+                    "fabric_name": self.fabric_name,
+                },
+            )
+        else:
+            # Diff run disabled — discover + diff + execute (discovery mode)
+            switches = self.data_model.get('vxlan', {}).get('topology', {}).get('switches', [])
+            leaf_switches = [s for s in switches if s.get('role') == 'leaf']
+
+            if not leaf_switches:
+                display.v(
+                    f"{op_label} [{self.fabric_name}] No leaf switches found — skipped"
+                )
+                return {'failed': False, 'msg': 'No leaf switches found — skipped'}
+
+            display.v(
+                f"{op_label} [{self.fabric_name}] Discovering and "
+                f"{self.OPERATION}ing ToR pairings"
+            )
+
+            return self.executor.execute_plugin(
+                module_name="cisco.nac_dc_vxlan.dtc.process_tor_pairing",
+                module_args={
+                    "operation": self.OPERATION,
+                    "fabric_name": self.fabric_name,
+                    "leaf_serial_number": leaf_switches[0].get('serial_number', ''),
+                    "current_pairings": tor_pairing_data if tor_pairing_data else [],
+                },
+            )
+
+    def _unmanaged_policy(self, resource_name, step):
+        """
+        Discover and remove unmanaged policies from NDFC.
+
+        Queries each switch for policies with the 'nac_' description prefix,
+        compares against the data model, and deletes any that are not declared.
+        Delegates to the unmanaged_policy action plugin which handles both
+        discovery and dcnm_policy deletion in a single call.
+
+        Requires switch serial numbers from the pre-fetched switch list
+        (populated by _pre_pipeline_setup on the remove subclass, stored
+        as self.fabric_switch_list).
+        """
+        switches = getattr(self, 'fabric_switch_list', [])
+        if not switches:
+            return {'failed': False, 'msg': 'No switches in fabric — skipped'}
+
+        serial_numbers = [
+            s['serialNumber'] for s in switches
+            if isinstance(s, dict) and 'serialNumber' in s
+        ]
+
+        if not serial_numbers:
+            return {'failed': False, 'msg': 'No switch serial numbers found — skipped'}
+
+        display.v(
+            f"{self.OPERATION.upper()} [{self.fabric_name}] Discovering and removing "
+            f"unmanaged policies across {len(serial_numbers)} switch(es)"
+        )
+
+        return self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.unmanaged_policy",
+            module_args={
+                "switch_serial_numbers": serial_numbers,
+                "data_model": self.data_model,
+                "fabric_name": self.fabric_name,
+            },
+        )
+
+    def _config_save(self, resource_name, step):
+        """
+        Execute a config-save via the fabric_deploy_manager action plugin.
+
+        Delegates to fabric_deploy_manager with operation='config_save',
+        consolidating config-save into a single code path. The fabric_deploy_manager
+        handles MCFG vs standard path resolution via ApiPathResolver.
+
+        Treats HTTP 500 as non-fatal since config-save can return 500
+        when there are no pending changes (matches original rescue block behavior).
+        """
+        result = self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.fabric_deploy_manager",
+            module_args={
+                "fabric_name": self.fabric_name,
+                "fabric_type": self.fabric_type,
+                "operation": "config_save",
+            },
+        )
+
+        if result.get('failed'):
+            return_code = None
+            try:
+                return_code = result.get('msg', {}).get('RETURN_CODE')
+            except (AttributeError, TypeError):
+                pass
+
+            if return_code == 500:
+                display.v(
+                    f"{self.OPERATION.upper()} [{self.fabric_name}] Config-save returned "
+                    f"HTTP 500 (non-fatal — no pending changes)"
+                )
+                return {'failed': False, 'msg': 'Config-save HTTP 500 (non-fatal)'}
+
+        return result

--- a/plugins/plugin_utils/pipeline_base.py
+++ b/plugins/plugin_utils/pipeline_base.py
@@ -929,6 +929,43 @@ class PipelineRunnerBase(ABC):
             },
         )
 
+    def _unmanaged_edge_connections(self, resource_name, step):
+        """
+        Discover and remove unmanaged edge connections from NDFC.
+
+        Replicates roles/dtc/remove/tasks/common/edge_connections.yml:
+          1. Build the unmanaged edge connection payload via the
+             unmanaged_edge_connections action plugin (which queries NDFC for
+             each switch's edge_/nace_ policies and diffs them against the
+             data model edge_connections).
+          2. Delete the resulting unmanaged policies via dcnm_policy with
+             state=deleted, use_desc_as_key=true, deploy=false.
+
+        Edge connections are NDFC policies (not links), so removal goes through
+        dcnm_policy — not dcnm_links, which requires src_fabric and a different
+        config schema.
+
+        Requires the pre-fetched switch list (populated by _pre_pipeline_setup,
+        stored as self.fabric_switch_list).
+        """
+        switches = getattr(self, 'fabric_switch_list', [])
+        if not switches:
+            return {'failed': False, 'msg': 'No switches in fabric — skipped'}
+
+        # Full configured edge_connections data model (rendered template output),
+        # not diff-narrowed: [{ "switch": [ {ip, policies}, ... ] }]
+        edge_connections_data = self.resource_data.get('edge_connections', {}).get('data', [])
+
+        # Step 1: Build the unmanaged edge connection payload
+        return self.executor.execute_plugin(
+            module_name="cisco.nac_dc_vxlan.dtc.unmanaged_edge_connections",
+            module_args={
+                "switch_data": switches,
+                "edge_connections": edge_connections_data,
+                "fabric_name": self.fabric_name,
+            },
+        )
+
     def _config_save(self, resource_name, step):
         """
         Execute a config-save via the fabric_deploy_manager action plugin.

--- a/plugins/plugin_utils/pipeline_base.py
+++ b/plugins/plugin_utils/pipeline_base.py
@@ -966,6 +966,28 @@ class PipelineRunnerBase(ABC):
             },
         )
 
+    def _fabric_has_preprovisioned_switches(self):
+        """
+        Return True if the data model defines any pre-provisioned switch
+        (``poap.preprovision``) for this fabric.
+
+        Used to gate the non-fatal HTTP 500 config-save handling so the bypass
+        only applies to pre-provisioned fabrics, where NDFC legitimately
+        returns 500 while switches are still reloading or not yet reachable.
+        """
+        switches = (
+            self.data_model.get('vxlan', {})
+            .get('topology', {})
+            .get('switches', [])
+        ) or []
+
+        return any(
+            isinstance(sw, dict)
+            and isinstance(sw.get('poap'), dict)
+            and sw['poap'].get('preprovision')
+            for sw in switches
+        )
+
     def _config_save(self, resource_name, step):
         """
         Execute a config-save via the fabric_deploy_manager action plugin.
@@ -974,8 +996,14 @@ class PipelineRunnerBase(ABC):
         consolidating config-save into a single code path. The fabric_deploy_manager
         handles MCFG vs standard path resolution via ApiPathResolver.
 
-        Treats HTTP 500 as non-fatal since config-save can return 500
-        when there are no pending changes (matches original rescue block behavior).
+        Treats an HTTP 500 from config-save as non-fatal **only when the data
+        model contains pre-provisioned switches** (``poap.preprovision``), so
+        the pipeline continues for pre-provisioned fabrics where NDFC can
+        return 500 to the intermediate recalculate/config-save while switches
+        are still reloading or not yet reachable. A 500 on a fabric without
+        pre-provisioned switches, and any other failure (400, auth, malformed
+        responses), remain fatal. The tolerated 500 is surfaced as a warning
+        rather than silenced.
         """
         result = self.executor.execute_plugin(
             module_name="cisco.nac_dc_vxlan.dtc.fabric_deploy_manager",
@@ -993,11 +1021,16 @@ class PipelineRunnerBase(ABC):
             except (AttributeError, TypeError):
                 pass
 
-            if return_code == 500:
-                display.v(
-                    f"{self.OPERATION.upper()} [{self.fabric_name}] Config-save returned "
-                    f"HTTP 500 (non-fatal — no pending changes)"
+            if return_code == 500 and self._fabric_has_preprovisioned_switches():
+                display.warning(
+                    f"{self.OPERATION.upper()} [{self.fabric_name}] config-save returned "
+                    f"HTTP 500; continuing because the data model contains pre-provisioned "
+                    f"switches (likely still reloading or not yet reachable in NDFC)."
                 )
-                return {'failed': False, 'msg': 'Config-save HTTP 500 (non-fatal)'}
+                display.v(
+                    f"{self.OPERATION.upper()} [{self.fabric_name}] config-save HTTP 500 "
+                    f"detail: {result.get('msg')}"
+                )
+                return {'failed': False, 'msg': 'Config-save HTTP 500 (non-fatal, pre-provisioned fabric)'}
 
         return result

--- a/plugins/plugin_utils/registry_loader.py
+++ b/plugins/plugin_utils/registry_loader.py
@@ -1,0 +1,498 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+"""
+Registry Loader — Shared YAML registry loader with LRU cache and validation.
+
+Provides a single entry point for all DTC action plugins to load their
+data-driven configuration from external YAML registry files under resources/.
+
+Includes three validation capabilities:
+  1. Cross-reference validation — pipeline resource_names vs resource_types keys
+  2. Pipeline symmetry validation — create/remove step correspondence
+  3. Schema validation — required fields check to catch YAML typos
+
+Usage:
+    from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.registry_loader import RegistryLoader
+
+    collection_path = RegistryLoader.get_collection_path()
+    resource_types = RegistryLoader.load(collection_path, 'resource_types')
+
+    # Validate all registries at startup
+    errors = RegistryLoader.validate_all(collection_path)
+    if errors:
+        raise ValueError(f"Registry validation failed: {errors}")
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import os
+import yaml
+from functools import lru_cache
+
+from ansible.utils.display import Display
+
+display = Display()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Schema Definitions — Required fields for each registry entry type
+# ══════════════════════════════════════════════════════════════════════════════
+
+REQUIRED_RESOURCE_FIELDS = {
+    'template',
+    'output_file',
+    'change_flag',
+    'diff_compare',
+    'fabric_types',
+}
+
+REQUIRED_PIPELINE_FIELDS = {
+    'resource_name',
+    'module',
+    'state',
+    'change_flag_guard',
+}
+
+
+REQUIRED_FABRIC_TYPE_FIELDS = {
+    'namespace',
+    'file_subdir',
+}
+
+# Pipeline fields that are known/valid (for typo detection)
+KNOWN_PIPELINE_FIELDS = {
+    'resource_name',
+    'module',
+    'state',
+    'state_full_run',
+    'full_run_strategy',
+    'data_key_full_run',
+    'change_flag_guard',
+    'data_model_guard',
+    'delete_mode_guard',
+    'skip_if_child_fabric',
+    'fabric_param',
+    'skip_diff',
+    'deploy',
+    'save',
+    'tag',
+}
+
+
+class RegistryLoader:
+    """
+    Generic loader for YAML registry files under resources/.
+
+    Provides:
+      - Cached loading via lru_cache (loaded once per Ansible run)
+      - Auto-discovery of collection path from __file__ location
+      - Tag filtering for pipeline steps
+      - Cross-reference, symmetry, and schema validation
+    """
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def load(collection_path, registry_name):
+        """
+        Load a named YAML registry file from resources/.
+
+        Args:
+            collection_path: Root path of the collection (cisco/nac_dc_vxlan/)
+            registry_name:   Name of the registry file (without .yml extension)
+
+        Returns:
+            Parsed YAML content as a dict.
+
+        Raises:
+            FileNotFoundError: If the registry file does not exist.
+            yaml.YAMLError: If the file contains invalid YAML.
+
+        Example:
+            resource_types = RegistryLoader.load('/path/to/collection', 'resource_types')
+        """
+        registry_path = os.path.join(collection_path, 'resources', f'{registry_name}.yml')
+        if not os.path.exists(registry_path):
+            raise FileNotFoundError(
+                f"Registry file not found: {registry_path}"
+            )
+        with open(registry_path, 'r') as f:
+            data = yaml.safe_load(f)
+        if data is None:
+            return {}
+        return data
+
+    @staticmethod
+    def get_collection_path():
+        """
+        Auto-derive the collection root from this file's location.
+
+        This file lives at: plugins/plugin_utils/registry_loader.py
+        Collection root is 3 directories up.
+
+        Returns:
+            Absolute path to the collection root directory.
+        """
+        # __file__ = plugins/plugin_utils/registry_loader.py
+        # Go up: plugin_utils → plugins → collection_root
+        this_dir = os.path.dirname(os.path.abspath(__file__))
+        plugin_utils_dir = this_dir                             # plugins/plugin_utils/
+        plugins_dir = os.path.dirname(plugin_utils_dir)         # plugins/
+        collection_root = os.path.dirname(plugins_dir)          # collection root
+        return collection_root
+
+    @staticmethod
+    def clear_cache():
+        """Clear the LRU cache — useful in testing."""
+        RegistryLoader.load.cache_clear()
+
+    @staticmethod
+    def filter_pipeline_by_tags(pipeline_steps, ansible_run_tags, role_tag=None):
+        """
+        Filter pipeline steps based on Ansible run tags.
+
+        Filtering rules (applied in order):
+          1. No active tags or empty → run all steps (no --tags specified)
+          2. 'all' in active tags → run all steps (Ansible convention)
+          3. role_tag in active tags → run all steps (role-level bypass)
+          4. Otherwise → include only steps whose tag matches an active tag
+          5. Steps with no tag field (tag is None) → always included
+
+        Args:
+            pipeline_steps: List of pipeline step dicts from YAML registry.
+            ansible_run_tags: Set/list of tags from ansible_run_tags.
+            role_tag: Optional role-level tag from registry. If present in
+                      ansible_run_tags, bypasses per-step filtering.
+
+        Returns:
+            Filtered list of pipeline steps.
+        """
+        if not ansible_run_tags or 'all' in ansible_run_tags:
+            return pipeline_steps
+
+        if role_tag and role_tag in ansible_run_tags:
+            return pipeline_steps
+
+        filtered = []
+        for step in pipeline_steps:
+            step_tag = step.get('tag')
+            if step_tag is None:
+                # Infrastructure steps (no tag) always run
+                filtered.append(step)
+            elif isinstance(step_tag, list):
+                # List tags — include if ANY tag matches (shared prep steps)
+                if set(step_tag) & set(ansible_run_tags):
+                    filtered.append(step)
+            elif step_tag in ansible_run_tags:
+                filtered.append(step)
+        return filtered
+
+    # ══════════════════════════════════════════════════════════════════════════
+    # Validation Methods (#6 — Registry Validation)
+    # ══════════════════════════════════════════════════════════════════════════
+
+    @staticmethod
+    def validate_all(collection_path):
+        """
+        Run all three validation checks and return combined results.
+
+        This is the primary entry point for registry validation. Call it
+        at plugin startup (with -vvv) or as part of CI.
+
+        Args:
+            collection_path: Root path of the collection.
+
+        Returns:
+            dict with:
+              - 'errors': List of error strings (things that will break)
+              - 'warnings': List of warning strings (things that might be wrong)
+              - 'valid': Boolean — True if no errors
+        """
+        errors = []
+        warnings = []
+
+        # Load all registries
+        try:
+            resource_types = RegistryLoader.load(collection_path, 'resource_types')
+            fabric_types = RegistryLoader.load(collection_path, 'fabric_types')
+            create_resources = RegistryLoader.load(collection_path, 'create_resources')
+            remove_resources = RegistryLoader.load(collection_path, 'remove_resources')
+        except (FileNotFoundError, yaml.YAMLError) as e:
+            return {
+                'errors': [f"Failed to load registries: {str(e)}"],
+                'warnings': [],
+                'valid': False,
+            }
+
+        # 1. Schema validation
+        schema_errors = RegistryLoader.validate_schema(
+            resource_types, create_resources, remove_resources, fabric_types,
+        )
+        errors.extend(schema_errors)
+
+        # 2. Cross-reference validation
+        xref_errors = RegistryLoader.validate_cross_references(
+            resource_types, create_resources, remove_resources, fabric_types,
+        )
+        errors.extend(xref_errors)
+
+        # 3. Pipeline symmetry validation
+        symmetry_warnings = RegistryLoader.validate_pipeline_symmetry(
+            create_resources, remove_resources
+        )
+        warnings.extend(symmetry_warnings)
+
+        return {
+            'errors': errors,
+            'warnings': warnings,
+            'valid': len(errors) == 0,
+        }
+
+    @staticmethod
+    def validate_cross_references(resource_types, create_resources, remove_resources, fabric_types):
+        """
+        Verify that all cross-references between registry files are valid.
+
+        Checks:
+          - Pipeline step resource_name values exist in resource_types
+            (internal methods starting with '_' and null are excluded)
+          - Fabric type keys in pipelines exist in fabric_types
+          - fabric_types lists in resource_types reference valid fabric type keys
+
+        Args:
+            resource_types:    Parsed resource_types.yml content
+            create_resources:  Parsed create_resources.yml content
+            remove_resources:  Parsed remove_resources.yml content
+            fabric_types:      Parsed fabric_types.yml content
+
+        Returns:
+            List of error strings. Empty list means all references are valid.
+        """
+        errors = []
+
+        valid_resources = set(resource_types.get('resource_types', {}).keys())
+        valid_fabrics = set(fabric_types.get('fabric_types', {}).keys())
+
+        # Validate create/remove pipeline references
+        for pipeline_name, pipelines_data in [
+            ('create', create_resources),
+            ('remove', remove_resources),
+        ]:
+            pipeline_key = f'{pipeline_name}_resources'
+            pipeline_dict = pipelines_data.get(pipeline_key, {})
+
+            for fabric_type, steps in pipeline_dict.items():
+                # Skip non-pipeline keys like 'role_tag'
+                if fabric_type == 'role_tag':
+                    continue
+
+                # Validate fabric type reference
+                if fabric_type not in valid_fabrics:
+                    errors.append(
+                        f"{pipeline_name} pipeline: unknown fabric_type '{fabric_type}'"
+                    )
+
+                if not isinstance(steps, list):
+                    continue
+
+                for idx, step in enumerate(steps):
+                    resource_name = step.get('resource_name')
+                    module = step.get('module', '')
+
+                    # Skip internal methods and null resource names
+                    if resource_name is None or (isinstance(module, str) and module.startswith('_')):
+                        continue
+
+                    if resource_name not in valid_resources:
+                        errors.append(
+                            f"{pipeline_name} pipeline [{fabric_type}] step {idx}: "
+                            f"unknown resource_name '{resource_name}'"
+                        )
+
+        # Validate common pipeline references are no longer needed
+        # (common role uses resource_types.yml directly via build_resource_data)
+
+        # Validate resource fabric_types references
+        for name, cfg in resource_types.get('resource_types', {}).items():
+            for ft in cfg.get('fabric_types', []):
+                if ft not in valid_fabrics:
+                    errors.append(
+                        f"resource_types '{name}': unknown fabric_type '{ft}'"
+                    )
+
+        return errors
+
+    @staticmethod
+    def validate_pipeline_symmetry(create_resources, remove_resources):
+        """
+        Verify create/remove pipeline step correspondence.
+
+        For each fabric type, warns when:
+          - A resource has a create step but no remove step
+          - A resource has a remove step but no create step
+
+        Internal methods (starting with '_') and null resource names are
+        excluded from symmetry checks since orchestration-only steps don't
+        require counterparts.
+
+        Args:
+            create_resources:  Parsed create_resources.yml content
+            remove_resources:  Parsed remove_resources.yml content
+
+        Returns:
+            List of warning strings. Empty list means all steps are symmetric.
+        """
+        warnings = []
+
+        create_dict = create_resources.get('create_resources', {})
+        remove_dict = remove_resources.get('remove_resources', {})
+
+        # Get all fabric types from both pipelines
+        all_fabric_types = set()
+        for ft in create_dict:
+            if ft != 'role_tag':
+                all_fabric_types.add(ft)
+        for ft in remove_dict:
+            if ft != 'role_tag':
+                all_fabric_types.add(ft)
+
+        for fabric_type in sorted(all_fabric_types):
+            create_steps = create_dict.get(fabric_type, [])
+            remove_steps = remove_dict.get(fabric_type, [])
+
+            # Extract non-internal resource names
+            create_resources = set()
+            for step in (create_steps if isinstance(create_steps, list) else []):
+                rn = step.get('resource_name')
+                module = step.get('module', '')
+                if rn is not None and not (isinstance(module, str) and module.startswith('_')):
+                    create_resources.add(rn)
+
+            remove_resources = set()
+            for step in (remove_steps if isinstance(remove_steps, list) else []):
+                rn = step.get('resource_name')
+                module = step.get('module', '')
+                if rn is not None and not (isinstance(module, str) and module.startswith('_')):
+                    remove_resources.add(rn)
+
+            create_only = create_resources - remove_resources
+            remove_only = remove_resources - create_resources
+
+            if create_only:
+                warnings.append(
+                    f"{fabric_type}: created but never removed: {sorted(create_only)}"
+                )
+            if remove_only:
+                warnings.append(
+                    f"{fabric_type}: removed but never created: {sorted(remove_only)}"
+                )
+
+        return warnings
+
+    @staticmethod
+    def validate_schema(resource_types, create_resources, remove_resources, fabric_types):
+        """
+        Validate that all registry entries have the required fields.
+
+        Catches typos like 'chang_flag_guard' instead of 'change_flag_guard'
+        at load time rather than at runtime when the missing value would
+        silently be None.
+
+        Args:
+            resource_types:    Parsed resource_types.yml content
+            create_resources:  Parsed create_resources.yml content
+            remove_resources:  Parsed remove_resources.yml content
+            fabric_types:      Parsed fabric_types.yml content
+
+        Returns:
+            List of error strings. Empty list means all schemas are valid.
+        """
+        errors = []
+
+        # Validate resource_types entries
+        for name, cfg in resource_types.get('resource_types', {}).items():
+            if not isinstance(cfg, dict):
+                errors.append(f"resource_types '{name}': entry is not a dict")
+                continue
+            missing = REQUIRED_RESOURCE_FIELDS - set(cfg.keys())
+            if missing:
+                errors.append(
+                    f"resource_types '{name}': missing required fields: {sorted(missing)}"
+                )
+
+        # Validate fabric_types entries
+        for name, cfg in fabric_types.get('fabric_types', {}).items():
+            if not isinstance(cfg, dict):
+                errors.append(f"fabric_types '{name}': entry is not a dict")
+                continue
+            missing = REQUIRED_FABRIC_TYPE_FIELDS - set(cfg.keys())
+            if missing:
+                errors.append(
+                    f"fabric_types '{name}': missing required fields: {sorted(missing)}"
+                )
+
+        # Validate pipeline step entries
+        for pipeline_name, pipelines_data in [
+            ('create', create_resources),
+            ('remove', remove_resources),
+        ]:
+            pipeline_key = f'{pipeline_name}_resources'
+            pipeline_dict = pipelines_data.get(pipeline_key, {})
+
+            for fabric_type, steps in pipeline_dict.items():
+                if fabric_type == 'role_tag':
+                    continue
+                if not isinstance(steps, list):
+                    errors.append(
+                        f"{pipeline_name} pipeline '{fabric_type}': value is not a list"
+                    )
+                    continue
+
+                for idx, step in enumerate(steps):
+                    if not isinstance(step, dict):
+                        errors.append(
+                            f"{pipeline_name} pipeline [{fabric_type}] step {idx}: "
+                            f"entry is not a dict"
+                        )
+                        continue
+
+                    missing = REQUIRED_PIPELINE_FIELDS - set(step.keys())
+                    if missing:
+                        errors.append(
+                            f"{pipeline_name} pipeline [{fabric_type}] step {idx} "
+                            f"({step.get('resource_name', '?')}): "
+                            f"missing required fields: {sorted(missing)}"
+                        )
+
+                    # Check for unknown fields (potential typos)
+                    unknown = set(step.keys()) - KNOWN_PIPELINE_FIELDS
+                    if unknown:
+                        # This is a warning-level issue but reported as error
+                        # to be conservative — unknown fields are likely typos
+                        errors.append(
+                            f"{pipeline_name} pipeline [{fabric_type}] step {idx} "
+                            f"({step.get('resource_name', '?')}): "
+                            f"unknown fields (possible typos): {sorted(unknown)}"
+                        )
+
+        return errors

--- a/resources/create_resources.yml
+++ b/resources/create_resources.yml
@@ -1,0 +1,743 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Create Pipelines — Ordered creation operations per fabric type
+#
+# Consumed by: manage_resources.py
+#
+# Each step defines:
+#   resource_name:        Key in resource_data dict for the data to pass.
+#                         Use null for internal methods that don't need data.
+#   module:               cisco.dcnm module name (prefix added at runtime).
+#                         Internal methods start with '_' (e.g., _config_save).
+#   state:                Module state parameter (merged, replaced, etc.).
+#                         Use null for internal methods.
+#   deploy:               (optional) Deploy after module execution.
+#                         true/false/null. Omit to use module default.
+#   save:                 (optional) Config save parameter passed to module.
+#                         true/false. Omit to use module default.
+#   skip_diff:            (optional) Skip diff comparison for this resource.
+#                         true to bypass diff. Omit or false for normal diff.
+#   fabric_param:         (optional) Override fabric parameter name sent to
+#                         the module. Default: 'fabric'. Use 'src_fabric'
+#                         for dcnm_vpc_pair. Use null to omit fabric param.
+#   data_model_guard:     (optional) Dot-path into the data model. Step is
+#                         skipped if the path resolves to falsy/missing.
+#                         Accepts a string or list. List uses AND semantics
+#                         — all paths must be truthy for the step to run.
+#   change_flag_guard:    (optional) Change flag name from build_resource_data.
+#                         Step is skipped if this flag is False. Use null
+#                         for steps that should always run. Steps that use
+#                         runtime_change_refs should set this to null — the
+#                         upstream steps' own guards provide build-time
+#                         filtering, and runtime_change_refs provides the
+#                         runtime gate.
+#   runtime_change_refs:  (optional) List of prior resource_names. Step is
+#                         skipped if none of them returned changed=true at
+#                         runtime. Used for config_save after a group of steps.
+#   tag:                  (optional) Per-step tag for --tags filtering.
+#                         Accepts a string or list. List uses OR semantics
+#                         — step is included if ANY tag is active. Steps
+#                         with no tag always run when tag filtering is active.
+#
+# Top-level keys:
+#   role_tag:             Tag that bypasses per-step filtering (e.g.,
+#                         --tags role_create runs the entire pipeline).
+#
+# Pipeline ordering respects creation dependencies:
+#   fabric → switches → vPC → interfaces → overlay → links → policies
+# ══════════════════════════════════════════════════════════════════════════════
+---
+
+create_resources:
+
+  role_tag: role_create
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # VXLAN_EVPN — Full pipeline with overlay, links, and edge connections
+  # ──────────────────────────────────────────────────────────────────────────
+  VXLAN_EVPN:
+    - resource_name: fabric
+      module: dcnm_fabric
+      state: merged
+      fabric_param: null
+      deploy: null
+      change_flag_guard: changes_detected_fabric
+      tag: cr_manage_fabric
+
+    - resource_name: inventory
+      module: dcnm_inventory
+      state: merged
+      save: false
+      deploy: false
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_inventory
+      tag: cr_manage_switches
+
+    - resource_name: underlay_ip_address
+      module: _underlay_ip_remote_diff
+      state: null
+      data_model_guard: vxlan.underlay.general.manual_underlay_allocation
+      change_flag_guard: changes_detected_underlay_ip_address
+      tag: cr_manage_switches
+
+    - resource_name: underlay_ip_address
+      module: dcnm_resource_manager
+      state: merged
+      deploy: null
+      data_model_guard: vxlan.underlay.general.manual_underlay_allocation
+      change_flag_guard: changes_detected_underlay_ip_address
+      tag: cr_manage_switches
+
+    - resource_name: update_switch_hostname_policy
+      module: _update_switch_hostname_policy
+      state: null
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_inventory
+      tag: cr_manage_switches
+
+    - resource_name: inventory_config_save
+      module: _config_save
+      state: null
+      change_flag_guard: null
+      data_model_guard: vxlan.topology.switches
+      runtime_change_refs:
+        - fabric
+        - inventory
+        - underlay_ip_address
+        - update_switch_hostname_policy
+      tag: cr_manage_switches
+
+    - resource_name: vpc_domain_id_resource
+      module: dcnm_resource_manager
+      state: merged
+      deploy: null
+      data_model_guard: vxlan.topology.vpc_peers
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_fabric_peering_links
+      module: dcnm_links
+      state: replaced
+      fabric_param: src_fabric
+      deploy: null
+      skip_diff: true
+      data_model_guard: vxlan.topology.vpc_peers
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_peering
+      module: dcnm_vpc_pair
+      state: replaced
+      fabric_param: src_fabric
+      deploy: false
+      data_model_guard: vxlan.topology.vpc_peers
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_config_save
+      module: _config_save
+      state: null
+      data_model_guard: vxlan.topology.vpc_peers
+      change_flag_guard: null
+      runtime_change_refs:
+        - vpc_domain_id_resource
+        - vpc_fabric_peering_links
+        - vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: tor_pairing
+      module: _tor_pairing
+      state: null
+      data_model_guard: vxlan.topology.tor_pairing
+      change_flag_guard: changes_detected_tor_pairing
+      tag: cr_manage_tor_pairing
+
+    - resource_name: tor_config_save
+      module: _config_save
+      state: null
+      data_model_guard: vxlan.topology.tor_pairing
+      change_flag_guard: null
+      runtime_change_refs:
+        - tor_pairing
+      tag: cr_manage_tor_pairing
+
+    - resource_name: interface_all
+      module: dcnm_interface
+      state: replaced
+      deploy: null
+      change_flag_guard: changes_detected_interfaces
+      tag: cr_manage_interfaces
+
+    - resource_name: edge_connections
+      module: dcnm_policy
+      state: merged
+      deploy: false
+      change_flag_guard: changes_detected_edge_connections
+      tag: cr_manage_edge_connections
+
+    - resource_name: vrfs
+      module: dcnm_vrf
+      state: replaced
+      deploy: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.overlay.vrfs
+      change_flag_guard: changes_detected_vrfs
+      tag: cr_manage_vrfs
+
+    - resource_name: vrf_loopback_attach
+      module: _vrf_loopback_attach
+      state: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.overlay.vrfs
+      change_flag_guard: changes_detected_vrfs
+      tag: cr_manage_vrfs
+
+    - resource_name: networks
+      module: dcnm_network
+      state: replaced
+      deploy: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.overlay.networks
+      change_flag_guard: changes_detected_networks
+      tag: cr_manage_networks
+
+    - resource_name: fabric_links
+      module: _fabric_links_query_and_filter
+      state: null
+      data_model_guard: vxlan.topology.fabric_links
+      change_flag_guard: changes_detected_fabric_links
+      tag: cr_manage_links
+
+    - resource_name: fabric_links
+      module: dcnm_links
+      state: replaced
+      fabric_param: src_fabric
+      deploy: false
+      data_model_guard: vxlan.topology.fabric_links
+      change_flag_guard: changes_detected_fabric_links
+      tag: cr_manage_links
+
+    - resource_name: policy
+      module: _policy_remote_diff
+      state: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy
+      change_flag_guard: changes_detected_policy
+      tag: cr_manage_policy
+
+    - resource_name: policy
+      module: dcnm_policy
+      state: merged
+      deploy: false
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy.policies
+        - vxlan.policy.groups
+        - vxlan.policy.switches
+      change_flag_guard: changes_detected_policy
+      tag: cr_manage_policy
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # eBGP_VXLAN — Similar to VXLAN_EVPN but no edge connections or links
+  # ──────────────────────────────────────────────────────────────────────────
+  eBGP_VXLAN:
+    - resource_name: fabric
+      module: dcnm_fabric
+      state: merged
+      fabric_param: null
+      deploy: null
+      skip_validation: true
+      change_flag_guard: changes_detected_fabric
+      tag: cr_manage_fabric
+
+    - resource_name: inventory
+      module: dcnm_inventory
+      state: merged
+      save: false
+      deploy: false
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_inventory
+      tag: cr_manage_switches
+
+    - resource_name: update_switch_hostname_policy
+      module: _update_switch_hostname_policy
+      state: null
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_inventory
+      tag: cr_manage_switches
+
+    - resource_name: inventory_config_save
+      module: _config_save
+      state: null
+      change_flag_guard: null
+      runtime_change_refs:
+        - fabric
+        - inventory
+        - update_switch_hostname_policy
+      tag: cr_manage_switches
+
+    - resource_name: vpc_domain_id_resource
+      module: dcnm_resource_manager
+      state: merged
+      deploy: null
+      data_model_guard: vxlan.topology.vpc_peers
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_fabric_peering_links
+      module: dcnm_links
+      state: replaced
+      fabric_param: src_fabric
+      deploy: null
+      skip_diff: true
+      data_model_guard: vxlan.topology.vpc_peers
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_peering
+      module: dcnm_vpc_pair
+      state: replaced
+      fabric_param: src_fabric
+      deploy: false
+      data_model_guard: vxlan.topology.vpc_peers
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_config_save
+      module: _config_save
+      state: null
+      data_model_guard: vxlan.topology.vpc_peers
+      change_flag_guard: null
+      runtime_change_refs:
+        - vpc_domain_id_resource
+        - vpc_fabric_peering_links
+        - vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: tor_pairing
+      module: _tor_pairing
+      state: null
+      data_model_guard: vxlan.topology.tor_pairing
+      change_flag_guard: changes_detected_tor_pairing
+      tag: cr_manage_tor_pairing
+
+    - resource_name: tor_config_save
+      module: _config_save
+      state: null
+      data_model_guard: vxlan.topology.tor_pairing
+      change_flag_guard: null
+      runtime_change_refs:
+        - tor_pairing
+      tag: cr_manage_tor_pairing
+
+    - resource_name: interface_all
+      module: dcnm_interface
+      state: replaced
+      deploy: null
+      change_flag_guard: changes_detected_interfaces
+      tag: cr_manage_interfaces
+
+    - resource_name: vrfs
+      module: dcnm_vrf
+      state: replaced
+      deploy: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.overlay.vrfs
+      change_flag_guard: changes_detected_vrfs
+      tag: cr_manage_vrfs
+
+    - resource_name: vrf_loopback_attach
+      module: _vrf_loopback_attach
+      state: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.overlay.vrfs
+      change_flag_guard: changes_detected_vrfs
+      tag: cr_manage_vrfs
+
+    - resource_name: networks
+      module: dcnm_network
+      state: replaced
+      deploy: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.overlay.networks
+      change_flag_guard: changes_detected_networks
+      tag: cr_manage_networks
+
+    - resource_name: policy
+      module: _policy_remote_diff
+      state: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy
+      change_flag_guard: changes_detected_policy
+      tag: cr_manage_policy
+
+    - resource_name: policy
+      module: dcnm_policy
+      state: merged
+      deploy: false
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy.policies
+        - vxlan.policy.groups
+        - vxlan.policy.switches
+      change_flag_guard: changes_detected_policy
+      tag: cr_manage_policy
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # ISN — No overlay, no vPC, no links. Edge connections + interfaces
+  # ──────────────────────────────────────────────────────────────────────────
+  ISN:
+    - resource_name: fabric
+      module: dcnm_fabric
+      state: merged
+      fabric_param: null
+      deploy: null
+      skip_validation: true
+      change_flag_guard: changes_detected_fabric
+      tag: cr_manage_fabric
+
+    - resource_name: inventory
+      module: dcnm_inventory
+      state: merged
+      deploy: false
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_inventory
+      tag: cr_manage_switches
+
+    - resource_name: update_switch_hostname_policy
+      module: _update_switch_hostname_policy
+      state: null
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_inventory
+      tag: cr_manage_switches
+
+    - resource_name: inventory_config_save
+      module: _config_save
+      state: null
+      change_flag_guard: null
+      runtime_change_refs:
+        - fabric
+        - inventory
+        - update_switch_hostname_policy
+      tag: cr_manage_switches
+
+    - resource_name: edge_connections
+      module: dcnm_policy
+      state: merged
+      deploy: false
+      change_flag_guard: changes_detected_edge_connections
+      tag: cr_manage_edge_connections
+
+    - resource_name: interface_all
+      module: dcnm_interface
+      state: replaced
+      deploy: null
+      change_flag_guard: changes_detected_interfaces
+      tag: cr_manage_interfaces
+
+    - resource_name: policy
+      module: _policy_remote_diff
+      state: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy
+      change_flag_guard: changes_detected_policy
+      tag: cr_manage_policy
+
+    - resource_name: policy
+      module: dcnm_policy
+      state: merged
+      deploy: false
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy
+      change_flag_guard: changes_detected_policy
+      tag: cr_manage_policy
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # External — vPC + edge connections + interfaces, no overlay or links
+  # ──────────────────────────────────────────────────────────────────────────
+  External:
+    - resource_name: fabric
+      module: dcnm_fabric
+      state: merged
+      fabric_param: null
+      deploy: null
+      skip_validation: true
+      change_flag_guard: changes_detected_fabric
+      tag: cr_manage_fabric
+
+    - resource_name: inventory
+      module: dcnm_inventory
+      state: merged
+      deploy: false
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_inventory
+      tag: cr_manage_switches
+
+    - resource_name: update_switch_hostname_policy
+      module: _update_switch_hostname_policy
+      state: null
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_inventory
+      tag: cr_manage_switches
+
+    - resource_name: inventory_config_save
+      module: _config_save
+      state: null
+      change_flag_guard: null
+      runtime_change_refs:
+        - fabric
+        - inventory
+        - update_switch_hostname_policy
+      tag: cr_manage_switches
+
+    - resource_name: vpc_domain_id_resource
+      module: dcnm_resource_manager
+      state: merged
+      deploy: null
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_fabric_peering_links
+      module: dcnm_links
+      state: replaced
+      fabric_param: src_fabric
+      deploy: null
+      skip_diff: true
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_peering
+      module: dcnm_vpc_pair
+      state: replaced
+      fabric_param: src_fabric
+      deploy: false
+      change_flag_guard: changes_detected_vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: vpc_config_save
+      module: _config_save
+      state: null
+      change_flag_guard: null
+      runtime_change_refs:
+        - vpc_domain_id_resource
+        - vpc_fabric_peering_links
+        - vpc_peering
+      tag: cr_manage_vpc_peers
+
+    - resource_name: edge_connections
+      module: dcnm_policy
+      state: merged
+      deploy: false
+      change_flag_guard: changes_detected_edge_connections
+      tag: cr_manage_edge_connections
+
+    - resource_name: interface_all
+      module: dcnm_interface
+      state: replaced
+      deploy: null
+      change_flag_guard: changes_detected_interfaces
+      tag: cr_manage_interfaces
+
+    - resource_name: policy
+      module: _policy_remote_diff
+      state: null
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy
+      change_flag_guard: changes_detected_policy
+      tag: cr_manage_policy
+
+    - resource_name: policy
+      module: dcnm_policy
+      state: merged
+      deploy: false
+      data_model_guard:
+        - vxlan.topology.switches
+        - vxlan.policy
+      change_flag_guard: changes_detected_policy
+      tag: cr_manage_policy
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # MSD — Multisite parent: fabric + child fabrics + prepare + overlay
+  # ──────────────────────────────────────────────────────────────────────────
+  MSD:
+    - resource_name: fabric
+      module: dcnm_fabric
+      state: merged
+      fabric_param: null
+      deploy: null
+      change_flag_guard: changes_detected_fabric
+      tag: cr_manage_fabric
+
+    - resource_name: child_fabrics
+      module: _manage_child_fabrics
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: changes_detected_child_fabrics
+      tag: cr_manage_fabric
+
+    - resource_name: child_fabric_config_save
+      module: _config_save
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: null
+      runtime_change_refs:
+        - child_fabrics
+      tag: cr_manage_switches
+
+    - resource_name: prepare_msite_data
+      module: _prepare_msite_data
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: null
+      tag:
+        - cr_manage_vrfs
+        - cr_manage_networks
+
+    - resource_name: bgw_anycast_vip
+      module: dcnm_resource_manager
+      state: merged
+      deploy: null
+      change_flag_guard: changes_detected_bgw_anycast_vip
+      tag:
+        - cr_manage_vrfs
+        - cr_manage_networks
+
+    - resource_name: msite_build_overlay
+      module: _msite_build_overlay
+      state: null
+      data_model_guard: vxlan.multisite.overlay
+      change_flag_guard: null
+      tag:
+        - cr_manage_vrfs
+        - cr_manage_networks
+
+    - resource_name: vrfs
+      module: dcnm_vrf
+      state: replaced
+      deploy: null
+      data_model_guard: vxlan.multisite.overlay.vrfs
+      change_flag_guard: changes_detected_vrfs
+      tag: cr_manage_vrfs
+
+    - resource_name: vrf_loopback_attach
+      module: _vrf_loopback_attach
+      state: null
+      data_model_guard: vxlan.multisite.overlay.vrfs
+      change_flag_guard: changes_detected_vrfs
+      tag: cr_manage_vrfs
+
+    - resource_name: networks
+      module: dcnm_network
+      state: replaced
+      deploy: null
+      data_model_guard: vxlan.multisite.overlay.networks
+      change_flag_guard: changes_detected_networks
+      tag: cr_manage_networks
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # MCFG — Similar to MSD but no BGW anycast VIP
+  # ──────────────────────────────────────────────────────────────────────────
+  MCFG:
+    - resource_name: fabric
+      module: dcnm_fabric_group
+      state: merged
+      fabric_param: null
+      deploy: null
+      change_flag_guard: changes_detected_fabric
+      tag: cr_manage_fabric
+
+    - resource_name: prepare_child_fabrics_data
+      module: _prepare_child_fabrics_data
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: null
+      tag: cr_manage_fabric
+
+    - resource_name: child_fabrics
+      module: _manage_child_fabrics
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: changes_detected_child_fabrics
+      tag: cr_manage_fabric
+
+    - resource_name: child_fabric_config_save
+      module: _config_save
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: null
+      runtime_change_refs:
+        - fabric
+        - child_fabrics
+      tag: cr_manage_fabric
+
+    - resource_name: prepare_msite_data
+      module: _prepare_msite_data
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: null
+      tag:
+        - cr_manage_vrfs
+        - cr_manage_networks
+
+    - resource_name: msite_build_overlay
+      module: _msite_build_overlay
+      state: null
+      data_model_guard: vxlan.multisite.overlay
+      change_flag_guard: null
+      tag:
+        - cr_manage_vrfs
+        - cr_manage_networks
+
+    - resource_name: vrfs
+      module: dcnm_vrf
+      state: replaced
+      deploy: null
+      data_model_guard: vxlan.multisite.overlay.vrfs
+      change_flag_guard: changes_detected_vrfs
+      tag: cr_manage_vrfs
+
+    - resource_name: vrf_loopback_attach
+      module: _vrf_loopback_attach
+      state: null
+      data_model_guard: vxlan.multisite.overlay.vrfs
+      change_flag_guard: changes_detected_vrfs
+      tag: cr_manage_vrfs
+
+    - resource_name: networks
+      module: dcnm_network
+      state: replaced
+      deploy: null
+      data_model_guard: vxlan.multisite.overlay.networks
+      change_flag_guard: changes_detected_networks
+      tag: cr_manage_networks

--- a/resources/fabric_types.yml
+++ b/resources/fabric_types.yml
@@ -1,0 +1,70 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Fabric Types — Namespace and subdirectory mapping
+#
+# Consumed by: build_resource_data.py, registry_loader.py (validation)
+#
+# Active fields (consumed at runtime by build_resource_data.py):
+#   - namespace:    Ansible variable namespace for resource data
+#   - file_subdir:  Output subdirectory under files/
+#
+# The fabric type keys themselves serve as the source of truth for valid
+# fabric types — used by registry_loader.py to validate cross-references
+# in create_resources.yml, remove_resources.yml, and resource_types.yml.
+#
+# ── Future generalization candidates ──
+# The following concepts are currently hardcoded in Python and could be
+# moved here if the architecture is generalized further:
+#   - global_key:           prep_002_global.py hardcodes per-type values
+#   - fabric_template_dir:  Not yet consumed by any plugin
+#   - supports_overlay:     Not yet consumed (guards are inline in plugins)
+#   - supports_vpc:         Not yet consumed (guards are inline in plugins)
+#   - supports_multisite:   fabric_deploy_manager.py hardcodes ('MSD', 'MCFG')
+# ══════════════════════════════════════════════════════════════════════════════
+---
+
+fabric_types:
+
+  VXLAN_EVPN:
+    namespace: vars_common_vxlan
+    file_subdir: vxlan
+
+  eBGP_VXLAN:
+    namespace: vars_common_ebgp_vxlan
+    file_subdir: ebgp_vxlan
+
+  ISN:
+    namespace: vars_common_isn
+    file_subdir: isn
+
+  MSD:
+    namespace: vars_common_msd
+    file_subdir: msd
+
+  MCFG:
+    namespace: vars_common_mcfg
+    file_subdir: mcfg
+
+  External:
+    namespace: vars_common_external
+    file_subdir: external

--- a/resources/remove_resources.yml
+++ b/resources/remove_resources.yml
@@ -1,0 +1,426 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Remove Pipelines — Ordered removal operations per fabric type
+#
+# Consumed by: remove_resources.py
+#
+# Each step defines:
+#   resource_name:        Key in resource_data dict for the data to pass.
+#                         Use null for internal methods that don't need data.
+#   module:               cisco.dcnm module name (prefix added at runtime).
+#                         Internal methods start with '_' (e.g., _tor_pairing).
+#   state:                Module state for diff_run=true (typically 'deleted').
+#                         Use null for internal methods.
+#   state_full_run:       (optional) Module state for diff_run=false (typically
+#                         'overridden'). Omit if state should be the same
+#                         regardless of diff_run mode.
+#   full_run_strategy:    (optional) Strategy for full-run data resolution.
+#                         'controller_diff' — query NDFC and diff against data
+#                         model. 'overridden' — send full data with overridden
+#                         state. Omit for default behavior.
+#   data_key_full_run:    (optional) Key override for full-run data source.
+#                         Default: 'data'. Used when the full-run payload
+#                         differs from the diff-run payload.
+#   data_key_overridden:  (optional) Key override for overridden strategy data.
+#                         Takes precedence over data_key_full_run when the
+#                         full_run_strategy is 'overridden'.
+#   deploy:               (optional) Deploy after module execution.
+#                         true/false/null. Omit to use module default.
+#   fabric_param:         (optional) Override fabric parameter name sent to
+#                         the module. Default: 'fabric'. Use 'src_fabric'
+#                         for dcnm_vpc_pair. Use null to omit fabric param.
+#   data_model_guard:     (optional) Dot-path into the data model. Step is
+#                         skipped if the path resolves to falsy/missing.
+#                         Accepts a string or list. List uses AND semantics
+#                         — all paths must be truthy for the step to run.
+#   change_flag_guard:    (optional) Change flag name from build_resource_data.
+#                         Step is skipped if this flag is False. Use null
+#                         for steps that should always run.
+#   delete_mode_guard:    (optional) User-configurable safety flag name.
+#                         Step is skipped unless this flag is truthy. Prevents
+#                         accidental resource removal.
+#   skip_if_child_fabric: (optional) Skip this step if the fabric is an active
+#                         MSD child. Prevents overlay removal on child fabrics
+#                         managed by a parent MSD.
+#   tag:                  (optional) Per-step tag for --tags filtering.
+#                         Accepts a string or list. List uses OR semantics
+#                         — step is included if ANY tag is active. Steps
+#                         with no tag always run when tag filtering is active.
+#
+# Top-level keys:
+#   role_tag:             Tag that bypasses per-step filtering (e.g.,
+#                         --tags role_remove runs the entire pipeline).
+#
+# Pipeline ordering is the REVERSE of creation to respect dependencies:
+#   edge_connections → policies → interfaces → networks → VRFs →
+#   links → vPC peers → switches
+# ══════════════════════════════════════════════════════════════════════════════
+---
+
+remove_resources:
+
+  role_tag: role_remove
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # VXLAN_EVPN — Full reverse pipeline
+  # ──────────────────────────────────────────────────────────────────────────
+  VXLAN_EVPN:
+    - resource_name: edge_connections
+      module: dcnm_links
+      state: deleted
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_edge_connections
+      delete_mode_guard: edge_connections_delete_mode
+      tag: rr_manage_edge_connections
+
+    - resource_name: policy
+      module: _unmanaged_policy
+      state: null
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_policy
+      delete_mode_guard: policy_delete_mode
+      tag: rr_manage_policy
+
+    - resource_name: interface_all
+      module: dcnm_interface
+      state: deleted
+      full_run_strategy: overridden
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_interfaces
+      delete_mode_guard: interface_delete_mode
+      tag: rr_manage_interfaces
+
+    - resource_name: networks
+      module: dcnm_network
+      state: deleted
+      full_run_strategy: controller_diff
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_networks
+      delete_mode_guard: network_delete_mode
+      skip_if_child_fabric: true
+      tag: rr_manage_networks
+
+    - resource_name: vrfs
+      module: dcnm_vrf
+      state: deleted
+      full_run_strategy: controller_diff
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_vrfs
+      delete_mode_guard: vrf_delete_mode
+      skip_if_child_fabric: true
+      tag: rr_manage_vrfs
+
+    - resource_name: fabric_links
+      module: _fabric_links_query_and_remove
+      state: null
+      data_model_guard:
+        - vxlan.topology.switches
+      change_flag_guard: changes_detected_fabric_links
+      delete_mode_guard: link_fabric_delete_mode
+      tag: rr_manage_links
+
+    - resource_name: fabric_links
+      module: dcnm_links
+      state: deleted
+      fabric_param: src_fabric
+      deploy: false
+      data_model_guard:
+        - vxlan.topology.switches
+      change_flag_guard: changes_detected_fabric_links
+      delete_mode_guard: link_fabric_delete_mode
+      tag: rr_manage_links
+
+    # vPC peers — uses dcnm_vpc_pair with src_fabric (not dcnm_links with fabric)
+    - resource_name: vpc_peering
+      module: dcnm_vpc_pair
+      state: deleted
+      state_full_run: overridden
+      change_flag_guard: changes_detected_vpc_peering
+      delete_mode_guard: vpc_delete_mode
+      fabric_param: src_fabric
+      tag: rr_manage_vpc_peers
+
+    # ToR pairing — uses process_tor_pairing plugin (shared internal method)
+    - resource_name: tor_pairing
+      module: _tor_pairing
+      state: null
+      change_flag_guard: changes_detected_tor_pairing
+      delete_mode_guard: tor_pairing_delete_mode
+      tag: rr_manage_tor_pairing
+
+    # Switches always use overridden (no diff_run branching)
+    - resource_name: inventory_no_bootstrap
+      module: dcnm_inventory
+      state: overridden
+      data_key_full_run: module_data
+      change_flag_guard: changes_detected_inventory
+      delete_mode_guard: inventory_delete_mode
+      tag: rr_manage_switches
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # eBGP_VXLAN — No edge connections or links
+  # ──────────────────────────────────────────────────────────────────────────
+  eBGP_VXLAN:
+    - resource_name: policy
+      module: _unmanaged_policy
+      state: null
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_policy
+      delete_mode_guard: policy_delete_mode
+      tag: rr_manage_policy
+
+    - resource_name: interface_all
+      module: dcnm_interface
+      state: deleted
+      full_run_strategy: overridden
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_interfaces
+      delete_mode_guard: interface_delete_mode
+      tag: rr_manage_interfaces
+
+    - resource_name: networks
+      module: dcnm_network
+      state: deleted
+      full_run_strategy: controller_diff
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_networks
+      delete_mode_guard: network_delete_mode
+      skip_if_child_fabric: true
+      tag: rr_manage_networks
+
+    - resource_name: vrfs
+      module: dcnm_vrf
+      state: deleted
+      full_run_strategy: controller_diff
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_vrfs
+      delete_mode_guard: vrf_delete_mode
+      skip_if_child_fabric: true
+      tag: rr_manage_vrfs
+
+    # vPC peers — uses dcnm_vpc_pair with src_fabric (not dcnm_links with fabric)
+    - resource_name: vpc_peering
+      module: dcnm_vpc_pair
+      state: deleted
+      state_full_run: overridden
+      change_flag_guard: changes_detected_vpc_peering
+      delete_mode_guard: vpc_delete_mode
+      fabric_param: src_fabric
+      tag: rr_manage_vpc_peers
+
+    # ToR pairing — uses process_tor_pairing plugin (shared internal method)
+    - resource_name: tor_pairing
+      module: _tor_pairing
+      state: null
+      change_flag_guard: changes_detected_tor_pairing
+      delete_mode_guard: tor_pairing_delete_mode
+      tag: rr_manage_tor_pairing
+
+    # Switches always use overridden (no diff_run branching)
+    - resource_name: inventory_no_bootstrap
+      module: dcnm_inventory
+      state: overridden
+      data_key_full_run: module_data
+      change_flag_guard: changes_detected_inventory
+      delete_mode_guard: inventory_delete_mode
+      tag: rr_manage_switches
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # ISN — Edge connections + interfaces, no overlay or vPC
+  # ──────────────────────────────────────────────────────────────────────────
+  ISN:
+    - resource_name: edge_connections
+      module: dcnm_links
+      state: deleted
+      change_flag_guard: changes_detected_edge_connections
+      delete_mode_guard: edge_connections_delete_mode
+      tag: rr_manage_edge_connections
+
+    - resource_name: policy
+      module: _unmanaged_policy
+      state: null
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_policy
+      delete_mode_guard: policy_delete_mode
+      tag: rr_manage_policy
+
+    - resource_name: interface_all
+      module: dcnm_interface
+      state: deleted
+      state_full_run: overridden
+      data_key_full_run: data_remove_overridden
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_interfaces
+      delete_mode_guard: interface_delete_mode
+      tag: rr_manage_interfaces
+
+    - resource_name: inventory_no_bootstrap
+      module: dcnm_inventory
+      state: overridden
+      data_key_full_run: module_data
+      change_flag_guard: changes_detected_inventory
+      delete_mode_guard: inventory_delete_mode
+      tag: rr_manage_switches
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # External — Edge connections + interfaces + vPC, no overlay
+  # ──────────────────────────────────────────────────────────────────────────
+  External:
+    - resource_name: edge_connections
+      module: dcnm_links
+      state: deleted
+      change_flag_guard: changes_detected_edge_connections
+      delete_mode_guard: edge_connections_delete_mode
+      tag: rr_manage_edge_connections
+
+    - resource_name: policy
+      module: _unmanaged_policy
+      state: null
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_policy
+      delete_mode_guard: policy_delete_mode
+      tag: rr_manage_policy
+
+    - resource_name: interface_all
+      module: dcnm_interface
+      state: deleted
+      state_full_run: overridden
+      data_key_full_run: data_remove_overridden
+      data_model_guard: vxlan.topology.switches
+      change_flag_guard: changes_detected_interfaces
+      delete_mode_guard: interface_delete_mode
+      tag: rr_manage_interfaces
+
+    - resource_name: vpc_peering
+      module: dcnm_vpc_pair
+      state: deleted
+      state_full_run: overridden
+      change_flag_guard: changes_detected_vpc_peering
+      delete_mode_guard: vpc_delete_mode
+      fabric_param: src_fabric
+      tag: rr_manage_vpc_peers
+
+    - resource_name: inventory_no_bootstrap
+      module: dcnm_inventory
+      state: overridden
+      data_key_full_run: module_data
+      change_flag_guard: changes_detected_inventory
+      delete_mode_guard: inventory_delete_mode
+      tag: rr_manage_switches
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # MSD — Multisite parent: prepare → networks → VRFs → child fabrics
+  # ──────────────────────────────────────────────────────────────────────────
+  MSD:
+    - resource_name: prepare_msite_data
+      module: _prepare_msite_data
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: null
+      tag:
+        - rr_manage_vrfs
+        - rr_manage_networks
+
+    - resource_name: msite_build_overlay
+      module: _msite_build_overlay
+      state: null
+      data_model_guard: vxlan.multisite.overlay
+      change_flag_guard: null
+      tag:
+        - rr_manage_vrfs
+        - rr_manage_networks
+
+    - resource_name: networks
+      module: dcnm_network
+      state: deleted
+      full_run_strategy: controller_diff
+      change_flag_guard: changes_detected_networks
+      delete_mode_guard: multisite_network_delete_mode
+      tag: rr_manage_networks
+
+    - resource_name: vrfs
+      module: dcnm_vrf
+      state: deleted
+      full_run_strategy: controller_diff
+      change_flag_guard: changes_detected_vrfs
+      delete_mode_guard: multisite_vrf_delete_mode
+      tag: rr_manage_vrfs
+
+    - resource_name: child_fabrics
+      module: _manage_child_fabrics
+      state: null
+      change_flag_guard: null
+      delete_mode_guard: multisite_child_fabric_delete_mode
+      tag: rr_manage_fabric
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # MCFG — Same structure as MSD
+  # ──────────────────────────────────────────────────────────────────────────
+  MCFG:
+    - resource_name: prepare_msite_data
+      module: _prepare_msite_data
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: null
+      tag:
+        - rr_manage_vrfs
+        - rr_manage_networks
+
+    - resource_name: msite_build_overlay
+      module: _msite_build_overlay
+      state: null
+      data_model_guard: vxlan.multisite.overlay
+      change_flag_guard: null
+      tag:
+        - rr_manage_vrfs
+        - rr_manage_networks
+
+    - resource_name: networks
+      module: dcnm_network
+      state: deleted
+      full_run_strategy: overridden
+      change_flag_guard: changes_detected_networks
+      delete_mode_guard: multisite_network_delete_mode
+      tag: rr_manage_networks
+
+    - resource_name: vrfs
+      module: dcnm_vrf
+      state: deleted
+      full_run_strategy: overridden
+      change_flag_guard: changes_detected_vrfs
+      delete_mode_guard: multisite_vrf_delete_mode
+      tag: rr_manage_vrfs
+
+    - resource_name: prepare_child_fabrics_data
+      module: _prepare_child_fabrics_data
+      state: null
+      data_model_guard: vxlan.multisite.child_fabrics
+      change_flag_guard: null
+      tag: rr_manage_fabric
+
+    - resource_name: child_fabrics
+      module: _manage_child_fabrics
+      state: null
+      change_flag_guard: null
+      delete_mode_guard: multisite_child_fabric_delete_mode
+      tag: rr_manage_fabric

--- a/resources/remove_resources.yml
+++ b/resources/remove_resources.yml
@@ -86,8 +86,8 @@ remove_resources:
   # ──────────────────────────────────────────────────────────────────────────
   VXLAN_EVPN:
     - resource_name: edge_connections
-      module: dcnm_links
-      state: deleted
+      module: _unmanaged_edge_connections
+      state: null
       data_model_guard: vxlan.topology.switches
       change_flag_guard: changes_detected_edge_connections
       delete_mode_guard: edge_connections_delete_mode
@@ -250,8 +250,8 @@ remove_resources:
   # ──────────────────────────────────────────────────────────────────────────
   ISN:
     - resource_name: edge_connections
-      module: dcnm_links
-      state: deleted
+      module: _unmanaged_edge_connections
+      state: null
       change_flag_guard: changes_detected_edge_connections
       delete_mode_guard: edge_connections_delete_mode
       tag: rr_manage_edge_connections
@@ -287,8 +287,8 @@ remove_resources:
   # ──────────────────────────────────────────────────────────────────────────
   External:
     - resource_name: edge_connections
-      module: dcnm_links
-      state: deleted
+      module: _unmanaged_edge_connections
+      state: null
       change_flag_guard: changes_detected_edge_connections
       delete_mode_guard: edge_connections_delete_mode
       tag: rr_manage_edge_connections

--- a/resources/resource_types.yml
+++ b/resources/resource_types.yml
@@ -1,0 +1,399 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Resource Types — Template→Render→Diff→Flag pipeline config
+#
+# Consumed by: build_resource_data.py
+#
+# Each entry defines the full pipeline for one NDFC resource type:
+#   - template:       Jinja2 template file to render (relative to role templates dir)
+#   - output_file:    Rendered output filename
+#   - var_name:       Variable name for the rendered data (defaults to resource key)
+#   - change_flag:    Flag to set on change (null = no flag)
+#   - diff_compare:   Whether structural diff is needed for targeted create/remove
+#   - fabric_types:   Which fabric types this resource applies to
+#   - pre_hooks:      (optional) Hooks before rendering
+#   - post_hooks:     (optional) Hooks after rendering. If a hook returns
+#                       'module_data' in its result, that becomes the
+#                       authoritative data for downstream NDFC modules
+#   - template_overrides: (optional) Per-fabric-type template substitution
+#                           (e.g. vpc_peering uses a different template for External)
+# ══════════════════════════════════════════════════════════════════════════════
+---
+
+resource_types:
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Fabric & Inventory
+  # ────────────────────────────────────────────────────────────────────────────
+
+  fabric:
+    template: ndfc_fabric.j2
+    output_file: ndfc_fabric.yml
+    var_name: fabric_config
+    change_flag: changes_detected_fabric
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - MSD
+      - MCFG
+      - External
+
+  child_fabrics:
+    template: null
+    output_file: null
+    change_flag: null
+    diff_compare: false
+    fabric_types:
+      - MSD
+
+  inventory:
+    template: ndfc_inventory.j2
+    output_file: ndfc_inventory.yml
+    var_name: inv_config
+    change_flag: changes_detected_inventory
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+    pre_hooks:
+      - get_poap_data
+    post_hooks:
+      - get_credentials
+
+  inventory_no_bootstrap:
+    template: ndfc_inventory_no_bootstrap.j2
+    output_file: ndfc_inventory_no_bootstrap.yml
+    var_name: updated_inv_config_no_bootstrap
+    change_flag: changes_detected_inventory
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+    post_hooks:
+      - get_credentials
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # VPC
+  # ────────────────────────────────────────────────────────────────────────────
+
+  vpc_domain_id_resource:
+    template: ndfc_vpc/ndfc_vpc_domain_id_resource.j2
+    output_file: ndfc_vpc_domain_id_resource.yml
+    change_flag: changes_detected_vpc_domain_id_resource
+    diff_compare: true
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+
+  vpc_fabric_peering_links:
+    template: ndfc_vpc/ndfc_vpc_fabric_peering_links.j2
+    output_file: ndfc_link_vpc_peering.yml
+    var_name: link_vpc_peering
+    change_flag: changes_detected_vpc_peering
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+
+  vpc_peering:
+    template: ndfc_vpc/ndfc_vpc_peering_pairs.j2
+    output_file: ndfc_vpc_peering.yml
+    change_flag: changes_detected_vpc_peering
+    diff_compare: true
+    template_overrides:
+      External: ndfc_vpc/ndfc_vpc_peering_pairs_external.j2
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - External
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # ToR Pairing
+  # ────────────────────────────────────────────────────────────────────────────
+
+  tor_pairing:
+    template: ndfc_tor_pairing.j2
+    output_file: ndfc_tor_pairing.yml
+    change_flag: changes_detected_tor_pairing
+    diff_compare: true
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Overlay
+  # ────────────────────────────────────────────────────────────────────────────
+
+  vrfs:
+    template: ndfc_attach_vrfs.j2
+    output_file: ndfc_attach_vrfs.yml
+    var_name: vrf_config
+    change_flag: changes_detected_vrfs
+    diff_compare: true
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+
+  vrf_loopback_attach:
+    template: ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_attach_vrfs_loopbacks.j2
+    output_file: attach_vrfs_loopbacks.yml
+    var_name: vrf_attach_config
+    change_flag: null
+    diff_compare: false
+    template_overrides:
+      MSD: ndfc_vrfs/msd_fabric/msd_fabric_attach_vrfs_loopbacks.j2
+      MCFG: ndfc_vrfs/mcfg_fabric/mcfg_fabric_attach_vrfs_loopbacks.j2
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+
+  networks:
+    template: ndfc_attach_networks.j2
+    output_file: ndfc_attach_networks.yml
+    var_name: net_config
+    change_flag: changes_detected_networks
+    diff_compare: true
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Interfaces (12 types)
+  # ────────────────────────────────────────────────────────────────────────────
+
+  interface_breakout:
+    template: ndfc_interfaces/ndfc_interface_breakout.j2
+    output_file: ndfc_interface_breakout.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_breakout_preprov:
+    template: ndfc_interfaces/ndfc_interface_breakout_preprov.j2
+    output_file: ndfc_interface_breakout_preprov.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_trunk:
+    template: ndfc_interfaces/ndfc_interface_trunk.j2
+    output_file: ndfc_interface_trunk.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_routed:
+    template: ndfc_interfaces/ndfc_interface_routed.j2
+    output_file: ndfc_interface_routed.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  sub_interface_routed:
+    template: ndfc_interfaces/ndfc_sub_interface_routed.j2
+    output_file: ndfc_sub_interface_routed.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_access:
+    template: ndfc_interfaces/ndfc_interface_access.j2
+    output_file: ndfc_interface_access.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_trunk_po:
+    template: ndfc_interfaces/ndfc_interface_trunk_po.j2
+    output_file: ndfc_interface_trunk_po.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_access_po:
+    template: ndfc_interfaces/ndfc_interface_access_po.j2
+    output_file: ndfc_interface_access_po.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_po_routed:
+    template: ndfc_interfaces/ndfc_interface_po_routed.j2
+    output_file: ndfc_interface_po_routed.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_loopback:
+    template: ndfc_interfaces/ndfc_loopback_interfaces.j2
+    output_file: ndfc_loopback_interfaces.yml
+    var_name: int_loopback_config
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_dot1q:
+    template: ndfc_interfaces/ndfc_interface_dot1q.j2
+    output_file: ndfc_interface_dot1q.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_vpc:
+    template: ndfc_interfaces/ndfc_interface_vpc.j2
+    output_file: ndfc_interface_vpc.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  interface_all:
+    template: null
+    output_file: ndfc_interface_all.yml
+    change_flag: changes_detected_interfaces
+    diff_compare: true
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Policies, Links, Edge Connections
+  # ────────────────────────────────────────────────────────────────────────────
+
+  policy:
+    template: ndfc_policy.j2
+    output_file: ndfc_policy.yml
+    var_name: policy_config
+    change_flag: changes_detected_policy
+    diff_compare: true
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN
+      - ISN
+      - External
+
+  fabric_links:
+    template: ndfc_fabric_links.j2
+    output_file: ndfc_fabric_links.yml
+    change_flag: changes_detected_fabric_links
+    diff_compare: true
+    fabric_types:
+      - VXLAN_EVPN
+
+  edge_connections:
+    template: ndfc_edge_connections.j2
+    output_file: ndfc_edge_connections.yml
+    change_flag: changes_detected_edge_connections
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - ISN
+      - External
+
+  underlay_ip_address:
+    template: ndfc_underlay_ip_address.j2
+    output_file: ndfc_underlay_ip_address.yml
+    change_flag: changes_detected_underlay_ip_address
+    diff_compare: true
+    fabric_types:
+      - VXLAN_EVPN
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # MSD-specific
+  # ────────────────────────────────────────────────────────────────────────────
+
+  bgw_anycast_vip:
+    template: ndfc_bgw_anycast_vip.j2
+    output_file: ndfc_bgw_anycast_vip.yml
+    change_flag: changes_detected_bgw_anycast_vip
+    diff_compare: false
+    fabric_types:
+      - MSD
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # Validation (must be last — runs after all resources are built)
+  # ────────────────────────────────────────────────────────────────────────────
+
+  check_msd_child:
+    template: null
+    output_file: null
+    change_flag: null
+    diff_compare: false
+    fabric_types:
+      - VXLAN_EVPN
+      - eBGP_VXLAN

--- a/roles/common_global/defaults/main.yml
+++ b/roles/common_global/defaults/main.yml
@@ -34,15 +34,16 @@ force_run_all: false
 stage_remove: false
 
 # Parameters to enable/disable remove role tasks
+edge_connections_delete_mode: false
 interface_delete_mode: false
 inventory_delete_mode: false
 link_fabric_delete_mode: false
 link_vpc_delete_mode: false
-edge_connections_delete_mode: false
 multisite_child_fabric_delete_mode: false
 multisite_network_delete_mode: false
 multisite_vrf_delete_mode: false
 network_delete_mode: false
 policy_delete_mode: false
+tor_pairing_delete_mode: false
 vpc_delete_mode: false
 vrf_delete_mode: false

--- a/roles/common_global/vars/main.yml
+++ b/roles/common_global/vars/main.yml
@@ -29,7 +29,8 @@ nac_tags:
     - cr_manage_switches
     - cr_manage_vpc_peers
     - cr_manage_interfaces
-    - cr_manage_vrfs_networks
+    - cr_manage_vrfs
+    - cr_manage_networks
     - cr_manage_policy
     - cr_manage_links
     - cr_manage_edge_connections
@@ -59,9 +60,12 @@ nac_tags:
     - cr_manage_switches
     - cr_manage_vpc_peers
     - cr_manage_interfaces
-    - cr_manage_vrfs_networks
+    - cr_manage_vrfs
+    - cr_manage_networks
     - cr_manage_policy
+    - cr_manage_links
     - cr_manage_edge_connections
+    - cr_manage_tor_pairing
     - rr_manage_edge_connections
     - rr_manage_interfaces
     - rr_manage_networks
@@ -81,7 +85,8 @@ nac_tags:
     - cr_manage_switches
     - cr_manage_vpc_peers
     - cr_manage_interfaces
-    - cr_manage_vrfs_networks
+    - cr_manage_vrfs
+    - cr_manage_networks
     - cr_manage_policy
     - cr_manage_links
     - cr_manage_edge_connections
@@ -106,7 +111,8 @@ nac_tags:
     - cr_manage_switches
     - cr_manage_vpc_peers
     - cr_manage_interfaces
-    - cr_manage_vrfs_networks
+    - cr_manage_vrfs
+    - cr_manage_networks
     - cr_manage_policy
     - cr_manage_links
     - cr_manage_edge_connections
@@ -122,11 +128,13 @@ nac_tags:
     - rr_manage_tor_pairing
   # All Create Tags
   create:
+    - role_create
     - cr_manage_fabric
     - cr_manage_switches
     - cr_manage_vpc_peers
     - cr_manage_interfaces
-    - cr_manage_vrfs_networks
+    - cr_manage_vrfs
+    - cr_manage_networks
     - cr_manage_policy
     - cr_manage_links
     - cr_manage_edge_connections
@@ -143,14 +151,17 @@ nac_tags:
     - cr_manage_vpc_peers
   create_interfaces:
     - cr_manage_interfaces
-  create_vrfs_networks:
-    - cr_manage_vrfs_networks
+  create_vrfs:
+    - cr_manage_vrfs
+  create_networks:
+    - cr_manage_networks
   create_policy:
     - cr_manage_policy
   create_links:
     - cr_manage_links
   # All Remove Tags
   remove:
+    - role_remove
     - rr_manage_interfaces
     - rr_manage_networks
     - rr_manage_vrfs

--- a/roles/dtc/common/tasks/main.yml
+++ b/roles/dtc/common/tasks/main.yml
@@ -19,73 +19,64 @@
 #
 # SPDX-License-Identifier: MIT
 
+# ─────────────────────────────────────────────────────────────────────────────
+# v2 Consolidated Common Role — Replaces per-fabric sub_main_*.yml files
+#
+# Uses the build_resource_data action plugin to execute the
+# Template→Render→Diff→Flag cycle for all resource types applicable to the
+# current fabric type.
+#
+# The plugin reads:
+#   - resources/resource_types.yml  — Template/output/diff config per resource,
+#                                     filtered by fabric_type
+#   - resources/fabric_types.yml    — Namespace and subdirectory mapping
+#
+# Outputs:
+#   - resource_data:  Dict of rendered data keyed by resource_name
+#                     (consumed by manage_resources / remove_resources)
+#   - change_flags:   Dict of change flag states
+#                     (consumed by downstream roles for skip logic)
+# ─────────────────────────────────────────────────────────────────────────────
+
 ---
 
 - name: Create Fact To Store Common Role Path
   ansible.builtin.set_fact:
     common_role_path: "{{ role_path }}"
-  tags: "{{ nac_tags.common_role }}" # Tags defined in roles/common_global/vars/main.yml
+  tags: "{{ nac_tags.common_role }}"
 
-- name: Initialize Change Flags
-  cisco.nac_dc_vxlan.common.change_flag_manager:
+- name: Build Resources
+  cisco.nac_dc_vxlan.dtc.build_resource_data:
     fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
     fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
+    data_model: "{{ data_model_extended }}"
     role_path: "{{ common_role_path }}"
-    operation: initialize
+    run_map_diff_run: "{{ run_map_read_result.diff_run }}"
+    force_run_all: "{{ force_run_all | default(false) }}"
+    check_roles: "{{ check_roles }}"
+  register: build_result
   tags: "{{ nac_tags.common_role }}"
-  delegate_to: localhost
 
-- name: Import Role Tasks for iBGP VXLAN Fabric
-  ansible.builtin.import_tasks: sub_main_vxlan.yml
+- name: Display Resource Build Summary
+  ansible.builtin.debug:
+    msg: "{{ build_result.msg | default('No build result') }}"
+    verbosity: 1
   tags: "{{ nac_tags.common_role }}"
-  when: data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN'
 
-- name: Import Role Tasks for eBGP VXLAN Fabric
-  ansible.builtin.import_tasks: sub_main_ebgp_vxlan.yml
+- name: Store Resource Data For Use In Subsequent Roles
+  ansible.builtin.set_fact:
+    resource_data: "{{ build_result.resource_data }}"
   tags: "{{ nac_tags.common_role }}"
-  when: data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN'
-
-- name: Import Role Tasks for ISN Fabric
-  ansible.builtin.import_tasks: sub_main_isn.yml
-  tags: "{{ nac_tags.common_role }}"
-  when: data_model_extended.vxlan.fabric.type == 'ISN'
-
-- name: Import Role Tasks for MSD Fabric
-  ansible.builtin.import_tasks: sub_main_msd.yml
-  tags: "{{ nac_tags.common_role }}"
-  when: data_model_extended.vxlan.fabric.type == 'MSD'
-
-- name: Import Role Tasks for MCFG Fabric
-  ansible.builtin.import_tasks: sub_main_mcfg.yml
-  tags: "{{ nac_tags.common_role }}" # Tags defined in roles/common_global/vars/main.yml
-  when: data_model_extended.vxlan.fabric.type == 'MCFG'
-
-- name: Import Role Tasks for External Fabric
-  ansible.builtin.import_tasks: sub_main_external.yml
-  tags: "{{ nac_tags.common_role }}"
-  when: data_model_extended.vxlan.fabric.type == 'External'
-
-- name: Retrieve Flag Values
-  cisco.nac_dc_vxlan.common.change_flag_manager:
-    fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
-    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
-    role_path: "{{ common_role_path }}"
-    operation: get
-  tags: "{{ nac_tags.common_role }}"
-  register: change_flag_result
   delegate_to: localhost
 
 - name: Store Change Flags For Use In Subsequent Roles
   ansible.builtin.set_fact:
-    change_flags: "{{ change_flag_result['flags'] }}"
+    change_flags: "{{ build_result.change_flags }}"
   tags: "{{ nac_tags.common_role }}"
   delegate_to: localhost
 
-- name: Display Flag Values
-  cisco.nac_dc_vxlan.common.change_flag_manager:
-    fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
-    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
-    role_path: "{{ common_role_path }}"
-    operation: display
+- name: Display Change Flag Values
+  ansible.builtin.debug:
+    msg: "Change flags: {{ change_flags }}"
+    verbosity: 1
   tags: "{{ nac_tags.common_role }}"
-  delegate_to: localhost

--- a/roles/dtc/common/tasks/main_old.yml
+++ b/roles/dtc/common/tasks/main_old.yml
@@ -1,0 +1,91 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+
+- name: Create Fact To Store Common Role Path
+  ansible.builtin.set_fact:
+    common_role_path: "{{ role_path }}"
+  tags: "{{ nac_tags.common_role }}" # Tags defined in roles/common_global/vars/main.yml
+
+- name: Initialize Change Flags
+  cisco.nac_dc_vxlan.common.change_flag_manager:
+    fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
+    role_path: "{{ common_role_path }}"
+    operation: initialize
+  tags: "{{ nac_tags.common_role }}"
+  delegate_to: localhost
+
+- name: Import Role Tasks for iBGP VXLAN Fabric
+  ansible.builtin.import_tasks: sub_main_vxlan.yml
+  tags: "{{ nac_tags.common_role }}"
+  when: data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN'
+
+- name: Import Role Tasks for eBGP VXLAN Fabric
+  ansible.builtin.import_tasks: sub_main_ebgp_vxlan.yml
+  tags: "{{ nac_tags.common_role }}"
+  when: data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN'
+
+- name: Import Role Tasks for ISN Fabric
+  ansible.builtin.import_tasks: sub_main_isn.yml
+  tags: "{{ nac_tags.common_role }}"
+  when: data_model_extended.vxlan.fabric.type == 'ISN'
+
+- name: Import Role Tasks for MSD Fabric
+  ansible.builtin.import_tasks: sub_main_msd.yml
+  tags: "{{ nac_tags.common_role }}"
+  when: data_model_extended.vxlan.fabric.type == 'MSD'
+
+- name: Import Role Tasks for MCFG Fabric
+  ansible.builtin.import_tasks: sub_main_mcfg.yml
+  tags: "{{ nac_tags.common_role }}" # Tags defined in roles/common_global/vars/main.yml
+  when: data_model_extended.vxlan.fabric.type == 'MCFG'
+
+- name: Import Role Tasks for External Fabric
+  ansible.builtin.import_tasks: sub_main_external.yml
+  tags: "{{ nac_tags.common_role }}"
+  when: data_model_extended.vxlan.fabric.type == 'External'
+
+- name: Retrieve Flag Values
+  cisco.nac_dc_vxlan.common.change_flag_manager:
+    fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
+    role_path: "{{ common_role_path }}"
+    operation: get
+  tags: "{{ nac_tags.common_role }}"
+  register: change_flag_result
+  delegate_to: localhost
+
+- name: Store Change Flags For Use In Subsequent Roles
+  ansible.builtin.set_fact:
+    change_flags: "{{ change_flag_result['flags'] }}"
+  tags: "{{ nac_tags.common_role }}"
+  delegate_to: localhost
+
+- name: Display Flag Values
+  cisco.nac_dc_vxlan.common.change_flag_manager:
+    fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
+    role_path: "{{ common_role_path }}"
+    operation: display
+  tags: "{{ nac_tags.common_role }}"
+  delegate_to: localhost

--- a/roles/dtc/common/templates/ndfc_bgw_anycast_vip.j2
+++ b/roles/dtc/common/templates/ndfc_bgw_anycast_vip.j2
@@ -2,10 +2,10 @@
 # DO NOT EDIT MANUALLY
 #
 
-{% set anycast_lo_id = vxlan.multisite.vtep_loopback_id | default(defaults.vxlan.multisite.vtep_loopback_id) %}
+{% set anycast_lo_id = data_model_extended.vxlan.multisite.vtep_loopback_id | default(defaults.vxlan.multisite.vtep_loopback_id) %}
 
-{% if vxlan.multisite.child_fabrics is defined and vxlan.multisite.child_fabrics is iterable %}
-{% for fabric in vxlan.multisite.child_fabrics %}
+{% if data_model_extended.vxlan.multisite.child_fabrics is defined and data_model_extended.vxlan.multisite.child_fabrics is iterable %}
+{% for fabric in data_model_extended.vxlan.multisite.child_fabrics %}
 {% if fabric.bgw_anycast_vip_ipv4 is defined %}
 - entity_name: "{{ fabric.name }}"
   pool_type: IP

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/advanced/dc_vxlan_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/advanced/dc_vxlan_fabric_advanced.j2
@@ -1,6 +1,6 @@
 {# Auto-generated NDFC DC VXLAN EVPN Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
   OVERLAY_MODE: {{ vxlan.global.ibgp.overlay_mode | default(defaults.vxlan.global.ibgp.overlay_mode) }}
-  GRFIELD_DEBUG_FLAG: Enable
+  GRFIELD_DEBUG_FLAG: {{ vxlan.global.ibgp.greenfield_cleanup | default(defaults.vxlan.global.ibgp.greenfield_cleanup) }}
   ENABLE_PVLAN: false
   AAA_REMOTE_IP_ENABLED: False
 {% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.2.2', '>=') and ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '<') %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
@@ -65,7 +65,15 @@
 {% endif %}
 {% endif %}
 {% endif %}
+{% if vxlan.global.ibgp.spine_ibgp_peer_template_freeform | default("") | trim %}
   IBGP_PEER_TEMPLATE: |2
-    {{ vxlan.global.ibgp.spine_ibgp_peer_template_freeform | default("") | indent(4, false) }}
+{{ vxlan.global.ibgp.spine_ibgp_peer_template_freeform | cisco.nac_dc_vxlan.dedent | indent(6, true) }}
+{% else %}
+  IBGP_PEER_TEMPLATE: ""
+{% endif %}
+{% if vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | default("") | trim %}
   IBGP_PEER_TEMPLATE_LEAF: |2
-    {{ vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | default("") | indent(4, false) }}
+{{ vxlan.global.ibgp.leaf_ibgp_peer_template_freeform | cisco.nac_dc_vxlan.dedent | indent(6, true) }}
+{% else %}
+  IBGP_PEER_TEMPLATE_LEAF: ""
+{% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
@@ -1,7 +1,8 @@
 {# Auto-generated NDFC DC VXLAN EVPN Security config data structure for fabric {{ vxlan.fabric.name }} #}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
-  ENABLE_SGT: false
-{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=') %}
+{% set enable_sgt = false %}
+  ENABLE_SGT: {{ enable_sgt | lower }}
+{% if enable_sgt and (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=')) %}
   securityGroupTagMacSegmentation: false
   securityGroupTagMacSegmentation_PREV: false
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
@@ -1,4 +1,8 @@
 {# Auto-generated NDFC DC VXLAN EVPN Security config data structure for fabric {{ vxlan.fabric.name }} #}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   ENABLE_SGT: false
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('4.2.1', '>=') %}
+  securityGroupTagMacSegmentation: false
+  securityGroupTagMacSegmentation_PREV: false
+{% endif %}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
@@ -1,7 +1,7 @@
 {# Auto-generated NDFC DC VXLAN EVPN Security config data structure for fabric {{ vxlan.fabric.name }} #}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   ENABLE_SGT: false
-{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('4.2.1', '>=') %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=') %}
   securityGroupTagMacSegmentation: false
   securityGroupTagMacSegmentation_PREV: false
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/advanced/ebgp_vxlan_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/advanced/ebgp_vxlan_fabric_advanced.j2
@@ -1,5 +1,5 @@
 {# Auto-generated NDFC eBGP VXLAN EVPN Advanced config data structure for fabric {{ vxlan.fabric.name }} #}
-  GRFIELD_DEBUG_FLAG: Enable
+  GRFIELD_DEBUG_FLAG: {{ vxlan.global.ebgp.greenfield_cleanup | default(defaults.vxlan.global.ebgp.greenfield_cleanup) }}
   ENABLE_PVLAN: false
   AAA_REMOTE_IP_ENABLED: False
   FABRIC_MTU: {{ vxlan.underlay.general.intra_fabric_interface_mtu | default(defaults.vxlan.underlay.general.intra_fabric_interface_mtu) }}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
@@ -4,6 +4,9 @@
   BGP_AS_MODE: "{{ vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) }}"
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Multi-AS' %}
   ALLOW_LEAF_SAME_AS: "{{ vxlan.global.ebgp.leaf_same_bgp_asn | default(defaults.vxlan.global.ebgp.leaf_same_bgp_asn) | lower }}"
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=') %}
+  bgpAsnAutoAllocation: "{{ vxlan.global.ebgp.bgp_asn_auto_allocation | default(defaults.vxlan.global.ebgp.bgp_asn_auto_allocation) | lower }}"
+{% endif %}
 {% endif %}
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Same-Tier-AS' %}
   LEAF_BGP_AS: "{{ vxlan.global.ebgp.leaf_bgp_asn | default(omit) }}"

--- a/roles/dtc/common/templates/ndfc_fabric_links.j2
+++ b/roles/dtc/common/templates/ndfc_fabric_links.j2
@@ -34,6 +34,10 @@
       mtu: "{{ link.mtu | default(defaults.vxlan.topology.fabric_links.mtu) }}"
       peer1_description: "{{ link.source_description | default('') }}"
       peer2_description: "{{ link.destination_description | default('') }}"
+{% if link.ipv4 is defined %}
+      peer1_ipv4_addr: "{{ link.ipv4.source_ipv4 }}"
+      peer2_ipv4_addr: "{{ link.ipv4.dest_ipv4 }}"
+{% endif %}
 {% if link.peer1_freeform is defined %}
       peer1_cmds: |2
         {{ link.peer1_freeform | indent(8) }}

--- a/roles/dtc/common/templates/ndfc_policy.j2
+++ b/roles/dtc/common/templates/ndfc_policy.j2
@@ -2,7 +2,10 @@
 # This NDFC policy and switch attachments config data structure is auto-generated
 # DO NOT EDIT MANUALLY
 #
-{% if data_model_extended.vxlan.policy.policies | default([]) | length > 0 %}
+{% if
+  data_model_extended.vxlan.policy.policies | default([]) | length > 0
+  and data_model_extended.vxlan.policy.switches | default([]) | length > 0
+%}
 - switch:
 {% for switch in data_model_extended.vxlan.policy.switches %}
     - ip: {{ switch.mgmt_ip_address }}

--- a/roles/dtc/common/templates/ndfc_underlay_ip_address.j2
+++ b/roles/dtc/common/templates/ndfc_underlay_ip_address.j2
@@ -2,12 +2,12 @@
 # This NDFC policy and switch attachments config data structure is auto-generated
 # DO NOT EDIT MANUALLY
 #
-{% if vxlan.underlay.general.manual_underlay_allocation is true %}
-{% set routing_lo_id = vxlan.underlay.general.underlay_routing_loopback_id %}
-{% set vtep_lo_id = vxlan.underlay.general.underlay_vtep_loopback_id %}
+{% if data_model_extended.vxlan.underlay.general.manual_underlay_allocation is true %}
+{% set routing_lo_id = data_model_extended.vxlan.underlay.general.underlay_routing_loopback_id %}
+{% set vtep_lo_id = data_model_extended.vxlan.underlay.general.underlay_vtep_loopback_id %}
 {%- set switch_secondary_ip = {} -%}
 {%- set switch_list = {} %}
-{%- for switch in vxlan.topology.switches %}
+{%- for switch in data_model_extended.vxlan.topology.switches %}
 {%- set _ = switch_list.update({
   switch.name: {
   'management_ipv4_address': switch.management.management_ipv4_address,
@@ -17,7 +17,7 @@
 }) %}
 {%- endfor %}
 {% macro generate_loopback_config(loopback_id) %}
-{%- for switch in vxlan.topology.switches %}
+{%- for switch in data_model_extended.vxlan.topology.switches %}
 {%- set ns = namespace(ipv4="") %}
 {%- for interface in switch.interfaces %}
 {%- if interface.name.lower() == "loopback" ~ loopback_id or interface.name.lower() == "lo" ~ loopback_id %}
@@ -32,7 +32,7 @@
   resource: "{{ ns.ipv4 }}"
   switch:
     - "{{ switch_list[switch.name].management_ipv4_address }}"
-{% endif %} 
+{% endif %}
 {% endfor %}
 {% endmacro %}
 {# resource for routing loopback #}
@@ -40,8 +40,8 @@
 {# resource for vtep loopback #}
 {{ generate_loopback_config(vtep_lo_id) }}
 {# resource for leaf in vPC #}
-{% if vxlan.topology.vpc_peers is defined %}
-{% for peer in vxlan.topology.vpc_peers %}
+{% if data_model_extended.vxlan.topology.vpc_peers is defined %}
+{% for peer in data_model_extended.vxlan.topology.vpc_peers %}
 - entity_name: "{{ switch_list[peer.peer1].serial_number }}~{{ switch_list[peer.peer2].serial_number }}~loopback{{ vtep_lo_id }}"
   pool_type: IP
   pool_name: "LOOPBACK{{ vtep_lo_id }}_IP_POOL"
@@ -54,8 +54,8 @@
 {# build p2p links - Check if ipv4 or ipv6 is present to distinct with fabric_link with template #}
 {# build subnet #}
 
-{% if vxlan.topology.fabric_links is defined %}
-{% for switch in vxlan.topology.fabric_links %}
+{% if data_model_extended.vxlan.topology.fabric_links is defined %}
+{% for switch in data_model_extended.vxlan.topology.fabric_links %}
 {% if switch.ipv4 is defined and switch.ipv4 is iterable %}
 - entity_name: "{{ switch_list[switch.source_device].serial_number }}~{{ switch.source_interface }}~{{ switch_list[switch.dest_device].serial_number }}~{{ switch.dest_interface }}"
   pool_type: SUBNET
@@ -86,5 +86,14 @@
 {% endif %}
 {% endfor %}
 
+{% endif %}
+{# resource for anycast RP (multicast replication only) #}
+{% set replication_mode = data_model_extended.vxlan.underlay.general.replication_mode | default(defaults.vxlan.underlay.general.replication_mode) %}
+{% if replication_mode == "multicast" and data_model_extended.vxlan.underlay.multicast.ipv4.anycast_rp is defined %}
+- entity_name: "ANYCAST_RP"
+  pool_type: IP
+  pool_name: "ANYCAST_RP_IP_POOL"
+  scope_type: fabric
+  resource: "{{ data_model_extended.vxlan.underlay.multicast.ipv4.anycast_rp }}"
 {% endif %}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_domain_id_resource.j2
+++ b/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_domain_id_resource.j2
@@ -2,12 +2,12 @@
 # This NDFC config data that updates links for vPC Fabric Peering is auto-generated
 # DO NOT EDIT MANUALLY
 #
-{% if vxlan.topology.vpc_peers is defined %}
+{% if data_model_extended.vxlan.topology.vpc_peers is defined %}
 {%- set switch_list = {} -%}
-{%- for switch in vxlan.topology.switches %}
+{%- for switch in data_model_extended.vxlan.topology.switches %}
 {% set _ = switch_list.update({switch.name : switch.serial_number}) %}
 {% endfor -%}
-{% for vpc in vxlan.topology.vpc_peers %}
+{% for vpc in data_model_extended.vxlan.topology.vpc_peers %}
 {% if vpc.domain_id is defined %}
 - entity_name: "{{ switch_list[vpc.peer1] }}~{{ switch_list[vpc.peer2] }}"
   pool_type: "ID"
@@ -16,4 +16,4 @@
   resource: "{{ vpc.domain_id }}"
 {% endif %}
 {% endfor %}
-{% endif %}
+{% endif %} 

--- a/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs.j2
+++ b/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs.j2
@@ -6,8 +6,6 @@
 {% for vpc_peers_pair in data_model_extended.vxlan.topology.vpc_peers %}
 - peerOneId: {{ vpc_peers_pair.peer1_mgmt_ip_address }}
   peerTwoId: {{ vpc_peers_pair.peer2_mgmt_ip_address }}
-{% if vpc_peers_pair.fabric_peering is defined %}
-  useVirtualPeerlink: {{ vpc_peers_pair.fabric_peering }}
-{% endif %}
+  useVirtualPeerlink: {{ vpc_peers_pair.fabric_peering | default(false) }}
 {% endfor %}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_attach_vrfs_loopbacks.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/dc_vxlan_fabric/dc_vxlan_fabric_attach_vrfs_loopbacks.j2
@@ -9,6 +9,7 @@
     "lanAttachList":
     [
 {% for attach in data_model_extended.vxlan.overlay.vrf_attach_groups_dict[vrf["vrf_attach_group"]] %}
+{% if attach['loopback_id'] is defined or attach['loopback_ipv4'] is defined or attach['loopback_ipv6'] is defined or attach['freeform_config'] is defined %}
       {
         "fabric": "{{ data_model_extended.vxlan.fabric.name }}",
         "vrfName": "{{ vrf["name"] }}",
@@ -32,6 +33,7 @@
       }{% if not loop.last %},{% endif %}
 {# Empty space needed to prettify and correctly represent the comma in a list continuation #}
 
+{% endif %}
 {% endfor %}
     ]
   }{% if not loop.last %},{% endif %}

--- a/roles/dtc/common/templates/ndfc_vrfs/mcfg_fabric/mcfg_fabric_attach_vrfs_loopbacks.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/mcfg_fabric/mcfg_fabric_attach_vrfs_loopbacks.j2
@@ -10,7 +10,7 @@
     "lanAttachList":
     [
 {% for attach in runtime_mcfg_data_model.overlay_attach_groups.vrf_attach_groups_dict[vrf['vrf_attach_group']] %}
-{% if attach.loopback_id is defined and attach.loopback_id %}
+{% if attach['loopback_id'] is defined or attach['loopback_ipv4'] is defined or attach['loopback_ipv6'] is defined or attach['freeform_config'] is defined %}
       {
         "vrfName": "{{ vrf["name"] }}",
 {% for switch in runtime_mcfg_data_model.switches %}
@@ -22,7 +22,7 @@
         "freeformConfig": "{{ attach['freeform_config'] | default('') | replace('\n', '\\n') | replace('"', '\\"') }}",
         "extensionValues": "",
 {% if vrf["vlan_id"] is defined  %}
-        "vlan": {{ vrf["vlan_id"] }},
+        "vlan": "{{ vrf["vlan_id"] }}",
 {% endif %}
         "deployment": true,
         "instanceValues": "{\"loopbackId\": \"{{ attach['loopback_id'] | default('')}}\", \"loopbackIpAddress\": \"{{ attach['loopback_ipv4'] | default('') }}\", \"loopbackIpV6Address\":\"{{ attach['loopback_ipv6'] | default('') }}\"}"

--- a/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_attach_vrfs_loopbacks.j2
+++ b/roles/dtc/common/templates/ndfc_vrfs/msd_fabric/msd_fabric_attach_vrfs_loopbacks.j2
@@ -10,7 +10,7 @@
     "lanAttachList":
     [
 {% for attach in runtime_msd_data_model.overlay_attach_groups.vrf_attach_groups_dict[vrf['vrf_attach_group']] %}
-{% if attach.loopback_id is defined and attach.loopback_id %}
+{% if attach['loopback_id'] is defined or attach['loopback_ipv4'] is defined or attach['loopback_ipv6'] is defined or attach['freeform_config'] is defined %}
       {
         "vrfName": "{{ vrf["name"] }}",
 {% for switch in runtime_msd_data_model.switches %}

--- a/roles/dtc/connectivity_check/tasks/controller_discovery.yml
+++ b/roles/dtc/connectivity_check/tasks/controller_discovery.yml
@@ -1,0 +1,129 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Recommendation #3: Centralized Controller State Discovery
+#
+# These tasks query NDFC controller state once and set facts consumed by the
+# create, remove, and common roles. This eliminates redundant API calls that
+# were previously scattered across:
+#   - remove/tasks/sub_main_{vxlan,ebgp_vxlan,isn,external}.yml (switchesByFabric)
+#   - common/tasks/sub_main_{vxlan,ebgp_vxlan}.yml (fabric-associations)
+#   - remove/tasks/common_vxlan/networks.yml (fabric-associations)
+#
+# Facts set:
+#   - fabric_switches:          List of switch dicts from NDFC inventory
+#   - fabric_has_switches:      Boolean — whether the fabric has registered switches
+#   - is_active_child_fabric:   Boolean — whether this fabric is a child of an MSD
+#   - fabric_exists:            Boolean — whether the fabric exists in NDFC
+# ─────────────────────────────────────────────────────────────────────────────
+
+---
+
+# ── Phase 2a: Query Fabric Switches ──────────────────────────────────────────
+
+- name: Query Fabric Switches from NDFC Inventory
+  cisco.dcnm.dcnm_rest:
+    method: GET
+    path: >-
+      /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{
+        data_model_extended.vxlan.fabric.name
+      }}/inventory/switchesByFabric
+  register: ndfc_fabric_switches_response
+  failed_when: false
+  tags: "{{ nac_tags.connectivity_check }}"
+
+- name: Set Fabric Switches Facts
+  ansible.builtin.set_fact:
+    fabric_switches: >-
+      {{
+        ndfc_fabric_switches_response.response.DATA
+        if (ndfc_fabric_switches_response.response.DATA is defined and
+            ndfc_fabric_switches_response.response.DATA is iterable and
+            ndfc_fabric_switches_response.response.DATA is not string)
+        else []
+      }}
+  tags: "{{ nac_tags.connectivity_check }}"
+
+- name: Set Fabric Has Switches Flag
+  ansible.builtin.set_fact:
+    fabric_has_switches: "{{ fabric_switches | length > 0 }}"
+  tags: "{{ nac_tags.connectivity_check }}"
+
+# ── Phase 2b: Query Multisite Fabric Associations ────────────────────────────
+
+- name: Query Multisite Fabric Associations from NDFC
+  cisco.dcnm.dcnm_rest:
+    method: GET
+    path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations
+  register: ndfc_msd_fabric_associations
+  failed_when: false
+  when: is_active_child_fabric is not defined
+  tags: "{{ nac_tags.connectivity_check }}"
+
+- name: Find Current Fabric in Multisite Associations
+  ansible.builtin.set_fact:
+    _selected_msd_fabric: >-
+      {{ ndfc_msd_fabric_associations['response']['DATA'] | json_query(json_query) }}
+  vars:
+    json_query: "[?fabricName=='{{ data_model_extended.vxlan.fabric.name }}']"
+  when:
+    - is_active_child_fabric is not defined
+    - ndfc_msd_fabric_associations is defined
+    - ndfc_msd_fabric_associations.response.DATA is defined
+  tags: "{{ nac_tags.connectivity_check }}"
+
+- name: Set Active Child Fabric Flag
+  ansible.builtin.set_fact:
+    is_active_child_fabric: >-
+      {{
+        true
+        if (_selected_msd_fabric is defined and
+            _selected_msd_fabric | length > 0 and
+            _selected_msd_fabric[0]['fabricParent'] != 'None')
+        else false
+      }}
+  when: is_active_child_fabric is not defined
+  tags: "{{ nac_tags.connectivity_check }}"
+
+# ── Phase 2c: Query Fabric Existence ─────────────────────────────────────────
+
+- name: Check Fabric Exists in NDFC
+  cisco.dcnm.dcnm_rest:
+    method: GET
+    path: >-
+      /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{{
+        data_model_extended.vxlan.fabric.name
+      }}
+  register: ndfc_fabric_info_response
+  failed_when: false
+  tags: "{{ nac_tags.connectivity_check }}"
+
+- name: Set Fabric Existence Fact
+  ansible.builtin.set_fact:
+    fabric_exists: >-
+      {{
+        true
+        if (ndfc_fabric_info_response.response.DATA is defined and
+            ndfc_fabric_info_response.response.DATA)
+        else false
+      }}
+  tags: "{{ nac_tags.connectivity_check }}"

--- a/roles/dtc/connectivity_check/tasks/main.yml
+++ b/roles/dtc/connectivity_check/tasks/main.yml
@@ -62,3 +62,11 @@
   ansible.builtin.set_fact:
     ndfc_version: "{{ ndfc_version.response.DATA.version }}"
   tags: "{{ nac_tags.connectivity_check }}" # Tags defined in roles/common_global/vars/main.yml
+
+# # ── Phase 2: Centralized Controller State Discovery (Recommendation #3) ──────
+# # Queries fabric switches, multisite associations, and fabric existence once.
+# # Sets facts consumed by common, create, and remove roles downstream.
+# - name: Centralized Controller State Discovery
+#   ansible.builtin.import_tasks: controller_discovery.yml
+#   tags: "{{ nac_tags.connectivity_check }}"
+#   when: data_model_extended is defined and data_model_extended.vxlan.fabric.name is defined

--- a/roles/dtc/create/tasks/main.yml
+++ b/roles/dtc/create/tasks/main.yml
@@ -19,43 +19,45 @@
 #
 # SPDX-License-Identifier: MIT
 
+# ─────────────────────────────────────────────────────────────────────────────
+# v2 Consolidated Create Role — Replaces per-fabric sub_main_*.yml files
+#
+# Uses the manage_resources action plugin with:
+#   - Recommendation #7: Explicit run_map_diff_run parameter passed from
+#     run_map_read_result.diff_run instead of relying on cleanup cascade
+#   - Recommendation #4: vPC peering handled via _vpc_peering_pipeline
+#     internal method (3-step sub-pipeline)
+#
+# The manage_resources plugin reads create_resources.yml to determine the
+# ordered pipeline for the given fabric type.
+# ─────────────────────────────────────────────────────────────────────────────
+
 ---
 
-- name: Import iBGP VXLAN Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_vxlan.yml
-  when:
-    - data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN'
-    - change_flags.changes_detected_any
+- name: Execute Create Resources
+  cisco.nac_dc_vxlan.dtc.manage_resources:
+    fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
+    data_model: "{{ data_model_extended }}"
+    resource_data: "{{ resource_data }}"
+    change_flags: "{{ change_flags }}"
+    nd_version: "{{ nd_version | default('') }}"
+    run_map_diff_run: "{{ run_map_read_result.diff_run }}"
+    force_run_all: "{{ force_run_all | default(false) }}"
+  register: create_result
+  when: change_flags.changes_detected_any
+  tags: "{{ nac_tags.create }}"
 
-- name: Import eBGP VXLAN Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_ebgp_vxlan.yml
-  when:
-    - data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN'
-    - change_flags.changes_detected_any
-
-- name: Import ISN Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_isn.yml
-  when:
-    - data_model_extended.vxlan.fabric.type == 'ISN'
-    - change_flags.changes_detected_any
-
-- name: Import MSD Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_msd.yml
-  when: data_model_extended.vxlan.fabric.type == 'MSD'
-
-- name: Import MCFG Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_mcfg.yml
-  when: data_model_extended.vxlan.fabric.type == 'MCFG'
-
-- name: Import External Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_external.yml
-  when:
-    - data_model_extended.vxlan.fabric.type == 'External'
-    - change_flags.changes_detected_any
+- name: Display Create Resources Summary
+  ansible.builtin.debug:
+    msg: "{{ create_result.msg | default('No changes required') }}"
+    verbosity: 1
+  tags: "{{ nac_tags.create }}"
 
 - name: Mark Stage Role Create Completed
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_create_completed
   register: run_map
   delegate_to: localhost
+  tags: "{{ nac_tags.create }}"

--- a/roles/dtc/create/tasks/main_old.yml
+++ b/roles/dtc/create/tasks/main_old.yml
@@ -1,0 +1,61 @@
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+
+- name: Import iBGP VXLAN Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_vxlan.yml
+  when:
+    - data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN'
+    - change_flags.changes_detected_any
+
+- name: Import eBGP VXLAN Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_ebgp_vxlan.yml
+  when:
+    - data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN'
+    - change_flags.changes_detected_any
+
+- name: Import ISN Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_isn.yml
+  when:
+    - data_model_extended.vxlan.fabric.type == 'ISN'
+    - change_flags.changes_detected_any
+
+- name: Import MSD Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_msd.yml
+  when: data_model_extended.vxlan.fabric.type == 'MSD'
+
+- name: Import MCFG Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_mcfg.yml
+  when: data_model_extended.vxlan.fabric.type == 'MCFG'
+
+- name: Import External Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_external.yml
+  when:
+    - data_model_extended.vxlan.fabric.type == 'External'
+    - change_flags.changes_detected_any
+
+- name: Mark Stage Role Create Completed
+  cisco.nac_dc_vxlan.common.run_map:
+    data_model: "{{ data_model_extended }}"
+    stage: role_create_completed
+  register: run_map
+  delegate_to: localhost

--- a/roles/dtc/deploy/tasks/main.yml
+++ b/roles/dtc/deploy/tasks/main.yml
@@ -1,4 +1,4 @@
- # Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -19,56 +19,40 @@
 #
 # SPDX-License-Identifier: MIT
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Consolidated Deploy Role — Replaces per-fabric sub_main_*.yml files
+#
+# The fabric_deploy_manager plugin handles all fabric-type-specific logic
+# internally based on the fabric_type parameter. Multisite parameters
+# (child_fabrics, VRF/Network response data) are resolved from task_vars
+# by the plugin rather than being passed explicitly per fabric type.
+#
+# Original per-fabric files preserved as main_old.yml and sub_main_*.yml.
+# ─────────────────────────────────────────────────────────────────────────────
+
 ---
 
-- name: Import iBGP VXLAN EVPN Role Tasks
-  ansible.builtin.import_tasks: sub_main_vxlan.yml
-  tags: "{{ nac_tags.deploy }}" # Tags defined in roles/common_global/vars/main.yml
-  when:
-    - data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN'
-    - change_flags.changes_detected_any
-
-- name: Import eBGP Role Tasks
-  ansible.builtin.import_tasks: sub_main_ebgp_vxlan.yml
+- name: Execute Deploy of Resources
+  cisco.nac_dc_vxlan.dtc.fabric_deploy_manager:
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
+    fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
+    data_model: "{{ data_model_extended }}"
+    nd_version: "{{ nd_version | default('') }}"
+    run_map_diff_run: "{{ run_map_read_result.diff_run }}"
+    force_run_all: "{{ force_run_all | default(false) }}"
+    operation: all
+  # vars:
+  #   ansible_command_timeout: 3000
+  #   ansible_connect_timeout: 3000
+  when: change_flags.changes_detected_any or
+        (change_flags_msd.changes_detected_any is defined and change_flags_msd.changes_detected_any) or
+        (change_flags_mcfg.changes_detected_any is defined and change_flags_mcfg.changes_detected_any)
   tags: "{{ nac_tags.deploy }}"
-  when:
-    - data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN'
-    - change_flags.changes_detected_any
-
-- name: Import MSD Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_msd.yml
-  tags: "{{ nac_tags.deploy }}"
-  when:
-    - data_model_extended.vxlan.fabric.type == 'MSD'
-    - (change_flags.changes_detected_any) or
-      (change_flags_msd.changes_detected_any is defined and change_flags_msd.changes_detected_any)
-
-- name: Import MCFG Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_mcfg.yml
-  tags: "{{ nac_tags.deploy }}" # Tags defined in roles/common_global/vars/main.yml
-  when:
-    - data_model_extended.vxlan.fabric.type == 'MCFG'
-    - (change_flags.changes_detected_any) or
-      (change_flags_mcfg.changes_detected_any is defined and change_flags_mcfg.changes_detected_any)
-
-- name: Import ISN Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_isn.yml
-  tags: "{{ nac_tags.deploy }}"
-  when:
-    - data_model_extended.vxlan.fabric.type == 'ISN'
-    - change_flags.changes_detected_any
-
-- name: Import External Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_external.yml
-  tags: "{{ nac_tags.deploy }}"
-  when:
-    - data_model_extended.vxlan.fabric.type == 'External'
-    - change_flags.changes_detected_any
 
 - name: Mark Stage Role Deploy Completed
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_deploy_completed
   register: run_map
-  tags: "{{ nac_tags.deploy }}"
   delegate_to: localhost
+  tags: "{{ nac_tags.deploy }}"

--- a/roles/dtc/deploy/tasks/main_old.yml
+++ b/roles/dtc/deploy/tasks/main_old.yml
@@ -1,0 +1,74 @@
+ # Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+
+- name: Import iBGP VXLAN EVPN Role Tasks
+  ansible.builtin.import_tasks: sub_main_vxlan.yml
+  tags: "{{ nac_tags.deploy }}" # Tags defined in roles/common_global/vars/main.yml
+  when:
+    - data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN'
+    - change_flags.changes_detected_any
+
+- name: Import eBGP Role Tasks
+  ansible.builtin.import_tasks: sub_main_ebgp_vxlan.yml
+  tags: "{{ nac_tags.deploy }}"
+  when:
+    - data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN'
+    - change_flags.changes_detected_any
+
+- name: Import MSD Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_msd.yml
+  tags: "{{ nac_tags.deploy }}"
+  when:
+    - data_model_extended.vxlan.fabric.type == 'MSD'
+    - (change_flags.changes_detected_any) or
+      (change_flags_msd.changes_detected_any is defined and change_flags_msd.changes_detected_any)
+
+- name: Import MCFG Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_mcfg.yml
+  tags: "{{ nac_tags.deploy }}" # Tags defined in roles/common_global/vars/main.yml
+  when:
+    - data_model_extended.vxlan.fabric.type == 'MCFG'
+    - (change_flags.changes_detected_any) or
+      (change_flags_mcfg.changes_detected_any is defined and change_flags_mcfg.changes_detected_any)
+
+- name: Import ISN Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_isn.yml
+  tags: "{{ nac_tags.deploy }}"
+  when:
+    - data_model_extended.vxlan.fabric.type == 'ISN'
+    - change_flags.changes_detected_any
+
+- name: Import External Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_external.yml
+  tags: "{{ nac_tags.deploy }}"
+  when:
+    - data_model_extended.vxlan.fabric.type == 'External'
+    - change_flags.changes_detected_any
+
+- name: Mark Stage Role Deploy Completed
+  cisco.nac_dc_vxlan.common.run_map:
+    data_model: "{{ data_model_extended }}"
+    stage: role_deploy_completed
+  register: run_map
+  tags: "{{ nac_tags.deploy }}"
+  delegate_to: localhost

--- a/roles/dtc/remove/tasks/common/vpc_peers.yml
+++ b/roles/dtc/remove/tasks/common/vpc_peers.yml
@@ -86,6 +86,6 @@
   ansible.builtin.debug:
     msg:
       - "-------------------------------------------------------------------------------------------------------"
-      - "+ SKIPPING Remove Unmanaged vPC Peering task because vpc_peering_delete_mode flag is set to False     +"
+      - "+ SKIPPING Remove Unmanaged vPC Peering task because vpc_delete_mode flag is set to False     +"
       - "-------------------------------------------------------------------------------------------------------"
   when: not ((vpc_delete_mode is defined) and (vpc_delete_mode is true|bool))

--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+# Copyright (c) 2025 Cisco Systems, Inc. and its affiliates
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
@@ -19,57 +19,58 @@
 #
 # SPDX-License-Identifier: MIT
 
+# ─────────────────────────────────────────────────────────────────────────────
+# v2 Consolidated Remove Role — Replaces per-fabric sub_main_*.yml files
+#
+# Uses the remove_resources action plugin with:
+#   - Recommendation #2: delete_mode_guard safety flags passed from task_vars
+#     to prevent accidental resource removal. Each pipeline step declares a
+#     delete_mode_guard field; the plugin checks the corresponding variable.
+#   - Recommendation #4: vPC peers use dcnm_vpc_pair with src_fabric param
+#   - Centralized facts from connectivity_check (#3): fabric_switches,
+#     is_active_child_fabric
+#
+# Delete mode variables are read directly from task_vars by the plugin.
+# They must be defined in group_vars/host_vars or passed as extra-vars:
+#   - policy_delete_mode
+#   - interface_delete_mode
+#   - edge_connections_delete_mode
+#   - link_vpc_delete_mode
+#   - link_fabric_delete_mode
+#   - vpc_delete_mode
+#   - inventory_delete_mode
+#   - network_delete_mode
+#   - vrf_delete_mode
+#   - multisite_network_delete_mode
+#   - multisite_vrf_delete_mode
+#   - multisite_child_fabric_delete_mode
+# ─────────────────────────────────────────────────────────────────────────────
+
 ---
 
-- name: Import iBGP VXLAN Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_vxlan.yml
-  # Check with Matt on changes_detected_policy here
-  # Was not there previously
-  when:
-    - data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN'
-    - change_flags.changes_detected_any
+- name: Execute Remove Resources
+  cisco.nac_dc_vxlan.dtc.remove_resources:
+    fabric_type: "{{ data_model_extended.vxlan.fabric.type }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
+    data_model: "{{ data_model_extended }}"
+    resource_data: "{{ resource_data }}"
+    change_flags: "{{ change_flags }}"
+    run_map_diff_run: "{{ run_map_read_result.diff_run }}"
+    force_run_all: "{{ force_run_all | default(false) }}"
+  register: remove_result
+  when: change_flags.changes_detected_any
+  tags: "{{ nac_tags.remove }}"
 
-- name: Import eBGP Role Tasks
-  ansible.builtin.import_tasks: sub_main_ebgp_vxlan.yml
-  # Check with Matt on changes_detected_policy here
-  # Was not there previously
-  when:
-    - data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN'
-    - change_flags.changes_detected_any
+- name: Display Remove Resources Summary
+  ansible.builtin.debug:
+    msg: "{{ remove_result.msg | default('No changes required') }}"
+    verbosity: 1
+  tags: "{{ nac_tags.remove }}"
 
-- name: Import MSD Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_msd.yml
-  when:
-    data_model_extended.vxlan.fabric.type == 'MSD'
-  # Current implementation has to leverage the changes_detected flags
-  # in the sub_main files to determine if the tasks should be run
-
-- name: Import MCFG Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_mcfg.yml
-  when:
-    data_model_extended.vxlan.fabric.type == 'MCFG'
-  # Current implementation has to leverage the changes_detected flags
-  # in the sub_main files to determine if the tasks should be run
-
-- name: Import ISN Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_isn.yml
-  when:
-    - data_model_extended.vxlan.fabric.type == 'ISN'
-    - change_flags.changes_detected_any
-
-- name: Import External Fabric Role Tasks
-  ansible.builtin.import_tasks: sub_main_external.yml
-  when:
-    - data_model_extended.vxlan.fabric.type == 'External'
-    - change_flags.changes_detected_any
-
-# ------------------------------------------------------------------------------
-# If we are not staging removal then we need to deploy any changes
-# that were made during the role remove stage and are now pending deployment.
-#
-# We do NOT need to do this for MSD or MCFG fabrics as those fabric types
-# do not have any changes currently that can be staged for removal.
-# ------------------------------------------------------------------------------
+# ─────────────────────────────────────────────────────────────────────────────
+# Deploy after removal for non-staged, qualifying fabric types
+# MSD and MCFG do not have pending deployment changes from removal
+# ─────────────────────────────────────────────────────────────────────────────
 - name: Log Deploy During Remove Info Message
   ansible.builtin.debug:
     msg: >
@@ -77,25 +78,21 @@
       "{{ data_model_extended.vxlan.fabric.type }}".
   when: >
     (stage_remove is false|bool) and (change_flags.changes_detected_any) and
-    (data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN' or
-    data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN' or
-    data_model_extended.vxlan.fabric.type == 'ISN' or
-    data_model_extended.vxlan.fabric.type == 'External')
+    (data_model_extended.vxlan.fabric.type in ['VXLAN_EVPN', 'eBGP_VXLAN', 'ISN', 'External'])
+  tags: "{{ nac_tags.remove }}"
 
 - name: Deploy Remove Changes
   ansible.builtin.import_role:
     name: cisco.nac_dc_vxlan.dtc.deploy
   when: >
     (stage_remove is false|bool) and (change_flags.changes_detected_any) and
-    (data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN' or
-    data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN' or
-    data_model_extended.vxlan.fabric.type == 'ISN' or
-    data_model_extended.vxlan.fabric.type == 'External')
-# ------------------------------------------------------------------------------
+    (data_model_extended.vxlan.fabric.type in ['VXLAN_EVPN', 'eBGP_VXLAN', 'ISN', 'External'])
+  tags: "{{ nac_tags.remove }}"
 
 - name: Mark Stage Role Remove Completed
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_remove_completed
   register: run_map
   delegate_to: localhost
+  tags: "{{ nac_tags.remove }}"

--- a/roles/dtc/remove/tasks/main_old.yml
+++ b/roles/dtc/remove/tasks/main_old.yml
@@ -1,0 +1,101 @@
+# Copyright (c) 2024 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+---
+
+- name: Import iBGP VXLAN Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_vxlan.yml
+  # Check with Matt on changes_detected_policy here
+  # Was not there previously
+  when:
+    - data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN'
+    - change_flags.changes_detected_any
+
+- name: Import eBGP Role Tasks
+  ansible.builtin.import_tasks: sub_main_ebgp_vxlan.yml
+  # Check with Matt on changes_detected_policy here
+  # Was not there previously
+  when:
+    - data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN'
+    - change_flags.changes_detected_any
+
+- name: Import MSD Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_msd.yml
+  when:
+    data_model_extended.vxlan.fabric.type == 'MSD'
+  # Current implementation has to leverage the changes_detected flags
+  # in the sub_main files to determine if the tasks should be run
+
+- name: Import MCFG Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_mcfg.yml
+  when:
+    data_model_extended.vxlan.fabric.type == 'MCFG'
+  # Current implementation has to leverage the changes_detected flags
+  # in the sub_main files to determine if the tasks should be run
+
+- name: Import ISN Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_isn.yml
+  when:
+    - data_model_extended.vxlan.fabric.type == 'ISN'
+    - change_flags.changes_detected_any
+
+- name: Import External Fabric Role Tasks
+  ansible.builtin.import_tasks: sub_main_external.yml
+  when:
+    - data_model_extended.vxlan.fabric.type == 'External'
+    - change_flags.changes_detected_any
+
+# ------------------------------------------------------------------------------
+# If we are not staging removal then we need to deploy any changes
+# that were made during the role remove stage and are now pending deployment.
+#
+# We do NOT need to do this for MSD or MCFG fabrics as those fabric types
+# do not have any changes currently that can be staged for removal.
+# ------------------------------------------------------------------------------
+- name: Log Deploy During Remove Info Message
+  ansible.builtin.debug:
+    msg: >
+      Deploying changes during role remove since fabric type is
+      "{{ data_model_extended.vxlan.fabric.type }}".
+  when: >
+    (stage_remove is false|bool) and (change_flags.changes_detected_any) and
+    (data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN' or
+    data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN' or
+    data_model_extended.vxlan.fabric.type == 'ISN' or
+    data_model_extended.vxlan.fabric.type == 'External')
+
+- name: Deploy Remove Changes
+  ansible.builtin.import_role:
+    name: cisco.nac_dc_vxlan.dtc.deploy
+  when: >
+    (stage_remove is false|bool) and (change_flags.changes_detected_any) and
+    (data_model_extended.vxlan.fabric.type == 'VXLAN_EVPN' or
+    data_model_extended.vxlan.fabric.type == 'eBGP_VXLAN' or
+    data_model_extended.vxlan.fabric.type == 'ISN' or
+    data_model_extended.vxlan.fabric.type == 'External')
+# ------------------------------------------------------------------------------
+
+- name: Mark Stage Role Remove Completed
+  cisco.nac_dc_vxlan.common.run_map:
+    data_model: "{{ data_model_extended }}"
+    stage: role_remove_completed
+  register: run_map
+  delegate_to: localhost

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -26,6 +26,7 @@ factory_defaults:
       ebgp:
         bgp_asn_mode: Multi-AS
         leaf_same_bgp_asn: false
+        bgp_asn_auto_allocation: true
         anycast_gateway_mac: 20:20:00:00:00:aa
         auth_proto: MD5
         enable_nxapi_http: false

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -34,6 +34,7 @@ factory_defaults:
         enable_nxapi_https: true
         nxapi_https_port: 443
         overlay_mode: cli
+        greenfield_cleanup: Disable
         layer2_vni_range:
           from: 30000
           to: 49000
@@ -80,6 +81,7 @@ factory_defaults:
         enable_nxapi_https: true
         nxapi_https_port: 443
         overlay_mode: cli
+        greenfield_cleanup: Disable
         layer2_vni_range:
           from: 30000
           to: 49000

--- a/roles/validate/files/rules/common/204_global_bootstrap.py
+++ b/roles/validate/files/rules/common/204_global_bootstrap.py
@@ -6,6 +6,7 @@ class Rule:
     @classmethod
     def match(cls, data_model):
         results = []
+        switches = []
         dhcp = None
 
         # Map fabric types to the keys used in the data model based on controller fabric types
@@ -66,6 +67,41 @@ class Rule:
                 results.append(f"vxlan.global.bootstrap.{dhcp}.domain_name is not supported for bootstrap in a VXLAN type fabric.")
             elif 'domain_name' in check['keys_not_found'] and fabric_type == "external":
                 results.append(f"vxlan.global.bootstrap.{dhcp}.domain_name is required for bootstrap in an External type fabric.")
+
+        dm_check = cls.data_model_key_check(data_model, ['vxlan', 'topology', 'switches'])
+        if 'switches' in dm_check['keys_data']:
+            switches = data_model['vxlan']['topology']['switches']
+
+        # Check if any switch has a poap key defined
+        poap_switches = []
+        for switch in switches:
+            dm_check = cls.data_model_key_check(switch, ['poap'])
+            if 'poap' in dm_check['keys_data']:
+                poap_switches.append(switch['name'])
+
+        if not poap_switches:
+            return results
+
+        enable_bootstrap = None
+        bootstrap_enable_keys = ['vxlan', 'global', fabric_type, 'bootstrap', 'enable_bootstrap']
+        check = cls.data_model_key_check(data_model, bootstrap_enable_keys)
+        if 'enable_bootstrap' in check['keys_found']:
+            enable_bootstrap = cls.safeget(data_model, bootstrap_enable_keys)
+
+        # Fall back to the common path if not found under fabric-type-specific path
+        if enable_bootstrap is None:
+            bootstrap_enable_keys = ['vxlan', 'global', 'bootstrap', 'enable_bootstrap']
+            check = cls.data_model_key_check(data_model, bootstrap_enable_keys)
+            if 'enable_bootstrap' in check['keys_found']:
+                enable_bootstrap = cls.safeget(data_model, bootstrap_enable_keys)
+
+        if enable_bootstrap is not True:
+            for switch_name in poap_switches:
+                results.append(
+                    f"vxlan.topology.switches.{switch_name} has poap defined but "
+                    f"vxlan.global.bootstrap.enable_bootstrap is not set to true."
+                )
+
         return results
 
     @classmethod

--- a/roles/validate/files/rules/common/321_topology_edge_connections.py
+++ b/roles/validate/files/rules/common/321_topology_edge_connections.py
@@ -1,5 +1,5 @@
 class Rule:
-    id = "311"
+    id = "321"
     description = "Verify edge connections have valid source devices and interfaces"
     severity = "HIGH"
 

--- a/roles/validate/files/rules/isn/204_global_bootstrap.py
+++ b/roles/validate/files/rules/isn/204_global_bootstrap.py
@@ -6,6 +6,7 @@ class Rule:
     @classmethod
     def match(cls, data_model):
         results = []
+        switches = []
         dhcp = None
 
         bootstrap_keys = ['vxlan', 'multisite', 'isn', 'bootstrap', 'enable_bootstrap']
@@ -37,6 +38,33 @@ class Rule:
                 return results
             if 'domain_name' in check['keys_not_found']:
                 results.append(f"vxlan.multisite.isn.bootstrap.{dhcp}.domain_name is required for bootstrap in an ISN type fabric.")
+
+        dm_check = cls.data_model_key_check(data_model, ['vxlan', 'topology', 'switches'])
+        if 'switches' in dm_check['keys_data']:
+            switches = data_model['vxlan']['topology']['switches']
+
+        # Check if any switch has a poap key defined
+        poap_switches = []
+        for switch in switches:
+            dm_check = cls.data_model_key_check(switch, ['poap'])
+            if 'poap' in dm_check['keys_data']:
+                poap_switches.append(switch['name'])
+
+        if not poap_switches:
+            return results
+
+        enable_bootstrap = None
+        bootstrap_enable_keys = ['vxlan', 'multisite', 'isn', 'bootstrap', 'enable_bootstrap']
+        check = cls.data_model_key_check(data_model, bootstrap_enable_keys)
+        if 'enable_bootstrap' in check['keys_found']:
+            enable_bootstrap = cls.safeget(data_model, bootstrap_enable_keys)
+
+        if enable_bootstrap is not True:
+            for switch_name in poap_switches:
+                results.append(
+                    f"vxlan.topology.switches.{switch_name} has poap defined but "
+                    f"vxlan.multisite.isn.bootstrap.enable_bootstrap is not set to true."
+                )
 
         return results
 

--- a/roles/validate/tasks/cleanup_model_files.yml
+++ b/roles/validate/tasks/cleanup_model_files.yml
@@ -24,7 +24,7 @@
 - name: Remove Service Model JSON Files
   ansible.builtin.find:
     paths: "{{ role_path }}/files/"
-    patterns: "{{ data_model_extended.vxlan.fabric.name }}_service_model*.json"
+    patterns: "{{ data_model_extended.vxlan.fabric.name }}_service_model*_previous.json"
     file_type: file
     recurse: false
   register: files_to_delete

--- a/roles/validate/tasks/main.yml
+++ b/roles/validate/tasks/main.yml
@@ -47,7 +47,7 @@
 
 - name: Mark Stage Role Validate Completed
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_validate_completed
   register: run_map
   delegate_to: localhost

--- a/roles/validate/tasks/manage_model_files_current.yml
+++ b/roles/validate/tasks/manage_model_files_current.yml
@@ -39,11 +39,26 @@
     force: true
   delegate_to: localhost
 
+- name: Stat Current Golden Service Model Data
+  ansible.builtin.stat:
+    path: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_golden.json"
+  register: current_golden_stat
+  when: validate_checksum_compare_enabled | default(false) | bool
+  delegate_to: localhost
+
+- name: Stat Current Extended Service Model Data
+  ansible.builtin.stat:
+    path: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_extended.json"
+  register: current_extended_stat
+  when: validate_checksum_compare_enabled | default(false) | bool
+  delegate_to: localhost
+
 # Read current golden service model data into a variable called 'smd_golden_current'
 - name: Read Current Service Model Data from Host
   ansible.builtin.include_vars:
     file: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_golden.json"
   register: smd_golden_current
+  when: validate_model_diff_enabled | default(false) | bool
   delegate_to: localhost
 
 # Read current extended service model data into a variable called 'data_model_extended_current'
@@ -51,41 +66,46 @@
   ansible.builtin.include_vars:
     file: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_extended.json"
   register: data_model_extended_current
+  when: validate_model_diff_enabled | default(false) | bool
   delegate_to: localhost
 
 - name: Display Model File Changes
   ansible.utils.fact_diff:
-    before: "{{ smd_golden_previous }}"
-    after: "{{ smd_golden_current }}"
+    before: "{{ smd_golden_previous | default({}) }}"
+    after: "{{ smd_golden_current | default({}) }}"
   register: smd_golden_diff
-  when: check_roles['save_previous']
+  when:
+    - validate_model_diff_enabled | default(false) | bool
+    - golden_stat.stat.exists | default(false)
   delegate_to: localhost
 
 - name: Display Extended Service Model File Changes
   ansible.utils.fact_diff:
-    before: "{{ data_model_extended_previous }}"
-    after: "{{ data_model_extended_current }}"
+    before: "{{ data_model_extended_previous | default({}) }}"
+    after: "{{ data_model_extended_current | default({}) }}"
   register: data_model_extended_diff
-  when: check_roles['save_previous']
+  when:
+    - validate_model_diff_enabled | default(false) | bool
+    - extended_stat.stat.exists | default(false)
   delegate_to: localhost
 
 - name: Mark All Stages Completed When No Model Changes Detected
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_all_completed
   when:
-    - check_roles['save_previous']
-    - smd_golden_diff.diff_lines | length == 0
-    - smd_golden_diff.diff_text | length == 0
-    - data_model_extended_diff.diff_lines | length == 0
-    - data_model_extended_diff.diff_text | length == 0
-    - run_map_read_result.diff_run is true
-    - force_run_all is false|bool
+    - validate_checksum_compare_enabled | default(false) | bool
+    - golden_stat.stat.exists | default(false)
+    - extended_stat.stat.exists | default(false)
+    - current_golden_stat.stat.exists | default(false)
+    - current_extended_stat.stat.exists | default(false)
+    - (golden_stat.stat.checksum | default('')) == (current_golden_stat.stat.checksum | default('__missing_current_golden__'))
+    - (extended_stat.stat.checksum | default('')) == (current_extended_stat.stat.checksum | default('__missing_current_extended__'))
   delegate_to: localhost
 
 - name: Mark All Stages Completed When Only The Validate Role Is Run
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: role_all_completed
   when: run_map_read_result.validate_only_run is true|bool
   delegate_to: localhost
@@ -93,13 +113,13 @@
 - name: No Model Changes Detected
   ansible.builtin.meta: end_host
   when:
-    - check_roles['save_previous']
-    - smd_golden_diff.diff_lines | length == 0
-    - smd_golden_diff.diff_text | length == 0
-    - data_model_extended_diff.diff_lines | length == 0
-    - data_model_extended_diff.diff_text | length == 0
-    - run_map_read_result.diff_run is true|bool
-    - force_run_all is false|bool
+    - validate_checksum_compare_enabled | default(false) | bool
+    - golden_stat.stat.exists | default(false)
+    - extended_stat.stat.exists | default(false)
+    - current_golden_stat.stat.exists | default(false)
+    - current_extended_stat.stat.exists | default(false)
+    - (golden_stat.stat.checksum | default('')) == (current_golden_stat.stat.checksum | default('__missing_current_golden__'))
+    - (extended_stat.stat.checksum | default('')) == (current_extended_stat.stat.checksum | default('__missing_current_extended__'))
   delegate_to: localhost
 
 # ------------------------------------------------------------------------

--- a/roles/validate/tasks/manage_model_files_previous.yml
+++ b/roles/validate/tasks/manage_model_files_previous.yml
@@ -39,7 +39,9 @@
   ansible.builtin.include_vars:
     file: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_golden.json"
   register: smd_golden_previous
-  when: golden_stat.stat.exists and check_roles['save_previous']
+  when:
+    - golden_stat.stat.exists
+    - validate_model_diff_enabled | default(false) | bool
   delegate_to: localhost
 
 # Read and store previous extended service model data into a variable called 'data_model_extended_previous'
@@ -47,7 +49,9 @@
   ansible.builtin.include_vars:
     file: "{{ role_path }}/files/{{ data_model_extended.vxlan.fabric.name }}_service_model_extended.json"
   register: data_model_extended_previous
-  when: extended_stat.stat.exists and check_roles['save_previous']
+  when:
+    - extended_stat.stat.exists
+    - validate_model_diff_enabled | default(false) | bool
   delegate_to: localhost
 
 # Rename golden file from previous run to append '_previous' to the filename

--- a/roles/validate/tasks/sub_main.yml
+++ b/roles/validate/tasks/sub_main.yml
@@ -135,14 +135,41 @@
 
 - name: Read Run Map From Previous Run
   cisco.nac_dc_vxlan.common.read_run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     play_tags: "{{ ansible_run_tags }}"
   register: run_map_read_result
   delegate_to: localhost
 
+- name: Set Validate Runtime Mode
+  ansible.builtin.set_fact:
+    validate_checksum_compare_enabled: >-
+      {{
+        check_roles['save_previous'] | bool and
+        run_map_read_result.diff_run | bool and
+        not (force_run_all | default(false) | bool)
+      }}
+    validate_model_diff_enabled: >-
+      {{
+        check_roles['save_previous'] | bool and
+        run_map_read_result.diff_run | bool and
+        not (force_run_all | default(false) | bool) and
+        display_model_diff | default(false) | bool
+      }}
+  delegate_to: localhost
+
+- name: Display Validate Runtime Mode
+  ansible.builtin.debug:
+    msg:
+      - "force_run_all={{ force_run_all | default(false) | bool }}"
+      - "diff_run={{ run_map_read_result.diff_run | bool }}"
+      - "ansible_run_tags={{ ansible_run_tags }}"
+      - "checksum_compare={{ validate_checksum_compare_enabled | bool }}"
+      - "display_model_diff={{ validate_model_diff_enabled | bool }}"
+  delegate_to: localhost
+
 - name: Initialize Run Map
   cisco.nac_dc_vxlan.common.run_map:
-    data_model: "{{ data_model_extended }}"
+    fabric_name: "{{ data_model_extended.vxlan.fabric.name }}"
     stage: starting_execution
   register: run_map
   delegate_to: localhost

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -47,3 +47,7 @@ plugins/action/dtc/fabric_deploy_manager.py action-plugin-docs # action plugin h
 plugins/action/common/change_flag_manager.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_110_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/dtc/process_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/build_resource_data.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/manage_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/remove_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/underlay_ip_manual_allocation_filter.py action-plugin-docs # action plugin has no matching module to provide documentation

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -47,3 +47,7 @@ plugins/action/dtc/fabric_deploy_manager.py action-plugin-docs # action plugin h
 plugins/action/common/change_flag_manager.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_110_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/dtc/process_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/build_resource_data.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/manage_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/remove_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/underlay_ip_manual_allocation_filter.py action-plugin-docs # action plugin has no matching module to provide documentation

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -47,3 +47,7 @@ plugins/action/dtc/fabric_deploy_manager.py action-plugin-docs # action plugin h
 plugins/action/common/change_flag_manager.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_110_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/dtc/process_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/build_resource_data.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/manage_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/remove_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/underlay_ip_manual_allocation_filter.py action-plugin-docs # action plugin has no matching module to provide documentation

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -47,3 +47,7 @@ plugins/action/dtc/fabric_deploy_manager.py action-plugin-docs # action plugin h
 plugins/action/common/change_flag_manager.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_110_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/dtc/process_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/build_resource_data.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/manage_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/remove_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/underlay_ip_manual_allocation_filter.py action-plugin-docs # action plugin has no matching module to provide documentation

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -40,3 +40,7 @@ plugins/action/dtc/fabric_deploy_manager.py action-plugin-docs # action plugin h
 plugins/action/common/change_flag_manager.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/common/prepare_plugins/prep_110_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
 plugins/action/dtc/process_tor_pairing.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/build_resource_data.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/manage_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/remove_resources.py action-plugin-docs # action plugin has no matching module to provide documentation
+plugins/action/dtc/underlay_ip_manual_allocation_filter.py action-plugin-docs # action plugin has no matching module to provide documentation


### PR DESCRIPTION

### Summary

Always render `useVirtualPeerlink` in `roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs.j2`, defaulting to `false` when `fabric_peering` is omitted from a `vpc_peers` entry.

### Problem

When `fabric_peering` is not set on a `vpc_peers` entry, the template currently skips the `useVirtualPeerlink` field entirely:

```jinja
{% if vpc_peers_pair.fabric_peering is defined %}
  useVirtualPeerlink: {{ vpc_peers_pair.fabric_peering }}
{% endif %}
```

Against a freshly-built fabric, the resulting `dcnm_vpc_pair` call has been observed to receive the pair as input but the artifact does not show a POST for it (the pair is absent from `result.diff[0].merged` and from `result.response`). A subsequent `dcnm_interface` step then fails when it tries to create a vPC port-channel on a peer in that pair:

```
Create pipeline failed at step 'interface_all' (dcnm_interface):
Switch '<ip>' is not part of VPC pair, but given I/F 'vpc<N>' is of type VPC
```

Full evidence (artifact JSON snippets and reproducer data model) is in the linked issue.

### Fix

```jinja
  useVirtualPeerlink: {{ vpc_peers_pair.fabric_peering | default(false) }}
```

This aligns the rendered payload with:

- The documented `dcnm_vpc_pair` default — `useVirtualPeerlink: { type: bool, default: false }`.
- The existing validation rule `roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py`, which already uses `peer.get("fabric_peering", False)`.
- The reference data model `nac-fabric1`, which sets `fabric_peering: false` explicitly and works end-to-end.

### Scope

- One file changed: `roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs.j2`.
- No behavior change for entries that already define `fabric_peering` (rendering for those is bit-identical).

### Verification

Manual Jinja render against three cases (`fabric_peering: true`, `fabric_peering: false`, omitted):

```
- peerOneId: 10.122.226.107
  peerTwoId: 10.122.226.108
  useVirtualPeerlink: True

- peerOneId: 10.122.226.115
  peerTwoId: 10.122.226.116
  useVirtualPeerlink: False

- peerOneId: 10.122.226.105
  peerTwoId: 10.122.226.106
  useVirtualPeerlink: False
```

The third case is the fix: previously, the `useVirtualPeerlink` line would not be emitted at all.

### Related issue

Closes #800.
