### PR TITLE
Adding support for vlan_id override under attachment

### DIFF
--- a/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
@@ -1,4 +1,4 @@
-{# Auto-generated NDFC DC VXLAN EVPN VRFs config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC VXLAN EVPN Networks config data structure for fabric {{ vxlan.fabric.name }} #}
 {% set networks = [] %}
 {% if data_model_extended.vxlan.overlay.networks is defined and data_model_extended.vxlan.overlay.networks %}
 {% set networks = data_model_extended.vxlan.overlay.networks %}
@@ -65,6 +65,15 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if attach['networks'] is defined %}
+{% for attached_net in attach['networks'] %}
+{% if attached_net['name'] == net['name'] %}
+{% if attached_net['vlan_id'] is defined and attached_net['vlan_id'] != net['vlan_id'] %}
+      vlan_id: {{ attached_net['vlan_id'] }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
@@ -74,6 +74,15 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if attach['networks'] is defined %}
+{% for attached_net in attach['networks'] %}
+{% if attached_net['name'] == net['name'] %}
+{% if attached_net['vlan_id'] is defined and attached_net['vlan_id'] != net['vlan_id'] %}
+      vlan_id: {{ attached_net['vlan_id'] }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
@@ -74,6 +74,15 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if attach['networks'] is defined %}
+{% for attached_net in attach['networks'] %}
+{% if attached_net['name'] == net['name'] %}
+{% if attached_net['vlan_id'] is defined and attached_net['vlan_id'] != net['vlan_id'] %}
+      vlan_id: {{ attached_net['vlan_id'] }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
+++ b/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
@@ -68,7 +68,7 @@ class Rule:
             if sm_networks and network_attach_groups:
                 results = cls.cross_reference_switches(network_attach_groups, switches, 'network', results)
                 results = cls.cross_reference_vpc_peers(network_attach_groups, vpc_peers, 'network', results)
-                results = cls.crooss_reference_attached_networks(network_attach_groups, switches, sm_networks, 'network', results)
+                results = cls.crooss_reference_attached_networks(network_attach_groups, sm_networks, 'network', results)
                 results = cls.cross_reference_vpc_peers_attributes(network_attach_groups, vpc_peers, 'network', results)
 
         return results
@@ -242,7 +242,7 @@ class Rule:
         return results
 
     @classmethod
-    def crooss_reference_attached_networks(cls, network_attach_groups, switches, networks, target, results):
+    def crooss_reference_attached_networks(cls, network_attach_groups, networks, target, results):
         """
         Check if each network defined under the network_attach_group exists.
         """

--- a/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
+++ b/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
@@ -185,9 +185,10 @@ class Rule:
     @classmethod
     def cross_reference_vpc_peers_attributes(cls, network_attach_groups, vpc_peers, target, results):
         """
-        Check if each network_attachment attributes (vlan_id, svi_enabled) is the same on each
+        Check if each network_attachment attributes are the same on each
         of the vpc peers.
         """
+        # Only vlan_id as now
 
         if not network_attach_groups or not vpc_peers:
             return results

--- a/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
+++ b/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
@@ -68,7 +68,7 @@ class Rule:
             if sm_networks and network_attach_groups:
                 results = cls.cross_reference_switches(network_attach_groups, switches, 'network', results)
                 results = cls.cross_reference_vpc_peers(network_attach_groups, vpc_peers, 'network', results)
-                results = cls.crooss_reference_attached_networks(network_attach_groups, sm_networks, 'network', results)
+                results = cls.cross_reference_attached_networks(network_attach_groups, sm_networks, 'network', results)
                 results = cls.cross_reference_vpc_peers_attributes(network_attach_groups, vpc_peers, 'network', results)
 
         return results
@@ -242,7 +242,7 @@ class Rule:
         return results
 
     @classmethod
-    def crooss_reference_attached_networks(cls, network_attach_groups, networks, target, results):
+    def cross_reference_attached_networks(cls, network_attach_groups, networks, target, results):
         """
         Check if each network defined under the network_attach_group exists.
         """

--- a/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
+++ b/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
@@ -68,6 +68,8 @@ class Rule:
             if sm_networks and network_attach_groups:
                 results = cls.cross_reference_switches(network_attach_groups, switches, 'network', results)
                 results = cls.cross_reference_vpc_peers(network_attach_groups, vpc_peers, 'network', results)
+                results = cls.crooss_reference_attached_networks(network_attach_groups, switches, sm_networks, 'network', results)
+                results = cls.cross_reference_vpc_peers_attributes(network_attach_groups, vpc_peers, 'network', results)
 
         return results
 
@@ -177,5 +179,95 @@ class Rule:
                             f"which has vPC peer '{vpc_peer}', but the vPC peer is not included "
                             f"in the same attach group. Both vPC peers should be in the same attach group."
                         )
