### PR TITLE
Renaming rule names and IDs due to duplicate ID

### DIFF
--- a/roles/validate/files/rules/common/321_topology_edge_connections.py
+++ b/roles/validate/files/rules/common/321_topology_edge_connections.py
@@ -1,5 +1,5 @@
 class Rule:
-    id = "311"
+    id = "321"
     description = "Verify edge connections have valid source devices and interfaces"
     severity = "HIGH"
 


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #822


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [X] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [X] other

## Proposed Changes
Changing ID of the rule


## Test Notes
NA


## Cisco Nexus Dashboard Version
NA


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
