### PR TITLE
Adding missing delete flags to docs/defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ Inside the [example repository](https://github.com/netascode/ansible-dc-vxlan-ex
 
 ```yaml
 # Control Parameters for 'Remove' role tasks in VXLAN EVPN fabric
+edge_connections_delete_mode: false
 interface_delete_mode: false
 inventory_delete_mode: false
 link_fabric_delete_mode: false
 link_vpc_delete_mode: false
 network_delete_mode: false
 policy_delete_mode: false
+tor_pairing_delete_mode: false
 vpc_delete_mode: false
 vrf_delete_mode: false
 
@@ -83,16 +85,19 @@ The following control variables are available in this collection.
 | Variable | Description | Default Value |
 | -------- | ------- | ------- |
 | `force_run_all` | Force all roles in the collection to run | `false` |
+| `edge_connections_delete_mode` | Remove edge_connections state as part of the remove role | `false` |
 | `interface_delete_mode` | Remove interface state as part of the remove role | `false` |
 | `inventory_delete_mode` | Remove inventory state as part of the remove role | `false` |
+| `link_fabric_delete_mode` | Remove fabric link state as part of the remove role | `false` |
 | `link_vpc_delete_mode` | Remove vpc link state as part of the remove role | `false` |
 | `multisite_child_fabric_delete_mode` | Remove child fabric from MSD fabric as part of the remove role | `false` |
 | `multisite_network_delete_mode` | Remove network state as part of the remove role for multisite (MSD) fabrics | `false` |
 | `multisite_vrf_delete_mode` | Remove vrf state as part of the remove role for multisite (MSD) fabrics | `false` |
 | `network_delete_mode` | Remove network state as part of the remove role | `false` |
 | `policy_delete_mode` | Remove policy state as part of the remove role | `false` |
-| `vrf_delete_mode` | Remove vrf state as part of the remove role | `false` |
+| `tor_pairing_delete_mode` | Remove tor pairing state as part of the remove role | `false` |
 | `vpc_delete_mode` | Remove vpc pair state as part of the remove role | `false` |
+| `vrf_delete_mode` | Remove vrf state as part of the remove role | `false` |
 
 These variables are described in more detail in different sections of this document.
 

--- a/roles/common_global/defaults/main.yml
+++ b/roles/common_global/defaults/main.yml
@@ -45,5 +45,5 @@ multisite_vrf_delete_mode: false
 network_delete_mode: false
 policy_delete_mode: false
 tor_pairing_delete_mode: false
-vrf_delete_mode: false
 vpc_delete_mode: false
+vrf_delete_mode: false

--- a/roles/common_global/defaults/main.yml
+++ b/roles/common_global/defaults/main.yml
@@ -34,15 +34,16 @@ force_run_all: false
 stage_remove: false
 
 # Parameters to enable/disable remove role tasks
+edge_connections_delete_mode: false
 interface_delete_mode: false
 inventory_delete_mode: false
 link_fabric_delete_mode: false
 link_vpc_delete_mode: false
-edge_connections_delete_mode: false
 multisite_child_fabric_delete_mode: false
 multisite_network_delete_mode: false
 multisite_vrf_delete_mode: false
 network_delete_mode: false
 policy_delete_mode: false
-vpc_delete_mode: false
+tor_pairing_delete_mode: false
 vrf_delete_mode: false
+vpc_delete_mode: false

--- a/roles/dtc/remove/tasks/common/vpc_peers.yml
+++ b/roles/dtc/remove/tasks/common/vpc_peers.yml
@@ -86,6 +86,6 @@
   ansible.builtin.debug:
     msg:
       - "-------------------------------------------------------------------------------------------------------"
-      - "+ SKIPPING Remove Unmanaged vPC Peering task because vpc_peering_delete_mode flag is set to False     +"
+      - "+ SKIPPING Remove Unmanaged vPC Peering task because vpc_delete_mode flag is set to False     +"
       - "-------------------------------------------------------------------------------------------------------"
   when: not ((vpc_delete_mode is defined) and (vpc_delete_mode is true|bool))


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #829 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [X] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [X] other

## Proposed Changes

- Adding all available control flags for the Remove Role on the README.md
- Adding default for tor_pairing_delete_mode
- Fixing typo on msg when running delete for vpc


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
