### PR TITLE
Release 0.8.1 Prep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,9 +26,9 @@ Modified
 
 * With release 0.8.1, the ptp.vlan_id key has been removed from the data model for vxlan.global.ebgp, vxlan.global.external, and vxlan.multisite.isn as the PTP VLAN ID is not supported for these fabric types.
 * With release 0.8.1, NaC VXLAN supports the following eBGP fabric scenarios with Nexus Dashboard 4.2 or later releases (See https://netascode.cisco.com for more info):
-•	Multi-AS Mode with ASN Auto Allocation
-•	Multi-AS Mode with Allow Same ASN On Leafs
-•	Same-Tier-AS Mode
+    •	Multi-AS Mode with ASN Auto Allocation
+    •	Multi-AS Mode with Allow Same ASN On Leafs
+    •	Same-Tier-AS Mode
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,41 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 .. contents:: ``Release Versions``
 
+`0.8.1`_
+=====================
+
+**Release Date:** ``2026-07-15``
+
+Added
+-----
+
+* ND 4.2.1 support
+
+  * Added additional fabric security options for ND 4.2.X (``securityGroupTagMacSegmentation`` and related fields)
+  * Gated ``securityGroupTagMacSegmentation`` emission on ``ENABLE_SGT`` to prevent unintended API payloads
+  * Gated ``securityGroupTagMacSegmentation`` on ``ndfc_version >= 12.5.0`` (ND 4.2.1+) to ensure backward compatibility
+
+* Added BGP ASN auto allocation support
+* Added greenfield cleanup option
+* Added bootstrap cross-reference validation rules
+
+Fixed
+-----
+
+* https://github.com/netascode/ansible-dc-vxlan/pull/835
+
+  * Fixed ToR pairing create and remove handling — partial failures now correctly set ``failed`` state
+  * Fixed MCFG empty intent removal being incorrectly scoped
+  * Added ``changed`` tracking to ToR pairing create/remove operations
+
+* Fix duplicate hostname issue in DTC pipeline (#828)
+* Fixed edge connections not being removed during ``role_remove`` (#824)
+* Fixed config-save HTTP 500 no longer aborting the create pipeline — execution continues (#819)
+* Fixed indentation in iBGP spine and leaf templates (#759)
+* Removed stale ``underlay.general.underlay_rp_loopback_id`` key from defaults and examples — the correct path is ``vxlan.underlay.multicast.underlay_rp_loopback_id`` (#833)
+* Added missing ``delete_flag`` / ``delete_mode`` entries to docs and defaults (#830)
+* Fixed rule name and ID inconsistencies in validation rule set (#823)
+
 `0.8.0`_
 =====================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,12 +16,7 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Added
 -----
 
-* ND 4.2.1 support
-
-  * Added additional fabric security options for ND 4.2.X (``securityGroupTagMacSegmentation`` and related fields)
-  * Gated ``securityGroupTagMacSegmentation`` emission on ``ENABLE_SGT`` to prevent unintended API payloads
-  * Gated ``securityGroupTagMacSegmentation`` on ``ndfc_version >= 12.5.0`` (ND 4.2.1+) to ensure backward compatibility
-
+* Added support for ND 4.2.1
 * Added BGP ASN auto allocation support
 * Added greenfield cleanup option
 * Added bootstrap cross-reference validation rules
@@ -29,19 +24,18 @@ Added
 Fixed
 -----
 
-* https://github.com/netascode/ansible-dc-vxlan/pull/835
-
-  * Fixed ToR pairing create and remove handling — partial failures now correctly set ``failed`` state
-  * Fixed MCFG empty intent removal being incorrectly scoped
-  * Added ``changed`` tracking to ToR pairing create/remove operations
-
-* Fix duplicate hostname issue in DTC pipeline (#828)
-* Fixed edge connections not being removed during ``role_remove`` (#824)
-* Fixed config-save HTTP 500 no longer aborting the create pipeline — execution continues (#819)
-* Fixed indentation in iBGP spine and leaf templates (#759)
-* Removed stale ``underlay.general.underlay_rp_loopback_id`` key from defaults and examples — the correct path is ``vxlan.underlay.multicast.underlay_rp_loopback_id`` (#833)
-* Added missing ``delete_flag`` / ``delete_mode`` entries to docs and defaults (#830)
-* Fixed rule name and ID inconsistencies in validation rule set (#823)
+* https://github.com/netascode/ansible-dc-vxlan/issues/688
+* https://github.com/netascode/ansible-dc-vxlan/issues/727
+* https://github.com/netascode/ansible-dc-vxlan/issues/749
+* https://github.com/netascode/ansible-dc-vxlan/issues/758
+* https://github.com/netascode/ansible-dc-vxlan/issues/799
+* https://github.com/netascode/ansible-dc-vxlan/issues/810
+* https://github.com/netascode/ansible-dc-vxlan/issues/813
+* https://github.com/netascode/ansible-dc-vxlan/issues/814
+* https://github.com/netascode/ansible-dc-vxlan/issues/822
+* https://github.com/netascode/ansible-dc-vxlan/issues/825
+* https://github.com/netascode/ansible-dc-vxlan/issues/829
+* https://github.com/netascode/ansible-dc-vxlan/issues/834
 
 `0.8.0`_
 =====================
@@ -603,6 +597,7 @@ The following roles have been added to the collection:
 
 This version of the collection includes support for an IPv4 Underlay only.  Support for IPv6 Underlay will be available in the next release.
 
+.. _0.8.1: https://github.com/netascode/ansible-dc-vxlan/compare/0.8.0...0.8.1
 .. _0.8.0: https://github.com/netascode/ansible-dc-vxlan/compare/0.7.2...0.8.0
 .. _0.7.2: https://github.com/netascode/ansible-dc-vxlan/compare/0.7.1...0.7.2
 .. _0.7.1: https://github.com/netascode/ansible-dc-vxlan/compare/0.7.0...0.7.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,15 @@ Added
 * Added greenfield cleanup option
 * Added bootstrap cross-reference validation rules
 
+Modified
+--------
+
+* With release 0.8.1, the ptp.vlan_id key has been removed from the data model for vxlan.global.ebgp, vxlan.global.external, and vxlan.multisite.isn as the PTP VLAN ID is not supported for these fabric types.
+* With release 0.8.1, NaC VXLAN supports the following eBGP fabric scenarios with Nexus Dashboard 4.2 or later releases (See https://netascode.cisco.com for more info):
+•	Multi-AS Mode with ASN Auto Allocation
+•	Multi-AS Mode with Allow Same ASN On Leafs
+•	Same-Tier-AS Mode
+
 Fixed
 -----
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: nac_dc_vxlan
-version: 0.8.0-dev
+version: 0.8.1-dev
 readme: README.md
 authors:
   - Charly Coueffe <ccoueffe>
@@ -32,5 +32,5 @@ tags: [cisco, dc, nd, ndfc, nxos, networking, vxlan, evpn, nac, sac]
 
 dependencies:
   "ansible.netcommon": ">=4.1.0"
-  "cisco.dcnm": ">=3.12.0"
+  "cisco.dcnm": ">=3.12.1"
   "community.general": ">=8.5.0"


### PR DESCRIPTION
## Release 0.8.1 Prep

Updates `galaxy.yml` and `CHANGELOG.rst` for the 0.8.1 release.

### Changes

- `galaxy.yml`: version bumped to `0.8.1-dev`, `cisco.dcnm` minimum bumped to `>=3.12.1`
- `CHANGELOG.rst`: Added 0.8.1 release section

### What's in 0.8.1

**Added**
- ND 4.2.1 support (fabric security options, SGT gating, ndfc_version guards)
- BGP ASN auto allocation
- Greenfield cleanup option
- Bootstrap cross-reference validation rules

**Fixed**
- #835: ToR pairing create/remove handling (partial failures, MCFG empty intent scoping, `changed` tracking)
- #828: Duplicate hostname issue in DTC pipeline
- #824: Edge connections not removed during `role_remove`
- #819: Config-save HTTP 500 no longer aborts create pipeline
- #833: Stale `underlay.general.underlay_rp_loopback_id` removed from defaults/examples
- #830: Missing `delete_flag`/`delete_mode` in docs and defaults
- #823: Rule name/ID inconsistencies in validation rule set
- #759: iBGP spine and leaf template indentation