### PR TITLE
Fix ToR pairing lifecycle and MCFG empty-intent removal

### DIFF
--- a/plugins/action/dtc/process_tor_pairing.py
+++ b/plugins/action/dtc/process_tor_pairing.py
@@ -581,6 +581,7 @@ class ActionModule(ActionBase):
         """Build and execute TOR pairing create operations via NDFC POST."""
         result = {
             'failed': False,
+            'changed': False,
             'api_results': [],
             'count': 0,
             'success_count': 0,
@@ -636,20 +637,22 @@ class ActionModule(ActionBase):
 
             if op_result['success']:
                 result['success_count'] += 1
+                result['changed'] = True
             else:
                 result['failure_count'] += 1
                 display.warning(
                     f"TOR Create: Failed to create pairing {pairing_id}: {op_result['msg']}"
                 )
 
-        if result['failure_count'] > 0 and result['success_count'] == 0:
+        if result['failure_count'] > 0:
             result['failed'] = True
-            result['msg'] = f"All {result['failure_count']} TOR pairing create(s) failed"
-        elif result['failure_count'] > 0:
-            result['msg'] = (
-                f"Created {result['success_count']} TOR pairing(s), "
-                f"{result['failure_count']} failed"
-            )
+            if result['success_count'] == 0:
+                result['msg'] = f"All {result['failure_count']} TOR pairing create(s) failed"
+            else:
+                result['msg'] = (
+                    f"Created {result['success_count']} TOR pairing(s), "
+                    f"{result['failure_count']} failed"
+                )
         else:
             result['msg'] = f"Successfully created {result['success_count']} TOR pairing(s)"
 
@@ -659,6 +662,7 @@ class ActionModule(ActionBase):
         """Build and execute TOR pairing remove operations via NDFC DELETE."""
         result = {
             'failed': False,
+            'changed': False,
             'api_results': [],
             'count': 0,
             'success_count': 0,
@@ -726,20 +730,23 @@ class ActionModule(ActionBase):
                     display.v(
                         f"TOR Remove: Pairing {pairing_id} already removed or not found"
                     )
+                else:
+                    result['changed'] = True
             else:
                 result['failure_count'] += 1
                 display.warning(
                     f"TOR Remove: Failed to remove pairing {pairing_id}: {op_result['msg']}"
                 )
 
-        if result['failure_count'] > 0 and result['success_count'] == 0:
+        if result['failure_count'] > 0:
             result['failed'] = True
-            result['msg'] = f"All {result['failure_count']} TOR pairing removal(s) failed"
-        elif result['failure_count'] > 0:
-            result['msg'] = (
-                f"Removed {result['success_count']} TOR pairing(s), "
-                f"{result['failure_count']} failed"
-            )
+            if result['success_count'] == 0:
+                result['msg'] = f"All {result['failure_count']} TOR pairing removal(s) failed"
+            else:
+                result['msg'] = (
+                    f"Removed {result['success_count']} TOR pairing(s), "
+                    f"{result['failure_count']} failed"
+                )
         else:
             result['msg'] = f"Successfully removed {result['success_count']} TOR pairing(s)"
 

--- a/plugins/action/dtc/remove_resources.py
+++ b/plugins/action/dtc/remove_resources.py
@@ -40,6 +40,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import json
+
 from ansible.utils.display import Display
 
 from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.pipeline_base import (
@@ -435,6 +437,50 @@ class ResourceRemover(PipelineRunnerBase):
             f"/fabrics/{self.fabric_name}/{resource_name}"
         )
 
+    def _controller_diff_get(self, resource_name):
+        """Return controller resources from a successful top-down GET."""
+        path = self._controller_diff_path(resource_name)
+        result = self.executor.execute_rest("GET", path)
+
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                f"Controller diff GET for {resource_name} returned an invalid result"
+            )
+
+        response = result.get('response')
+        error = result.get('msg')
+        status = (
+            response if isinstance(response, dict)
+            else error if isinstance(error, dict)
+            else {}
+        )
+        return_code = status.get('RETURN_CODE')
+
+        if result.get('failed') or return_code != 200:
+            detail = error or response or result
+            raise RuntimeError(
+                f"Controller diff GET for {resource_name} failed: "
+                f"RETURN_CODE={return_code}, path={path}, response={detail}"
+            )
+
+        data = response.get('DATA')
+        if isinstance(data, str):
+            try:
+                data = json.loads(data)
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError(
+                    f"Controller diff GET for {resource_name} returned invalid JSON: "
+                    f"path={path}, error={exc}"
+                ) from exc
+
+        if not isinstance(data, list):
+            raise RuntimeError(
+                f"Controller diff GET for {resource_name} returned invalid DATA: "
+                f"path={path}, expected=list, actual={type(data).__name__}"
+            )
+
+        return data
+
     def _get_fabric_id(self):
         """
         Get the numeric fabric ID from NDFC for the current fabric.
@@ -650,26 +696,7 @@ class ResourceRemover(PipelineRunnerBase):
         Returns:
             List of VRF dicts formatted for dcnm_vrf state: deleted.
         """
-        result = self.executor.execute_rest(
-            "GET",
-            self._controller_diff_path('vrfs'),
-        )
-
-        controller_vrfs = []
-        try:
-            response = result.get('response', {})
-            data = response.get('DATA', response)
-            if isinstance(data, str):
-                import json
-                data = json.loads(data)
-            if isinstance(data, list):
-                controller_vrfs = data
-        except (KeyError, TypeError, ValueError):
-            display.warning(
-                f"REMOVE [{self.fabric_name}] Failed to parse VRF response "
-                f"— skipping controller diff for VRFs"
-            )
-            return []
+        controller_vrfs = self._controller_diff_get('vrfs')
 
         # Build data model set of VRF names
         dm_vrf_names = frozenset(
@@ -709,26 +736,7 @@ class ResourceRemover(PipelineRunnerBase):
         Returns:
             List of network dicts formatted for dcnm_network state: deleted.
         """
-        result = self.executor.execute_rest(
-            "GET",
-            self._controller_diff_path('networks'),
-        )
-
-        controller_networks = []
-        try:
-            response = result.get('response', {})
-            data = response.get('DATA', response)
-            if isinstance(data, str):
-                import json
-                data = json.loads(data)
-            if isinstance(data, list):
-                controller_networks = data
-        except (KeyError, TypeError, ValueError):
-            display.warning(
-                f"REMOVE [{self.fabric_name}] Failed to parse network response "
-                f"— skipping controller diff for networks"
-            )
-            return []
+        controller_networks = self._controller_diff_get('networks')
 
         # Build data model set of network names
         dm_net_names = frozenset(

--- a/plugins/action/dtc/remove_resources.py
+++ b/plugins/action/dtc/remove_resources.py
@@ -164,6 +164,7 @@ class ResourceRemover(PipelineRunnerBase):
         resource_entry = self.resource_data.get(resource_name, {})
         default_state = step.get('state')
         full_run_state = step.get('state_full_run')
+        full_run_strategy = step.get('full_run_strategy')
         data_key_full_run = step.get('data_key_full_run', 'data')
         full_run_override_key = step.get('data_key_overridden')
 
@@ -187,12 +188,28 @@ class ResourceRemover(PipelineRunnerBase):
                 removed = diff.get('removed', [])
                 if removed:
                     return (removed, default_state)
+
+            # An explicit empty multisite list means remove every live item.
+            # Deferred overlay rendering has no resource diff to supply in
+            # this case, so discover the deletion set from the controller.
+            overlay = (
+                self.data_model.get('vxlan', {})
+                .get('multisite', {})
+                .get('overlay', {})
+            )
+            if (
+                full_run_strategy == 'controller_diff'
+                and self.fabric_type in ('MSD', 'MCFG')
+                and resource_name in overlay
+                and overlay.get(resource_name) == []
+            ):
+                method = getattr(self, f"_controller_diff_{resource_name}", None)
+                if method is not None:
+                    return (method([]), default_state)
             return ([], default_state)
 
         # Full run with controller_diff strategy: query NDFC, diff, return
         # only items on the controller that are absent from the data model.
-        full_run_strategy = step.get('full_run_strategy')
-
         if full_run_strategy == 'controller_diff':
             method_name = f"_controller_diff_{resource_name}"
             method = getattr(self, method_name, None)
@@ -405,6 +422,18 @@ class ResourceRemover(PipelineRunnerBase):
     # ══════════════════════════════════════════════════════════════════════════
     # Controller Diff — Query NDFC, diff against data model, return deletions
     # ══════════════════════════════════════════════════════════════════════════
+
+    def _controller_diff_path(self, resource_name):
+        """Return the live top-down resource path for the current parent type."""
+        if self.fabric_type == 'MCFG':
+            return (
+                "/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down"
+                f"/fabrics/{self.fabric_name}/{resource_name}"
+            )
+        return (
+            "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2"
+            f"/fabrics/{self.fabric_name}/{resource_name}"
+        )
 
     def _get_fabric_id(self):
         """
@@ -623,8 +652,7 @@ class ResourceRemover(PipelineRunnerBase):
         """
         result = self.executor.execute_rest(
             "GET",
-            f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2"
-            f"/fabrics/{self.fabric_name}/vrfs",
+            self._controller_diff_path('vrfs'),
         )
 
         controller_vrfs = []
@@ -683,8 +711,7 @@ class ResourceRemover(PipelineRunnerBase):
         """
         result = self.executor.execute_rest(
             "GET",
-            f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/v2"
-            f"/fabrics/{self.fabric_name}/networks",
+            self._controller_diff_path('networks'),
         )
 
         controller_networks = []

--- a/plugins/action/dtc/remove_resources.py
+++ b/plugins/action/dtc/remove_resources.py
@@ -199,7 +199,7 @@ class ResourceRemover(PipelineRunnerBase):
             )
             if (
                 full_run_strategy == 'controller_diff'
-                and self.fabric_type in ('MSD', 'MCFG')
+                and self.fabric_type == 'MCFG'
                 and resource_name in overlay
                 and overlay.get(resource_name) == []
             ):

--- a/plugins/plugin_utils/pipeline_base.py
+++ b/plugins/plugin_utils/pipeline_base.py
@@ -856,7 +856,7 @@ class PipelineRunnerBase(ABC):
                 f"{len(items)} ToR pairing(s)"
             )
 
