### PR TITLE
Fix securityGroupTagMacSegmentation version-gate threshold (ndfc_version >= 12.5.0)

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
@@ -1,7 +1,7 @@
 {# Auto-generated NDFC DC VXLAN EVPN Security config data structure for fabric {{ vxlan.fabric.name }} #}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   ENABLE_SGT: false
-{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('4.2.1', '>=') %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=') %}
   securityGroupTagMacSegmentation: false
   securityGroupTagMacSegmentation_PREV: false
 {% endif %}


### PR DESCRIPTION
## Related Issue(s)

Fixes #814

## Related Collection Role

* [x] cisco.nac_dc_vxlan.dtc.create

## Related Data Model Element

* [x] other (template-only version-gate fix — no data model change)

## Proposed Changes

#812 gates `securityGroupTagMacSegmentation` with `ndfc_version | version_compare('4.2.1', '>=')`. The variable is `ndfc_version` (NDFC scheme, e.g. `12.4.1.321`), but the threshold `4.2.1` is an ND-scheme number, so the comparison is always true (every NDFC release is `12.x`, and `12.x >= 4.2.1`). The field is therefore sent to every controller — including ND 4.1, which does not support it and rejects fabric create/update with HTTP 500.

This corrects the threshold to the NDFC version that ships with ND 4.2.1, keeping `ndfc_version` as-is:

- ND 4.1.1g → NDFC `12.4.1.321`
- ND 4.2.1 → NDFC `12.5.0.475`

so the gate becomes `ndfc_version | version_compare('12.5.0', '>=')`.

## Test Notes

Validated against Nexus Dashboard 4.1.1g (NDFC 12.4.1.321):

- Before: fabric create failed with `RETURN_CODE 500` — `invalid fields [{securityGroupTagMacSegmentation=false, securityGroupTagMacSegmentation_PREV=false}]`.
- After: the field is no longer emitted on ND 4.1, and fabric create/deploy completes successfully.

## Cisco Nexus Dashboard Version

4.1.1g (NDFC 12.4.1.321); feature targets ND 4.2.1+ (NDFC 12.5.0.475).

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly (N/A — template-only fix)
* [ ] Assigned the proper reviewers
