### PR TITLE
Added filter to the interface_all excluded vpc_peer_link

### DIFF
--- a/plugins/action/dtc/build_resource_data.py
+++ b/plugins/action/dtc/build_resource_data.py
@@ -748,17 +748,34 @@ class ResourceDataBuilder:
         ]
 
         # Aggregate create list (no breakout_preprov)
+        # vPC peer-link entries (profile.mode == 'vpc_peer_link') are pipeline
+        # plumbing used to build the peer-link between switches — they must
+        # not be pushed through the interface_all create path as regular
+        # interfaces, so filter them out here.
         create_list = []
         for itype in interface_types_create:
             entry = self.resource_data.get(itype, {})
             data = entry.get('data', []) if isinstance(entry, dict) else []
+            if itype == 'interface_vpc':
+                data = [
+                    d for d in data
+                    if (d.get('profile') or {}).get('mode') != 'vpc_peer_link'
+                ]
             create_list.extend(data)
 
         # Aggregate remove/overridden list (includes breakout_preprov)
+        # vPC peer-link entries are pipeline plumbing and must not be
+        # torn down by the remove/overridden pass — filter them out here
+        # for the same reason we exclude them from create_list.
         remove_list = []
         for itype in interface_types_remove:
             entry = self.resource_data.get(itype, {})
             data = entry.get('data', []) if isinstance(entry, dict) else []
+            if itype == 'interface_vpc':
+                data = [
+                    d for d in data
+                    if (d.get('profile') or {}).get('mode') != 'vpc_peer_link'
+                ]
             remove_list.extend(data)
 
         # Write aggregated file for diff comparison

--- a/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs_external.j2
+++ b/roles/dtc/common/templates/ndfc_vpc/ndfc_vpc_peering_pairs_external.j2
@@ -23,10 +23,10 @@
 {% set peer1_switch = data_model_extended.vxlan.topology.switches | selectattr('name', 'equalto', vpc_peers_pair.peer1) | first %}
 {% set peer2_switch = data_model_extended.vxlan.topology.switches | selectattr('name', 'equalto', vpc_peers_pair.peer2) | first %}
 {% if peer1_switch.interfaces is defined %}
-{% set peer1_vpc_interface = peer1_switch.interfaces | selectattr('name', 'match', '^(port-channel|po)') | selectattr('mode', 'equalto', 'vpc_peer_link') | first | default({}) %}
+{% set peer1_vpc_interface = peer1_switch.interfaces | selectattr('name', 'match', '(?i)^(port-channel|po)') | selectattr('mode', 'equalto', 'vpc_peer_link') | first | default({}) %}
 {% endif %}
 {% if peer2_switch.interfaces is defined %}
-{% set peer2_vpc_interface = peer2_switch.interfaces | selectattr('name', 'match', '^(port-channel|po)') | selectattr('mode', 'equalto', 'vpc_peer_link') | first | default({}) %}
+{% set peer2_vpc_interface = peer2_switch.interfaces | selectattr('name', 'match', '(?i)^(port-channel|po)') | selectattr('mode', 'equalto', 'vpc_peer_link') | first | default({}) %}
 {% endif %}
 {% if peer1_vpc_interface.name is defined %}
     PEER1_PO_CONF: |2-
@@ -36,8 +36,8 @@
     PC_MODE: {{ peer1_vpc_interface.pc_mode | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.pc_mode)}}
     PEER1_PO_DESC: "{{ peer1_vpc_interface.description | default('') }}"
     PEER2_PO_DESC: "{{ peer2_vpc_interface.description | default('') }}"
-    PEER1_PCID: {{ peer1_vpc_interface.name | default('') | regex_replace('^(port-channel|po)', '') | default('') }}
-    PEER2_PCID: {{ peer2_vpc_interface.name | default('') | regex_replace('^(port-channel|po)', '') | default('') }}
+    PEER1_PCID: {{ peer1_vpc_interface.name | default('') | regex_replace('(?i)^(port-channel|po)', '') | default('') }}
+    PEER2_PCID: {{ peer2_vpc_interface.name | default('') | regex_replace('(?i)^(port-channel|po)', '') | default('') }}
     PEER1_MEMBER_INTERFACES: "{{ peer1_vpc_interface.members | default([]) | join(',') }}"
     PEER2_MEMBER_INTERFACES: "{{ peer2_vpc_interface.members | default([]) | join(',') }}"
     ALLOWED_VLANS: "{{ convert_ranges(peer1_vpc_interface.trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans)  | trim }}"

--- a/roles/validate/files/rules/external/311_topology_switch_vpc_peerlink_consistency.py
+++ b/roles/validate/files/rules/external/311_topology_switch_vpc_peerlink_consistency.py
@@ -73,7 +73,7 @@ class Rule:
         vpc_channels = []
         if switch.get('interfaces'):
             for interface in switch['interfaces']:
-                interface_name = interface.get('name', '')
+                interface_name = interface.get('name', '').lower()
                 is_pc = (interface_name.startswith('port-channel') or
                          interface_name.startswith('po'))
                 if is_pc and interface.get('mode') == 'vpc_peer_link':


### PR DESCRIPTION
Filter to create role to exclude vpc_interface of vpc_peer_link mode

<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
<!--- To link the issue to the PR, use one of the keywords: Fixes #xxx or Closes #xxx or Resolves #xxx -->


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [ x] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ x] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ x] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Added filter to remove vpc_interfaces where the mode is vpc_peer_link as these interfaces are created in the vpc pairing module and not in the interface module

## Test Notes
Tested on 3.2.2. With this link 
```
---
vxlan:
  topology:
    vpc_peers:
      - peer1: SWITCH1
        peer2: SWTICH2
        domain_id: 11
        keepalive_vrf: management
        peer1_keepalive_ipv4: 11.13.20.68
        peer2_keepalive_ipv4: 11.13.20.69
        peer1_domain_conf: |2
            peer-switch
            system-priority 4192
            role priority 4192
            peer-gateway
            layer3 peer-router
            ip arp synchronize
            auto-recovery
        peer2_domain_conf: |2
            peer-switch
            system-priority 4192
            peer-gateway
            layer3 peer-router
            ip arp synchronize
            auto-recovery
        peer1_peerlink_interfaces:
          - name: ethernet1/49
          - name: ethernet1/50
        peer2_peerlink_interfaces:
          - name: ethernet1/49
          - name: ethernet1/50

## Cisco Nexus Dashboard Version
3.2.2

## Checklist

* [ ] Latest commit is rebased from develop with merge conflicts resolved
* [ ] New or updates to documentation has been made accordingly
* [ ] Assigned the proper reviewers