-            return self.executor.execute_plugin(
+            result = self.executor.execute_plugin(
                 module_name="cisco.nac_dc_vxlan.dtc.process_tor_pairing",
                 module_args={
                     "operation": self.OPERATION,
@@ -880,7 +880,7 @@ class PipelineRunnerBase(ABC):
                 f"{self.OPERATION}ing ToR pairings"
             )
 
-            return self.executor.execute_plugin(
+            result = self.executor.execute_plugin(
                 module_name="cisco.nac_dc_vxlan.dtc.process_tor_pairing",
                 module_args={
                     "operation": self.OPERATION,
@@ -889,6 +889,27 @@ class PipelineRunnerBase(ABC):
                     "current_pairings": tor_pairing_data if tor_pairing_data else [],
                 },
             )
+
+        # A partially successful operation must still be config-saved before
+        # the failure stops the pipeline. Fully successful operations use the
+        # normal tor_config_save step through runtime_change_refs.
+        if result.get('failed') and result.get('changed'):
+            display.warning(
+                f"{op_label} [{self.fabric_name}] ToR pairing partially succeeded; "
+                "running config-save before reporting the failure"
+            )
+            config_save_result = self._config_save(
+                'tor_config_save', step
+            )
+            result['config_save_result'] = config_save_result
+            if config_save_result.get('failed'):
+                result['msg'] = (
+                    f"{result.get('msg', 'ToR pairing partially failed')}; "
+                    "config-save also failed: "
+                    f"{config_save_result.get('msg', 'unknown error')}"
+                )
+
+        return result
 
     def _unmanaged_policy(self, resource_name, step):
         """

--- a/plugins/plugin_utils/registry_loader.py
+++ b/plugins/plugin_utils/registry_loader.py
@@ -88,6 +88,7 @@ KNOWN_PIPELINE_FIELDS = {
     'state_full_run',
     'full_run_strategy',
     'data_key_full_run',
+    'runtime_change_refs',
     'change_flag_guard',
     'data_model_guard',
     'delete_mode_guard',
@@ -96,6 +97,7 @@ KNOWN_PIPELINE_FIELDS = {
     'skip_diff',
     'deploy',
     'save',
+    'skip_validation',
     'tag',
 }
 

--- a/resources/remove_resources.yml
+++ b/resources/remove_resources.yml
@@ -438,7 +438,7 @@ remove_resources:
     - resource_name: networks
       module: dcnm_network
       state: deleted
-      full_run_strategy: overridden
+      full_run_strategy: controller_diff
       change_flag_guard: changes_detected_networks
       delete_mode_guard: multisite_network_delete_mode
       tag: rr_manage_networks
@@ -446,7 +446,7 @@ remove_resources:
     - resource_name: vrfs
       module: dcnm_vrf
       state: deleted
-      full_run_strategy: overridden
+      full_run_strategy: controller_diff
       change_flag_guard: changes_detected_vrfs
       delete_mode_guard: multisite_vrf_delete_mode
       tag: rr_manage_vrfs
@@ -454,7 +454,6 @@ remove_resources:
     - resource_name: prepare_child_fabrics_data
       module: _prepare_child_fabrics_data
       state: null
-      data_model_guard: vxlan.multisite.child_fabrics
       change_flag_guard: null
       tag: rr_manage_fabric
 

--- a/resources/remove_resources.yml
+++ b/resources/remove_resources.yml
@@ -150,6 +150,22 @@ remove_resources:
       delete_mode_guard: link_fabric_delete_mode
       tag: rr_manage_links
 
+    # ToR pairing — uses process_tor_pairing plugin (shared internal method)
+    - resource_name: tor_pairing
+      module: _tor_pairing
+      state: null
+      change_flag_guard: changes_detected_tor_pairing
+      delete_mode_guard: tor_pairing_delete_mode
+      tag: rr_manage_tor_pairing
+
+    - resource_name: tor_config_save
+      module: _config_save
+      state: null
+      change_flag_guard: null
+      runtime_change_refs:
+        - tor_pairing
+      tag: rr_manage_tor_pairing
+
     # vPC peers — uses dcnm_vpc_pair with src_fabric (not dcnm_links with fabric)
     - resource_name: vpc_peering
       module: dcnm_vpc_pair
@@ -160,13 +176,13 @@ remove_resources:
       fabric_param: src_fabric
       tag: rr_manage_vpc_peers
 
-    # ToR pairing — uses process_tor_pairing plugin (shared internal method)
-    - resource_name: tor_pairing
-      module: _tor_pairing
+    - resource_name: vpc_config_save
+      module: _config_save
       state: null
-      change_flag_guard: changes_detected_tor_pairing
-      delete_mode_guard: tor_pairing_delete_mode
-      tag: rr_manage_tor_pairing
+      change_flag_guard: null
+      runtime_change_refs:
+        - vpc_peering
+      tag: rr_manage_vpc_peers
 
     # Switches always use overridden (no diff_run branching)
     - resource_name: inventory_no_bootstrap
@@ -218,6 +234,22 @@ remove_resources:
       skip_if_child_fabric: true
       tag: rr_manage_vrfs
 
+    # ToR pairing — uses process_tor_pairing plugin (shared internal method)
+    - resource_name: tor_pairing
+      module: _tor_pairing
+      state: null
+      change_flag_guard: changes_detected_tor_pairing
+      delete_mode_guard: tor_pairing_delete_mode
+      tag: rr_manage_tor_pairing
+
+    - resource_name: tor_config_save
+      module: _config_save
+      state: null
+      change_flag_guard: null
+      runtime_change_refs:
+        - tor_pairing
+      tag: rr_manage_tor_pairing
+
     # vPC peers — uses dcnm_vpc_pair with src_fabric (not dcnm_links with fabric)
     - resource_name: vpc_peering
       module: dcnm_vpc_pair
@@ -228,13 +260,13 @@ remove_resources:
       fabric_param: src_fabric
       tag: rr_manage_vpc_peers
 
-    # ToR pairing — uses process_tor_pairing plugin (shared internal method)
-    - resource_name: tor_pairing
-      module: _tor_pairing
+    - resource_name: vpc_config_save
+      module: _config_save
       state: null
-      change_flag_guard: changes_detected_tor_pairing
-      delete_mode_guard: tor_pairing_delete_mode
-      tag: rr_manage_tor_pairing
+      change_flag_guard: null
+      runtime_change_refs:
+        - vpc_peering
+      tag: rr_manage_vpc_peers
 
     # Switches always use overridden (no diff_run branching)
     - resource_name: inventory_no_bootstrap
@@ -318,6 +350,14 @@ remove_resources:
       change_flag_guard: changes_detected_vpc_peering
       delete_mode_guard: vpc_delete_mode
       fabric_param: src_fabric
+      tag: rr_manage_vpc_peers
+
+    - resource_name: vpc_config_save
+      module: _config_save
+      state: null
+      change_flag_guard: null
+      runtime_change_refs:
+        - vpc_peering
       tag: rr_manage_vpc_peers
 
     - resource_name: inventory_no_bootstrap

--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -61,7 +61,7 @@
   when: >
     change_flags.changes_detected_any or
     ((force_run_all | default(false) | bool) and
-    (data_model_extended.vxlan.fabric.type in ['MSD', 'MCFG']))
+    (data_model_extended.vxlan.fabric.type == 'MCFG'))
   tags: "{{ nac_tags.remove }}"
 
 - name: Display Remove Resources Summary

--- a/roles/dtc/remove/tasks/main.yml
+++ b/roles/dtc/remove/tasks/main.yml
@@ -58,7 +58,10 @@
     run_map_diff_run: "{{ run_map_read_result.diff_run }}"
     force_run_all: "{{ force_run_all | default(false) }}"
   register: remove_result
-  when: change_flags.changes_detected_any
+  when: >
+    change_flags.changes_detected_any or
+    ((force_run_all | default(false) | bool) and
+    (data_model_extended.vxlan.fabric.type in ['MSD', 'MCFG']))
   tags: "{{ nac_tags.remove }}"
 
 - name: Display Remove Resources Summary


### PR DESCRIPTION
## Related Issue(s)

Fixes #834

## Related Collection Role

* [ ] cisco.nac_dc_vxlan.validate
* [x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Elements

* [x] `vxlan.topology`
* [x] `vxlan.multisite.child_fabrics`
* [x] `vxlan.multisite.overlay.networks`
* [x] `vxlan.multisite.overlay.vrfs`

## Summary

This PR corrects ToR pairing create/remove result handling and dependency ordering. It also fixes MCFG removal when networks, VRFs, and child fabrics are removed from the desired data model.

### Major Updates

* Report successful ToR create and remove mutations as changed.
* Fail a ToR batch when any requested operation fails.
* Config-save successful mutations before reporting a partial batch failure.
* Config-save successful ToR and vPC removals.
* Remove ToR pairings before their dependent vPC pairings.
* Discover MCFG network and VRF removals from live controller state.
* Treat explicit empty MCFG network, VRF, and child-fabric lists as authoritative removal intent.
* Allow forced MCFG reconciliation to repair stale controller state even when local change flags are clear.
* Preserve existing MSD behavior and API-call patterns.
* Coordinate with the companion `cisco.dcnm.dcnm_network` ToR-serial removal fix.

## Proposed Changes

### ToR Pairing Lifecycle

* Report successful ToR create and remove operations as `changed=true`.
* Return `failed=true` when any requested operation fails, including partial batches.
* Preserve `changed=true` when a partial batch already modified controller state.
* Config-save successful ToR mutations before returning a partial failure.
* Add normal config-save steps after successful ToR and vPC removals.
* Remove ToR pairings before vPC pairings for VXLAN and eBGP VXLAN fabrics.
* Apply vPC removal config-save behavior to VXLAN, eBGP VXLAN, and External fabrics.
* Register `runtime_change_refs` and `skip_validation` as valid pipeline fields.

### MCFG Empty-Intent Removal

* Replace empty `overridden` payload handling with live controller-diff discovery for MCFG networks and VRFs.
* Use MCFG OneManage top-down APIs when discovering parent networks and VRFs.
* Treat explicit empty multisite network and VRF lists as authoritative removal intent in full and diff runs.
* Prepare child-fabric removal data even when desired child-fabric membership is empty.
* Allow `force_run_all` to enter MCFG removal when local change flags are clear.
* Preserve existing multisite delete-mode safety guards.
* Keep forced-entry and explicit-empty behavior scoped to MCFG so MSD behavior and API-call profiles remain unchanged.
* Remove resources in dependency order:

```text
networks -> VRFs -> child fabrics
```

### Related Network ToR Serial Handling

During live network-removal validation, a separate issue was found in `cisco.dcnm.dcnm_network`: detach requests included ToR-port data, but the subsequent config-deploy target set contained only regular leaf serials. Omitted ToR switches could remain pending and prevent the network from reaching a deletable state.

The companion module fix:

* Resolves ToR logical names encoded in existing `torPorts` data to inventory serial numbers.
* Adds those serials to the existing undeploy/config-deploy target set.
* Applies only to detach and undeploy processing; normal create and attachment deployment remain unchanged.
* Deduplicates serials through existing sets.
* Introduces no additional discovery, attachment, status, or deployment API calls.

This companion fix is distinct from the ToR pairing lifecycle changes in PR #835. PR #835 changes NaC resource orchestration; ToR serial resolution belongs to `cisco.dcnm.dcnm_network`.

## Behavior Details

### Partial ToR Batch Handling

Each ToR pairing is sent to ND as a separate REST request, so a batch is not atomic.

```text
Pairing A: succeeds
Pairing B: succeeds
Pairing C: fails
```

ND has already accepted A and B, so the result must report both facts:

```text
changed = true
failed  = true
```

The task reports `changed=true` because controller state changed and `failed=true` because the complete desired state was not reached. Because a failed pipeline step normally prevents the following config-save step, a partially successful ToR batch now config-saves successful mutations before returning the original failure. Config-save does not hide or clear that failure.

| Batch result | `changed` | `failed` | Config-save behavior |
|---|---:|---:|---|
| All operations succeed | true | false | Normal following pipeline step |
| Some succeed and some fail | true | true | Runs before reporting failure |
| All operations fail | false | true | Not required |
| Nothing needs changing | false | false | Not required |
| Removal is already absent | false | false | Not required |

### ToR and vPC Removal Ordering

ToR pairing depends on the underlying leaf and ToR vPC relationships. Creation establishes vPC pairing first:

```text
vPC pairing -> config-save -> ToR pairing -> config-save
```

Removal reverses the dependency order:

```text
ToR pairing -> config-save -> vPC pairing -> config-save
```

This prevents config-save from processing an intermediate state where a ToR association remains after its dependent vPC relationship has been removed.

### MCFG Stale-State Recovery

Previously, an empty desired MCFG list could leave controller resources untouched. Once the empty model was saved locally, later runs could also skip removal because no local changes were detected.

MCFG removal now queries live parent state through:

```text
/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/fabrics/{fabric}/networks
/onemanage/appcenter/cisco/ndfc/api/v1/onemanage/top-down/fabrics/{fabric}/vrfs
```

Resources present on the controller but absent from the desired model are sent to `dcnm_network` or `dcnm_vrf` with `state: deleted`. Child-fabric preparation also queries current membership when desired membership is empty.

### Practical Example: Explicit Empty Networks and VRFs

Assume an MCFG parent contains:

```text
VRFs: Tenant-A, Tenant-B
Networks: Web, Database
```

The desired model is intentionally changed to:

```yaml
vxlan:
  multisite:
    overlay:
      vrfs: []
      networks: []
```

The empty lists mean the desired resource count is zero. The controller diff calculates:

```text
Controller VRFs: Tenant-A, Tenant-B
Desired VRFs: none
VRFs to delete: Tenant-A, Tenant-B

Controller networks: Web, Database
Desired networks: none
Networks to delete: Web, Database
```

It then supplies explicit deletion data:

```yaml
state: deleted
config:
  - vrf_name: Tenant-A
  - vrf_name: Tenant-B
```

```yaml
state: deleted
config:
  - net_name: Web
  - net_name: Database
```

Discovery uses MCFG OneManage endpoints. The explicit-empty fallback is scoped to MCFG so a diff run can recover when deferred rendering produces no removal records without changing MSD behavior.

### Practical Example: `force_run_all`

Consider this sequence:

1. The controller contains `Tenant-A` and `Web`.
2. The desired model is changed to empty lists.
3. Removal fails before controller cleanup finishes.
4. The local golden model is nevertheless updated to empty.
5. The controller still contains `Tenant-A` and `Web`.

The next local comparison reports:

```text
Previous local model: vrfs=[], networks=[]
Current local model:  vrfs=[], networks=[]
changes_detected_any: false
```

Without forced reconciliation, removal remains skipped. With `force_run_all: true`, MCFG enters the removal pipeline despite clear local flags:

```text
Local change detected: no
Forced reconciliation: yes
Controller VRFs found: Tenant-A
Controller networks found: Web
Result: both removed
```

| Situation | `force_run_all` | Local changes | Result |
|---|---:|---:|---|
| Lists changed from populated to empty | false | true | Pipeline runs and deletes resources |
| Previous removal failed and local model is empty | false | false | Pipeline remains skipped |
| Previous removal failed and local model is empty | true | false | Pipeline runs and repairs controller drift |
| Local and controller state are both empty | true | false | Pipeline runs, finds nothing, and returns `changed=false` |

With `force_run_all: true` and multisite delete-mode flags enabled, MCFG continuously reconciles against the data model. A VRF or network created manually in NDFC but absent from the model can be discovered and removed even when no local file changed.

These forced-entry and explicit-empty changes are intentionally scoped to MCFG. MSD keeps its existing removal behavior and API-call profile.

### Network Removal With ToR Attachments

NDFC represents ToR attachment data as values such as:

```text
nac-msd-fabric1-tor1(Ethernet1/8,Ethernet1/9)
nac-msd-fabric1-tor2(Ethernet1/8,Ethernet1/9)
```

Regular attachment records contain parent leaf serials. ToR names must be resolved through already-fetched fabric inventory.

Before the companion fix:

```text
detach attachment -> config-deploy leaves only -> ToR state remains pending
```

With the companion fix:

```text
detach attachment -> config-deploy leaves + ToRs -> bulk-delete network
```

The target is submitted through one config-deploy request. Serial-set deduplication includes each switch only once even when many networks use it.

## Validation

### Nexus Dashboard Version Coverage

| Nexus Dashboard version | MSD | MCFG |
|---|---|---|
| 4.1 | PASS | PASS |
| 4.2 | PASS | PASS |

### Static Validation

* Python syntax validation passed.
* YAML parsing passed.
* Ansible `--syntax-check` passed for `role_remove`.
* `git diff --check` passed.
* Registry validation completed with no errors.
* No unit tests were added in this change.

### Live MCFG Removal

| Item | Value |
|---|---|
| Nexus Dashboard | 4.1.1g |
| NDFC | 12.4.1.321 |
| Parent fabric | `nac-mcfg-parent` |
| Fabric type | MCFG / multicluster parent |
| Command | `ansible-playbook -i inventory.yaml vxlan.yaml --limit nac-mcfg-parent --tags role_remove` |

The desired model contained empty network, VRF, and child-fabric lists while the controller still contained:

| Resource | Discovered | Removed | Result |
|---|---:|---:|---|
| Networks | 3 | 3 | PASS |
| VRFs | 6 | 6 | PASS |
| Child-fabric associations | 3 | 3 | PASS |

The first run completed with `failed=0` and removed resources in dependency order. Network and VRF modules used explicit `state: deleted` operations generated from the live controller diff.

An identical second run reported:

| Resource | Controller count | Removal result |
|---|---:|---|
| Networks | 0 | No diff |
| VRFs | 0 | No diff |
| Child-fabric associations | 0 | No change |

The second removal pipeline returned `changed=false`. Read-only API verification confirmed that the MCFG parent had `members: []` and the former children were standalone with no parent association.

### Live MSD Network Removal With ToR Serial Targeting

The companion module was validated against `nac-msd-parent` with ten deployed networks attached to five regular leaf switches and two ToR switches.

| Item | Result |
|---|---|
| Networks requested for deletion | 10 |
| Unique regular switch serials | 5 |
| Unique ToR serials | 2 |
| ToR1 serial | `9KAF3PEEM69` |
| ToR2 serial | `94AUUGP0PGY` |
| Total config-deploy target set | 7 unique serials |
| Config-deploy API calls | 1 |
| Bulk-delete result | All 10 networks successful |
| Completion time | 52 seconds |
| Final parent-network query | `DATA: []` |

The config-deploy request included both ToR serials:

```text
.../config-deploy/91UQYYX48UZ,9GHOBG795B0,9KAF3PEEM69,
94AUUGP0PGY,9COAFSU2I11,9COFX2TYGHA,95532ROUIQA
```

The earlier path omitted the two ToR serials and timed out after approximately 555 seconds while networks remained pending. With the companion fix, NDFC completed config-deploy and returned all ten names in the bulk-delete success list.

The companion `dcnm_network` test file passed all 59 unit tests. Focused coverage confirms detach includes ToR serials while normal create/attach does not expand its target set. These tests and the module implementation are not part of PR #835 itself.

## Checklist

* [x] Latest commit is based on `develop`
* [x] Documentation impact reviewed; no documentation changes required
* [ ] Assigned the proper reviewers
