### PR TITLE
Fix hostname policy management so the bulk policy API fallback behaves correctly

### DIFF
--- a/plugins/action/dtc/update_switch_hostname_policy.py
+++ b/plugins/action/dtc/update_switch_hostname_policy.py
@@ -28,6 +28,7 @@ import json
 
 from ansible.plugins.action import ActionBase
 from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import (
+    NdfcBulkPolicyApiUnavailable,
     ndfc_get_fabric_policies_by_template,
     ndfc_get_switch_policy_using_template
 )
@@ -73,8 +74,8 @@ class ActionModule(ActionBase):
                 )
                 # If successful, return the bulk result
                 return policies_dict, True
-            except Exception as e:
-                # Bulk API not available or failed, mark it and fall back
+            except NdfcBulkPolicyApiUnavailable:
+                # Bulk API not available, mark it and fall back
                 self.bulk_api_available = False
 
         # Fallback: Query each switch individually

--- a/plugins/plugin_utils/helper_functions.py
+++ b/plugins/plugin_utils/helper_functions.py
@@ -25,6 +25,29 @@
 # For example in prepare_serice_model.py we can do the following:
 #  from ..helper_functions import do_something
 
+
+class NdfcBulkPolicyApiUnavailable(Exception):
+    """
+    Raised when the NDFC bulk policy lookup API is not available.
+    """
+
+
+class NdfcDuplicatePolicyError(Exception):
+    """
+    Raised when NDFC has duplicate policies for a switch/template pair.
+    """
+
+
+def _ndfc_policy_id_list(policies):
+    """
+    Return a comma-separated policyId/id list for error messages.
+    """
+    policy_ids = []
+    for policy in policies:
+        policy_ids.append(str(policy.get("policyId") or policy.get("id") or "unknown"))
+    return ", ".join(policy_ids)
+
+
 def data_model_key_check(tested_object, keys):
     """
     Check if key(s) are found and exist in the data model.
@@ -127,17 +150,32 @@ def ndfc_get_switch_policy_using_template(self, task_vars, tmp, switch_serial_nu
     """
     policy_data = ndfc_get_switch_policy(self, task_vars, tmp, switch_serial_number)
 
