### PR TITLE
manage edge bgp_password

### DIFF
--- a/roles/dtc/common/templates/ndfc_edge_connections.j2
+++ b/roles/dtc/common/templates/ndfc_edge_connections.j2
@@ -17,8 +17,12 @@
           description: {{ 'nace_bgp_peer_template_dci_underlay_jython_' + link.source_device + '_' + link.source_interface + '_' + link.dest_device }}
           name: bgp_peer_template_dci_underlay_jython
           policy_vars:
-            BGP_PASSWORD: "{{ link.bgp_section.bgp_password | default('') }}"
-            BGP_PASSWORD_ENABLE: {{ link.bgp_section.bgp_password_enable | default(defaults.vxlan.topology.edge_connections.bgp_section.bgp_password_enable) }}
+{% if link.bgp_section is defined and link.bgp_section.bgp_password is defined and link.bgp_section.bgp_password is not none and link.bgp_section.bgp_password | length > 0 %}
+            BGP_PASSWORD_ENABLE: true
+            BGP_PASSWORD: "{{ link.bgp_section.bgp_password }}"
+{% else %}
+            BGP_PASSWORD_ENABLE: false
+{% endif %}
             TEMPLATE_NAME: {{ data_model_extended.vxlan.fabric.name + '-' + link.dest_fabric + '-IPV4-EBGP' }}
             NEIGHBOR_ASN: "{{ link.bgp_section.neighbor_asn }}"
             OVERRIDE_LOCAL_ASN: false

--- a/roles/dtc/common/templates/ndfc_edge_connections.j2
+++ b/roles/dtc/common/templates/ndfc_edge_connections.j2
@@ -17,10 +17,11 @@
           description: {{ 'nace_bgp_peer_template_dci_underlay_jython_' + link.source_device + '_' + link.source_interface + '_' + link.dest_device }}
           name: bgp_peer_template_dci_underlay_jython
           policy_vars:
-{% if link.bgp_section is defined and link.bgp_section.bgp_password is defined and link.bgp_section.bgp_password is not none and link.bgp_section.bgp_password | length > 0 %}
-            BGP_PASSWORD_ENABLE: true
+{% if link.bgp_section.bgp_password_enable | default(defaults.vxlan.topology.edge_connections.bgp_section.bgp_password_enable) | bool %}
             BGP_PASSWORD: "{{ link.bgp_section.bgp_password }}"
+            BGP_PASSWORD_ENABLE: true
 {% else %}
+            BGP_PASSWORD: ""
             BGP_PASSWORD_ENABLE: false
 {% endif %}
             TEMPLATE_NAME: {{ data_model_extended.vxlan.fabric.name + '-' + link.dest_fabric + '-IPV4-EBGP' }}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -259,7 +259,7 @@ factory_defaults:
         source_interface_mtu: 9216
         source_interface_enabled: true
         bgp_section:
-          bgp_password_enable: true
+          bgp_password_enable: false
     underlay:
       general:
         routing_protocol: ospf

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -259,7 +259,7 @@ factory_defaults:
         source_interface_mtu: 9216
         source_interface_enabled: true
         bgp_section:
-          bgp_password_enable: false
+          bgp_password_enable: true
     underlay:
       general:
         routing_protocol: ospf

--- a/roles/validate/files/rules/common/321_topology_edge_connections.py
+++ b/roles/validate/files/rules/common/321_topology_edge_connections.py
@@ -1,6 +1,6 @@
 class Rule:
     id = "321"
-    description = "Verify edge connections have valid source devices and interfaces"
+    description = "Verify edge connections have valid source devices, interfaces, and bgp password configuration"
     severity = "HIGH"
 
     @classmethod
@@ -40,6 +40,26 @@ class Rule:
             if source_interface and '.' in source_interface:
                 results.append(
                     f"vxlan.topology.edge_connections.{source_device} source_interface must not contain a '.' (sub-interfaces are not allowed)."
+                )
+
+            # Verify bgp_password is provided when bgp_password_enable is true
+            bgp_section = edge_connection.get("bgp_section", {})
+            defaults = data_model.get("defaults", {})
+            default_bgp_pw_enable = (
+                defaults.get("vxlan", {})
+                .get("topology", {})
+                .get("edge_connections", {})
+                .get("bgp_section", {})
+                .get("bgp_password_enable", False)
+            )
+            bgp_password_enable = bgp_section.get("bgp_password_enable", default_bgp_pw_enable)
+            bgp_password = bgp_section.get("bgp_password", "")
+
+            if bgp_password_enable and (not bgp_password or str(bgp_password).strip() == ""):
+                results.append(
+                    f"vxlan.topology.edge_connections.{source_device} "
+                    f"bgp_password_enable is true but bgp_password is not provided. "
+                    f"A non-empty bgp_password is required when bgp_password_enable is true."
                 )
 
         return results


### PR DESCRIPTION
update bgp_password_enable for edge connection. Change to false. By default it was enabled but if you don't provide password it failed, because password can't be empty.

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

change default value for edge bgp password enable.

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
