### PR TITLE
Gate securityGroupTagMacSegmentation emission on ENABLE_SGT

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2
@@ -1,7 +1,8 @@
 {# Auto-generated NDFC DC VXLAN EVPN Security config data structure for fabric {{ vxlan.fabric.name }} #}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
-  ENABLE_SGT: false
-{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=') %}
+{% set enable_sgt = false %}
+  ENABLE_SGT: {{ enable_sgt | lower }}
+{% if enable_sgt and (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=')) %}
   securityGroupTagMacSegmentation: false
   securityGroupTagMacSegmentation_PREV: false
 {% endif %}


### PR DESCRIPTION
## Related Issue(s)

Fixes #825

## Related Collection Role

* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element

* [x] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes

On NDFC >= 12.5.0 (ND 4.2.x), `dcnm_fabric` create fails for any VXLAN EVPN fabric with a non-IPv6 underlay because the fabric security template emits `securityGroupTagMacSegmentation: false` while `ENABLE_SGT` is `false`. NDFC only accepts `securityGroupTagMacSegmentation` when `ENABLE_SGT == True`:

```
Create pipeline failed at step 'fabric' (dcnm_fabric): The following parameter(value) combination(s) are invalid and need to be reviewed: securityGroupTagMacSegmentation(False) requires ENABLE_SGT == True. ENABLE_SGT valid values: [False, True].
```

The `securityGroupTagMacSegmentation` keys were added in #812 under the pre-existing hardcoded `ENABLE_SGT: false`, gated only by NDFC version. #815 corrected the version-gate threshold to `12.5.0` but did not address the dependency on `ENABLE_SGT`, so on controllers that pass the version gate the field still ships as `false` next to `ENABLE_SGT: false` — an always-invalid pair.

This change makes `ENABLE_SGT` and the `securityGroupTagMacSegmentation` emission share a single source of truth (`enable_sgt`) in `roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/security/dc_vxlan_fabric_security.j2`, and gates the field on `enable_sgt` in addition to the existing version gate. With SGT disabled the field is no longer emitted, so the invalid combination can never be sent; the two keys can no longer disagree.

```jinja
{% set enable_sgt = false %}
  ENABLE_SGT: {{ enable_sgt | lower }}
{% if enable_sgt and (ndfc_version | cisco.nac_dc_vxlan.version_compare('12.5.0', '>=')) %}
  securityGroupTagMacSegmentation: false
  securityGroupTagMacSegmentation_PREV: false
{% endif %}
```

`ENABLE_SGT: false` renders exactly as before, so existing behavior is unchanged for every controller version.

## Test Notes

Rendered the template with an Ansible-equivalent Jinja environment (`version_compare` backed by `packaging`, `trim_blocks=True`) against NDFC `12.5.0.475`, non-IPv6 underlay, SGT not configured:

* Before — emits the rejected pair:
  ```
  ENABLE_SGT: false
  securityGroupTagMacSegmentation: false
  securityGroupTagMacSegmentation_PREV: false
  ```
* After — emits only `ENABLE_SGT: false`; `securityGroupTagMacSegmentation` is absent, so `dcnm_fabric` create is accepted.
* IPv6 underlay — block skipped in both cases (unchanged).
* Guard check with `enable_sgt = true` + NDFC >= 12.5.0 — emits `ENABLE_SGT: true` together with `securityGroupTagMacSegmentation`, i.e. the valid pair NDFC expects.

Validated end-to-end against a live NDFC 12.5.0.475 (ND 4.2.1) controller with this branch installed: `dtc.create` for VXLAN EVPN fabrics on an IPv4 underlay completed successfully (`PLAY RECAP` `failed=0`, `dcnm_fabric` reporting `Create pipeline completed`), and the previous `securityGroupTagMacSegmentation(False) requires ENABLE_SGT == True` rejection no longer occurs. The same fabrics failed create on the same controller before the change.

## Cisco Nexus Dashboard Version

Nexus Dashboard 4.2.1 (build 4.2.1.10) / Fabric Controller (NDFC) 12.5.0.475

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly <!-- N/A: template-only change, no data-model surface added -->
* [ ] Assigned the proper reviewers
