### PR TITLE
Add eBGP ASN auto-allocation fabric support

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
@@ -3,6 +3,9 @@
   SUPER_SPINE_BGP_AS: "{{ vxlan.global.ebgp.super_spine_bgp_asn | default(omit) }}"
   BGP_AS_MODE: "{{ vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) }}"
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Multi-AS' %}
+{% if vxlan.global.ebgp.bgp_asn_auto_allocation is defined %}
+  bgpAsnAutoAllocation: "{{ vxlan.global.ebgp.bgp_asn_auto_allocation | lower }}"
+{% endif %}
   ALLOW_LEAF_SAME_AS: "{{ vxlan.global.ebgp.leaf_same_bgp_asn | default(defaults.vxlan.global.ebgp.leaf_same_bgp_asn) | lower }}"
 {% endif %}
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Same-Tier-AS' %}

--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
@@ -3,8 +3,8 @@
   SUPER_SPINE_BGP_AS: "{{ vxlan.global.ebgp.super_spine_bgp_asn | default(omit) }}"
   BGP_AS_MODE: "{{ vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) }}"
 {% if vxlan.global.ebgp.bgp_asn_mode | default(defaults.vxlan.global.ebgp.bgp_asn_mode) == 'Multi-AS' %}
-{% if vxlan.global.ebgp.bgp_asn_auto_allocation is defined %}
-  bgpAsnAutoAllocation: "{{ vxlan.global.ebgp.bgp_asn_auto_allocation | lower }}"
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=') %}
+  bgpAsnAutoAllocation: "{{ vxlan.global.ebgp.bgp_asn_auto_allocation | default(defaults.vxlan.global.ebgp.bgp_asn_auto_allocation) | lower }}"
 {% endif %}
   ALLOW_LEAF_SAME_AS: "{{ vxlan.global.ebgp.leaf_same_bgp_asn | default(defaults.vxlan.global.ebgp.leaf_same_bgp_asn) | lower }}"
 {% endif %}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -25,6 +25,7 @@ factory_defaults:
     global:
       ebgp:
         bgp_asn_mode: Multi-AS
+        bgp_asn_auto_allocation: true
         leaf_same_bgp_asn: false
         anycast_gateway_mac: 20:20:00:00:00:aa
         auth_proto: MD5


### PR DESCRIPTION
## Related Issue(s)

Resolves #749

Companion `nac-vxlan` PR adds the corresponding schema element and Robot validation.

This PR incorporates the version-gating and default-value behavior proposed in
#752, together with additional end-to-end validation of all three eBGP ASN
allocation scenarios.

## Related Collection Role

* [x] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element

* [ ] vxlan.fabric
* [x] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [x] defaults.vxlan
* [ ] other

## Proposed Changes

Add support for the optional `vxlan.global.ebgp.bgp_asn_auto_allocation`
data-model element for Multi-AS eBGP VXLAN fabrics.

When explicitly defined, the eBGP fabric template maps the data-model value to
the NDFC `bgpAsnAutoAllocation` fabric setting.

For NDFC `12.5.0` and later, the collection defaults ASN auto allocation to
`true`, matching the controller default for new Multi-AS fabrics. The setting
is not sent to earlier NDFC versions, preserving backward compatibility with
controllers that do not support the nvPair.

This enables configurations such as:

```yaml
vxlan:
  global:
    ebgp:
      bgp_asn_mode: Multi-AS
      bgp_asn_auto_allocation: false
      leaf_same_bgp_asn: true
```

Previously, the collection did not send `bgpAsnAutoAllocation` to NDFC.
Consequently, NDFC used its default auto-allocation behavior and rejected
Multi-AS fabrics configured with `leaf_same_bgp_asn: true`, because ASN auto
allocation and allowing the same leaf ASN are mutually exclusive.

The setting remains optional in the service model. Existing Multi-AS models
that do not define it use the NDFC 4.2 default of enabled auto allocation.
Models using `leaf_same_bgp_asn: true` must explicitly disable auto allocation.

## Test Notes

Tested manually against ND06 using Nexus Dashboard 4.2 and NDFC
`12.5.0.475`.

Validated three complete eBGP VXLAN scenarios:

| Scenario | Configuration | Result |
|---|---|---|
| Auto-AS | Multi-AS, auto allocation enabled, same leaf ASN disabled | Passed |
| Same-Tier-AS | Explicit leaf and border ASNs by tier | Passed |
| Manual Multi-AS | Auto allocation disabled, same leaf ASN enabled, ASNs assigned through policies | Passed |

Results:

- All three fabrics were successfully created and deployed.
- All eight switches reached In-Sync in every scenario.
- All Ansible playbook executions completed with `failed=0`.
- Robot fabric validation passed `45/45` tests across the three scenarios.
- Manual Multi-AS successfully applied shared ASNs through `leaf_bgp_asn`
  policies without the previous mutually-exclusive-options error.
- Cleanup completed successfully for all fabrics and switches.
- The setting is version-gated to NDFC `12.5.0` and later so earlier
  controllers retain their existing payload behavior.

Observed Manual Multi-AS NDFC values:

```text
BGP_AS_MODE=Multi-AS
bgpAsnAutoAllocation=false
ALLOW_LEAF_SAME_AS=true
```

Observed Auto-AS NDFC values:

```text
BGP_AS_MODE=Multi-AS
bgpAsnAutoAllocation=true
ALLOW_LEAF_SAME_AS=false
```

## Cisco Nexus Dashboard Version

Nexus Dashboard 4.2  
NDFC `12.5.0.475`

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
