### PR TITLE
Adding support for freeform config under attachment

### DIFF
--- a/plugins/filter/dedent.py
+++ b/plugins/filter/dedent.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 Cisco Systems, Inc. and its affiliates
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+# the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# SPDX-License-Identifier: MIT
+
+DOCUMENTATION = r"""
+  name: dedent
+  version_added: "0.8.0"
+  short_description: Remove common leading whitespace from text
+  description:
+    - Remove common leading whitespace from every line in the input text.
+    - Useful for normalizing multiline strings defined with YAML block scalars (|2, |, etc.).
+  positional: text
+  options:
+    text:
+      description: The text to dedent.
+      type: str
+      required: true
+"""
+
+EXAMPLES = r"""
+
+# Basic usage - remove common leading whitespace
+dedented_text: "{{ my_multiline_var | cisco.nac_dc_vxlan.dedent }}"
+
+# Combine with indent to normalize and re-indent
+normalized_config: "{{ ibgp_template | cisco.nac_dc_vxlan.dedent | indent(6, true) }}"
+"""
+
+RETURN = r"""
+  _value:
+    description:
+      - The dedented string with common leading whitespace removed.
+    type: str
+"""
+
+import textwrap
+
+from ansible.module_utils.six import string_types
+from ansible.errors import AnsibleFilterError, AnsibleFilterTypeError
+from ansible.module_utils.common.text.converters import to_native
+from jinja2.runtime import Undefined
+from jinja2.exceptions import UndefinedError
+
+
+def dedent(text):
+    """
+    Remove common leading whitespace from every line in text.
+    Args:
+        text (str): The text string to dedent.
+    Returns:
+        str: The dedented text.
+    Raises:
+        AnsibleFilterTypeError: If the text argument is not a string.
+        AnsibleFilterError: If the dedent operation fails.
+    """
+    if isinstance(text, Undefined):
+        return text
+
+    if text is None:
+        return ""
+
+    if not isinstance(text, string_types):
+        raise AnsibleFilterTypeError(f"dedent requires a string, got: {type(text)}")
+
+    if not text:
+        return text
+
+    try:
+        return textwrap.dedent(text)
+    except UndefinedError:
+        raise
+    except Exception as e:
+        raise AnsibleFilterError("Unable to dedent text: %s" % to_native(e), orig_exc=e)
+
+
+# ---- Ansible filters ----
+class FilterModule(object):
+    """ Dedent filter - remove common leading whitespace """
+
+    def filters(self):
+        return {
+            "dedent": dedent
+        }

--- a/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
@@ -1,4 +1,4 @@
-{# Auto-generated NDFC DC VXLAN EVPN VRFs config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC VXLAN EVPN Networks config data structure for fabric {{ vxlan.fabric.name }} #}
 {% set networks = [] %}
 {% if data_model_extended.vxlan.overlay.networks is defined and data_model_extended.vxlan.overlay.networks %}
 {% set networks = data_model_extended.vxlan.overlay.networks %}
@@ -65,7 +65,16 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
-{% if attach['ports'] is defined %}
+{% if attach['networks'] is defined %}
+{% for attached_net in attach['networks'] %}
+{% if attached_net['name'] == net['name'] %}
+{% if attached_net['freeform_config'] is defined %}
+      freeform_config: |-
+{{ attached_net['freeform_config'] | cisco.nac_dc_vxlan.dedent | indent(8, true) }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}{% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}
 {% if 'tors' in attach and attach['tors'] %}

--- a/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
@@ -74,6 +74,16 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if attach['networks'] is defined %}
+{% for attached_net in attach['networks'] %}
+{% if attached_net['name'] == net['name'] %}
+{% if attached_net['freeform_config'] is defined %}
+      freeform_config: |-
+{{ attached_net['freeform_config'] | cisco.nac_dc_vxlan.dedent | indent(8, true) }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
@@ -74,6 +74,16 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if attach['networks'] is defined %}
+{% for attached_net in attach['networks'] %}
+{% if attached_net['name'] == net['name'] %}
+{% if attached_net['freeform_config'] is defined %}
+      freeform_config: |-
+{{ attached_net['freeform_config'] | cisco.nac_dc_vxlan.dedent | indent(8, true) }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
+++ b/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
@@ -68,6 +68,7 @@ class Rule:
             if sm_networks and network_attach_groups:
                 results = cls.cross_reference_switches(network_attach_groups, switches, 'network', results)
                 results = cls.cross_reference_vpc_peers(network_attach_groups, vpc_peers, 'network', results)
+                results = cls.cross_reference_attached_networks(network_attach_groups, sm_networks, 'network', results)
 
         return results
 
@@ -177,5 +178,36 @@ class Rule:
                             f"which has vPC peer '{vpc_peer}', but the vPC peer is not included "
                             f"in the same attach group. Both vPC peers should be in the same attach group."
                         )
+
+        return results
+
+    @classmethod
+    def cross_reference_attached_networks(cls, network_attach_groups, networks, target, results):
+        """
+        Check if each network defined under the network_attach_group exists.
+        """
+
+        if not network_attach_groups:
+            return results
+
+        for attach_group in network_attach_groups:
+            group_name = attach_group.get('name')
+            group_switches = attach_group.get('switches', [])
+            networks_name = [net['name'] for net in networks]
+
+            for switch in group_switches:
+                hostname = switch.get('hostname')
+                attached_networks = switch.get('networks')
+
+                if attached_networks:
+                    for network in attached_networks:
+                        attached_network_name = network.get('name')
+                        if attached_network_name not in networks_name:
+                            results.append(
+                                f"{target}_attach_group '{group_name}' contains switch '{hostname}' "
+                                f"which defines a network '{attached_network_name}', but the network "
+                                f"is not defined in the service model. Add the Network to the service "
+                                f"model and re-run the playbook."
+                            )
 
         return results


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
Fixes #820 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [X] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Adding a new keys under under attachment groups in order to add the freeform Config related for the corresponding network

```yaml
- name: attach_group
        switches:
          - hostname: leaf1
            networks:
              - name: Network1
                freeform_config: |
                  interface Vlan3101
                  no autostate
```

## Test Notes
Depends on base collection PR:
https://github.com/CiscoDevNet/ansible-dcnm/pull/689


## Cisco Nexus Dashboard Version
ND 3.1, 3.2, 4.1


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
