### PR TITLE
Process ToR pairing removals when desired intent is empty

### DIFF
--- a/plugins/plugin_utils/pipeline_base.py
+++ b/plugins/plugin_utils/pipeline_base.py
@@ -833,11 +833,16 @@ class PipelineRunnerBase(ABC):
         resource_entry = self.resource_data.get('tor_pairing', {})
         tor_pairing_data = resource_entry.get('module_data', resource_entry.get('data', []))
 
-        # For create: skip if no pairing data at all
-        # For remove: still need to proceed when diff_run is disabled (NDFC may have stale pairings)
-        if not tor_pairing_data:
-            if self.OPERATION == 'create' or (self.run_map_diff_run and not self.force_run_all):
-                return {'failed': False, 'msg': 'No ToR pairing data — skipped'}
+        # For create: skip if no pairing data at all — diff.updated can't
+        # contain anything to add when the desired data model is empty.
+        # For remove: never skip here. An empty desired list is the normal
+        # representation of "this pairing existed before and must be removed
+        # now"; the real work lives in diff.removed (diff-run branch below)
+        # or is discovered from NDFC (full-run/discovery branch below).
+        # Skipping early would silently drop pending removals and leave
+        # stale ToR pairings in NDFC (see: fabric-deletion stale-ToR incident).
+        if not tor_pairing_data and self.OPERATION == 'create':
+            return {'failed': False, 'msg': 'No ToR pairing data — skipped'}
 
         if self.run_map_diff_run and not self.force_run_all:
             # Diff run active — items pre-computed by build_resource_data (direct mode)


### PR DESCRIPTION
## Related Issue(s)
Fixes #841

## Related Collection Role
* [ ] cisco.nac_dc_vxlan.validate
* [ ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
* [ ] vxlan.fabric
* [ ] vxlan.global
* [x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes

This is a small, isolated fix to the empty-data guard in _tor_pairing()
(plugins/plugin_utils/pipeline_base.py): 15 lines changed
(10 insertions, 5 deletions).

Before this fix, _tor_pairing() returned early whenever the desired
tor_pairing data was empty — for both create and remove, whenever diff-run
mode was active. For remove, that meant it returned before ever looking at
resource_data['tor_pairing']['diff']['removed'], silently dropping any
pending unpair operation.

Now, skipping on empty data only applies to create, where it's still
correct (nothing declared means nothing to add). For remove, the method
always falls through to the existing diff-run / discovery-mode branches,
which already read diff.removed correctly or query NDFC directly, and
already return a clean "nothing to remove" result when diff.removed is
empty too. Nothing else in _tor_pairing() changes.

## Test Notes

I tested this with a 12-case local mock harness (isolated calls to
_tor_pairing(), covering create/remove, empty/non-empty desired data,
diff-run/discovery mode, the delete-mode guard, partial/total failure, and
idempotent no-ops — plus one full run_pipeline() integration test that
reproduces the reported scenario end to end), and a negative-regression
check: reverting this change breaks 6 of the 12 cases, and restoring it
brings all 12 back to passing.

I also validated this against a live Jenkins run (NDFC 12.4.1.321 / Nexus
Dashboard 4.1.1g, virtual N9K-C9300v, NX-OS 10.6(2)). With this fix,
_tor_pairing() actually reaches the real DELETE request against NDFC for
the stale pairing in diff.removed — confirming the early-return is fixed.
NDFC rejected that specific DELETE with HTTP 400 because the ToR switch
still had network deployments attached
("Switches [...] have existing network deployments"). That's expected: it
shows the unpair is now actually being attempted instead of silently
skipped. It doesn't mean a full MCFG removal succeeds end to end yet — the
network/VRF detachment issue is a separate, independent defect (MCFG
multisite overlay empty-intent removal), tracked separately, and outside
the scope of this PR.

## Cisco Nexus Dashboard Version

4.1.1g (NDFC 12.4.1.321)

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
