### PR TITLE
Remove stale underlay.general.underlay_rp_loopback_id from defaults and examples

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,16 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 .. contents:: ``Release Versions``
 
+Unreleased
+=====================
+
+Modified
+--------
+
+* ``vxlan.underlay.general.underlay_rp_loopback_id`` is no longer supported. Configure the
+  underlay RP loopback under ``vxlan.underlay.multicast.underlay_rp_loopback_id`` instead.
+  Removed the stale key from the bundled defaults and examples.
+
 `0.8.0`_
 =====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,16 +8,6 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 .. contents:: ``Release Versions``
 
-Unreleased
-=====================
-
-Modified
---------
-
-* ``vxlan.underlay.general.underlay_rp_loopback_id`` is no longer supported. Configure the
-  underlay RP loopback under ``vxlan.underlay.multicast.underlay_rp_loopback_id`` instead.
-  Removed the stale key from the bundled defaults and examples.
-
 `0.8.0`_
 =====================
 

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -272,7 +272,6 @@ factory_defaults:
         underlay_routing_loopback_id: 0
         underlay_vtep_loopback_id: 1
         underlay_routing_protocol_tag: UNDERLAY
-        underlay_rp_loopback_id: 254
         intra_fabric_interface_mtu: 9216
         layer2_host_interface_mtu: 9216
         unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_empty_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_empty_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_full_large_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_large_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_ingress_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_ingress_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_asm_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_asm_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_bidir_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_isis_multicast_bidir_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_ingress_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_ingress_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_asm_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_asm_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_bidir_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_ospf_multicast_bidir_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true

--- a/tests/integration/host_vars/examples/fabric_full_small_sha_example/underlay.yaml
+++ b/tests/integration/host_vars/examples/fabric_full_small_sha_example/underlay.yaml
@@ -32,7 +32,6 @@ vxlan:
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
-      underlay_rp_loopback_id: 3
       intra_fabric_interface_mtu: 9216
       layer2_host_interfacde_mtu: 9216
       unshut_host_interfaces: true


### PR DESCRIPTION
## Related Issue(s)

N/A

## Related Collection Role

* [x] cisco.nac_dc_vxlan.validate

## Related Data Model Element

* [x] vxlan.underlay
* [x] defaults.vxlan

## Proposed Changes

`underlay_rp_loopback_id` belongs under `vxlan.underlay.multicast` — that's where the schema defines it and where the fabric templates read it. A stale copy under `vxlan.underlay.general` was still lingering in the bundled defaults and a few example files, doing nothing.

This PR removes those leftover `general` copies. The real ones under `multicast` are left untouched.

- **`roles/validate/files/defaults.yml`** — drop the dead `general` default (the `multicast` one stays).
- **9 integration examples** (`tests/integration/host_vars/examples/*/underlay.yaml`) — drop the same dead `general` line.
- **`CHANGELOG.rst`** — noted under `Unreleased`.

## Test Notes

No behavior change — nothing reads the `general` path (both `dc_vxlan_fabric_replication.j2` and `ebgp_vxlan_fabric_evpn.j2` read `multicast.underlay_rp_loopback_id`). The two `ingress` examples correctly end up with no RP loopback, since ingress replication doesn't use one.

## Cisco Nexus Dashboard Version

N/A

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