-    try:
-        policy_match = next(
-            (item for item in policy_data["response"]["DATA"] if item["templateName"] == template_name and item['serialNumber'] == switch_serial_number)
+    policy_response = policy_data.get("response") or policy_data.get("msg") or {}
+    return_code = policy_response.get("RETURN_CODE")
+    if return_code != 200:
+        raise Exception(f"Policy lookup failed for switch {switch_serial_number}: {policy_response}")
+
+    policy_matches = [
+        item for item in policy_response.get("DATA", [])
+        if item["templateName"] == template_name and item['serialNumber'] == switch_serial_number
+    ]
+
+    if len(policy_matches) > 1 and template_name == "host_11_1":
+        raise NdfcDuplicatePolicyError(
+            f"Duplicate host_11_1 policies found for switch serial {switch_serial_number}. "
+            f"Policy IDs: {_ndfc_policy_id_list(policy_matches)}. "
+            "Duplicate hostname policies are controller drift and must be reconciled before continuing."
         )
-    except StopIteration:
+
+    if not policy_matches:
         if template_name == "host_11_1":
             policy_match = None
         else:
             err_msg = f"Policy for template {template_name} and switch {switch_serial_number} not found!"
             err_msg += f" Please ensure switch with serial number {switch_serial_number} is part of the fabric."
             raise Exception(err_msg)
+    else:
+        policy_match = policy_matches[0]
 
     return policy_match
 
@@ -357,7 +395,9 @@ def ndfc_get_fabric_policies_by_template(self, task_vars, tmp, fabric_name, temp
         :policies_dict: Dictionary mapping serial_number to policy data.
 
     :Raises:
-        N/A
+        NdfcBulkPolicyApiUnavailable: If the bulk policy lookup API is not installed.
+        NdfcDuplicatePolicyError: If duplicate host_11_1 policies are found for a switch serial.
+        Exception: If the bulk policy lookup fails for another reason.
     """
     policy_response = self._execute_module(
         module_name="cisco.dcnm.dcnm_rest",
@@ -369,10 +409,38 @@ def ndfc_get_fabric_policies_by_template(self, task_vars, tmp, fabric_name, temp
         tmp=tmp
     )
 
+    policy_result = policy_response.get("response") or policy_response.get("msg") or {}
+    return_code = policy_result.get("RETURN_CODE")
+
+    if return_code == 404:
+        raise NdfcBulkPolicyApiUnavailable(
+            f"Bulk policy lookup API is unavailable for fabric {fabric_name} and template {template_name}."
+        )
+
+    if return_code != 200:
+        raise Exception(
+            f"Bulk policy lookup failed for fabric {fabric_name} and template {template_name}: {policy_result}"
+        )
+
     # Build a dictionary mapping serial number to policy
     policies_dict = {}
-    if policy_response.get('response') and policy_response['response'].get('DATA'):
-        for policy in policy_response['response']['DATA']:
-            policies_dict[policy['serialNumber']] = policy
+    duplicate_check = {}
+    for policy in policy_result.get('DATA') or []:
+        serial_number = policy['serialNumber']
+        policies_dict[serial_number] = policy
+        duplicate_check.setdefault(serial_number, []).append(policy)
+
+    if template_name == "host_11_1":
+        duplicate_details = [
+            f"{serial_number}: {_ndfc_policy_id_list(policies)}"
+            for serial_number, policies in duplicate_check.items()
+            if len(policies) > 1
+        ]
+        if duplicate_details:
+            raise NdfcDuplicatePolicyError(
+                "Duplicate host_11_1 policies found. "
+                f"Serial/policy IDs: {'; '.join(duplicate_details)}. "
+                "Duplicate hostname policies are controller drift and must be reconciled before continuing."
+            )
 
     return policies_dict


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [x] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

## Summary

Fix hostname policy management so the bulk policy API fallback behaves correctly and duplicate hostname policies fail loudly.

## Changes

- Added explicit `NdfcBulkPolicyApiUnavailable` handling for the NDFC bulk policy lookup API.
- Updated bulk policy lookup to inspect `RETURN_CODE` from `dcnm_rest` results.
- Treat `404` from the bulk policy endpoint as “bulk API unavailable” and fall back to per-switch policy lookup.
- Treat other non-200 bulk lookup responses as real failures instead of silently continuing.
- Added `NdfcDuplicatePolicyError` for duplicate policy drift detection.
- Updated `host_11_1` lookup logic to fail when more than one hostname policy exists for the same switch serial.
- Limited fallback in `update_switch_hostname_policy.py` to only the explicit bulk-unavailable case.

## Why

On unpatched ND/NDFC systems, the bulk policy lookup endpoint can return `404`. Previously, that result was interpreted as an empty successful lookup, causing the hostname policy action to think no `host_11_1` policy existed and create a new same-priority policy. Repeated runs could create duplicate hostname policies, leaving NDFC to choose whichever policy wins.

This change makes the intended fallback path explicit and prevents duplicate hostname policies from being silently ignored.

## Verification

- Python syntax check passed for the modified files.
- Mocked `404` bulk lookup confirms fallback signal is raised.
- Mocked duplicate `host_11_1` policy lookup confirms duplicate detection fails loudly.

If we detect a duplicate policy then the following error is generated and stop execution

```bash
atal: [nac-mcfg-fabric1]: FAILED! => {
    "changed": false,
    "msg": "Manage resources failed: Duplicate host_11_1 policies found for switch serial 9G6AZ38620E. Policy IDs: POLICY-346130, POLICY-344650, POLICY-343180. Duplicate hostname policies are controller drift and must be reconciled before continuing."
}
```

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
