### PR TITLE
Added discovery cred support for external and ISN fabrics

### DIFF
--- a/roles/dtc/common/templates/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/dc_external_fabric/dc_external_fabric_inventory.j2
@@ -27,6 +27,10 @@
       hostname: {{ switch['name'] }}
       model: {{ pdata['model'] }}
       version: {{ pdata['version'] }}
+{% if switch['poap'].discovery_creds is defined and switch['poap'].discovery_creds %}
+      discovery_username: PLACE_HOLDER_USERNAME
+      discovery_password: PLACE_HOLDER_PASSWORD
+{% endif %}
       config_data:
         modulesModel: {{ pdata['modulesModel'] }}
         gateway: {{ pdata['gateway'] }}
@@ -42,6 +46,10 @@
     - preprovision_serial: {{ switch['poap']['preprovision']['serial_number'] }}
       model: {{  switch['poap']['preprovision']['model'] }}
       version: {{ switch['poap']['preprovision']['version']  }}
+{% if switch['poap'].discovery_creds is defined and switch['poap'].discovery_creds %}
+      discovery_username: PLACE_HOLDER_USERNAME
+      discovery_password: PLACE_HOLDER_PASSWORD
+{% endif %}
       config_data:
         modulesModel: {{ switch['poap']['preprovision']['modulesModel'] }}
         gateway: {{ switch['management']['default_gateway_v4'] | ansible.utils.ipaddr('address') }}/{{ switch['management']['subnet_mask_ipv4'] }}

--- a/roles/dtc/common/templates/ndfc_inventory/isn_fabric/isn_fabric_inventory.j2
+++ b/roles/dtc/common/templates/ndfc_inventory/isn_fabric/isn_fabric_inventory.j2
@@ -26,6 +26,10 @@
       hostname: {{ switch['name'] }}
       model: {{ pdata['model'] }}
       version: {{ pdata['version'] }}
+{% if switch['poap'].discovery_creds is defined and switch['poap'].discovery_creds %}
+      discovery_username: PLACE_HOLDER_USERNAME
+      discovery_password: PLACE_HOLDER_PASSWORD
+{% endif %}
       config_data:
         modulesModel: {{ pdata['modulesModel'] }}
         gateway: {{ pdata['gateway'] }}
@@ -42,6 +46,10 @@
     - preprovision_serial: {{ switch['poap']['preprovision']['serial_number'] }}
       model: {{  switch['poap']['preprovision']['model'] }}
       version: {{ switch['poap']['preprovision']['version']  }}
+{% if switch['poap'].discovery_creds is defined and switch['poap'].discovery_creds %}
+      discovery_username: PLACE_HOLDER_USERNAME
+      discovery_password: PLACE_HOLDER_PASSWORD
+{% endif %}
       config_data:
         modulesModel: {{ switch['poap']['preprovision']['modulesModel'] }}
         gateway: {{ switch['management']['default_gateway_v4'] | ansible.utils.ipaddr('address') }}/{{ switch['management']['subnet_mask_ipv4'] }}


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [x ] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Added support for discovery creds in other fabric types than VXLAN: ISN and External

## Test Notes
Tested and provides the correct payload to the inventory module


## Cisco Nexus Dashboard Version
3.2.2

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