+
+        return results
+
+    @classmethod
+    def cross_reference_vpc_peers_attributes(cls, network_attach_groups, vpc_peers, target, results):
+        """
+        Check if each network_attachment attributes (vlan_id, svi_enabled) is the same on each
+        of the vpc peers.
+        """
+
+        if not network_attach_groups or not vpc_peers:
+            return results
+
+        # Build a mapping of vPC peers: hostname -> peer_hostname
+        vpc_peer_mapping = {}
+        for vpc_pair in vpc_peers:
+            peer1 = vpc_pair.get('peer1')
+            peer2 = vpc_pair.get('peer2')
+            if peer1 and peer2:
+                vpc_peer_mapping[peer1] = peer2
+                vpc_peer_mapping[peer2] = peer1
+
+        # Check each attach group
+        for attach_group in network_attach_groups:
+            group_name = attach_group.get('name')
+            group_switches = attach_group.get('switches', [])
+            group_switches_dict = {sw['hostname']: {k: v for k, v in sw.items() if k != 'hostname'} for sw in group_switches}
+
+            # Get the network subkey that overwrites the global values defined at Network level
+            for switch in group_switches:
+                hostname = switch.get('hostname')
+                if hostname in vpc_peer_mapping:
+                    vpc_peer_name = vpc_peer_mapping[hostname]
+                    vpc_peer = group_switches_dict.get(vpc_peer_name)
+                    peer1_networks_override = switch.get('networks')
+                    peer2_networks_override = None
+
+                    if vpc_peer:
+                        peer2_networks_override = vpc_peer.get('networks')
+
+                        if peer1_networks_override and not peer2_networks_override:
+                            results.append(
+                                f"{target}_attach_group '{group_name}' contains switch '{hostname}' "
+                                f"which has vPC peer '{vpc_peer_name}' and defines Network attributes, but the "
+                                f"vPC peer doesn't contain those attributes. Both vPC peers must have the "
+                                f"same Network attributes under the same attach group."
+                            )
+
+                        if peer1_networks_override and peer2_networks_override:
+                            peer1_nets = {net['name']: {k: v for k, v in net.items() if k != 'name'} for net in peer1_networks_override}
+                            peer2_nets = {net['name']: {k: v for k, v in net.items() if k != 'name'} for net in peer2_networks_override}
+
+                            if peer1_nets != peer2_nets:
+                                results.append(
+                                    f"{target}_attach_group '{group_name}' contains switch '{hostname}' "
+                                    f"which has vPC peer '{vpc_peer}' and defines Network attributes, but those "
+                                    f"attributes are not the same. Both vPC peers must have the "
+                                    f"same Network attributes under the same attach group."
+                                )
+
+        return results
+
+    @classmethod
+    def crooss_reference_attached_networks(cls, network_attach_groups, switches, networks, target, results):
+        """
+        Check if each network defined under the network_attach_group exists.
+        """
+
+        if not network_attach_groups:
+            return results
+
+        for attach_group in network_attach_groups:
+            group_name = attach_group.get('name')
+            group_switches = attach_group.get('switches', [])
+            networks_name = [net['name'] for net in networks]
+
+            for switch in group_switches:
+                hostname = switch.get('hostname')
+                attached_networks = switch.get('networks')
+
+                if attached_networks:
+                    for network in attached_networks:
+                        attached_network_name = network.get('name')
+                        if attached_network_name not in networks_name:
+                            results.append(
+                                f"{target}_attach_group '{group_name}' contains switch '{hostname}' "
+                                f"which defines a network '{attached_network_name}', but the network "
+                                f"is not defined in the service model. Add the Network to the service "
+                                f"model and re-run the playbook."
+                            )
 
         return results


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #807 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [X] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Adding a new keys under under attachment groups in order to override the vlan_id for the corresponding network

```yaml
- name: attach_group
        switches:
          - hostname: leaf1
            networks:
              - name: Network1
                vlan_id: 10
```
      


## Test Notes
Depends on base collection PR:
https://github.com/CiscoDevNet/ansible-dcnm/pull/687


## Cisco Nexus Dashboard Version
ND 3.1, 3.2, 4.1


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
