### PR TITLE
Fix silently skipped deletion of the final MCFG VRFs/networks (unsafe sentinel serialization)

### DIFF
--- a/plugins/action/dtc/build_resource_data.py
+++ b/plugins/action/dtc/build_resource_data.py
@@ -116,6 +116,32 @@ class ResourceDataBuilder:
             return value.lower() in ('1', 'true', 'yes', 'on')
         return bool(value)
 
+    @staticmethod
+    def _normalize_for_yaml(obj):
+        """
+        Recursively convert Ansible-wrapped values (e.g. AnsibleUnsafeText)
+        to plain Python types so the result can be safely round-tripped
+        with yaml.safe_dump()/yaml.safe_load().
+
+        str.__str__() is used instead of plain str() because Ansible's
+        "unsafe" string wrapper overrides __str__ (and similar dunder
+        methods) to keep re-wrapping its own output as unsafe -- calling
+        the base str implementation directly is the reliable way to get a
+        genuinely plain str back.
+        """
+        if isinstance(obj, dict):
+            return {
+                ResourceDataBuilder._normalize_for_yaml(k): ResourceDataBuilder._normalize_for_yaml(v)
+                for k, v in obj.items()
+            }
+        if isinstance(obj, (list, tuple)):
+            return [ResourceDataBuilder._normalize_for_yaml(v) for v in obj]
+        if isinstance(obj, bool) or obj is None or isinstance(obj, (int, float)):
+            return obj
+        if isinstance(obj, str):
+            return str.__str__(obj)
+        raise TypeError(f"Unsupported sentinel value type: {type(obj).__name__}")
+
     def _should_run_structural_diff(self, diff_compare):
         """Structural diff data is only consumed during targeted diff runs."""
         return bool(diff_compare) and self.run_map_diff_run and not self.force_run_all
@@ -461,6 +487,17 @@ class ResourceDataBuilder:
         data model (including vrf_attach_groups and network_attach_groups)
         to a sentinel file and compares against the previous version.
 
+        The previous sentinel is loaded exactly once, via
+        _load_overlay_sentinel(), before ANY local state is touched --
+        the deferred-build cache file included. If that load fails
+        (sentinel written by a version of this collection before this
+        fix, or genuinely corrupted), it raises RuntimeError and this
+        method makes no further changes: the existing sentinel and cache
+        file are both left exactly as they were, no change flag is set,
+        and no create/remove step downstream can act on a value we
+        failed to read correctly. See _load_overlay_sentinel() for the
+        required recovery step.
+
         When a change is detected, sets BOTH the aggregate flag
         (changes_detected_msite_overlay) AND per-resource flags
         (changes_detected_vrfs, changes_detected_networks) so that
@@ -469,12 +506,6 @@ class ResourceDataBuilder:
         Also cleans up the deferred build cache file from any prior
         pipeline run in this playbook execution.
         """
-        # Clean up deferred build cache from prior pipeline runs so that
-        # each playbook run starts with a fresh cache.
-        cache_file = os.path.join(self.output_path, '_msite_overlay_cache.json')
-        if os.path.exists(cache_file):
-            os.remove(cache_file)
-
         overlay = (
             self.data_model
             .get('vxlan', {})
@@ -485,43 +516,46 @@ class ResourceDataBuilder:
         sentinel_file = os.path.join(self.output_path, '_msite_overlay_sentinel.yml')
         old_sentinel = sentinel_file + '.old'
 
-        # Handle empty/missing overlay: still need to detect removal of
-        # previously existing overlay data (user removed all VRFs/networks).
-        if not overlay:
-            if not os.path.exists(sentinel_file):
-                # No previous sentinel and no current overlay — nothing to detect
-                return
-            # Previous sentinel exists but overlay is now empty — detect removal
-            shutil.copy2(sentinel_file, old_sentinel)
-            os.remove(sentinel_file)
-            with open(sentinel_file, 'w') as f:
-                f.write(yaml.dump({}, default_flow_style=False, sort_keys=True))
-            if self._run_diff_model_changes(old_sentinel, sentinel_file):
-                if self.check_roles.get('save_previous', False):
-                    self.change_flags['changes_detected_msite_overlay'] = True
-                    self.change_flags['changes_detected_vrfs'] = True
-                    self.change_flags['changes_detected_networks'] = True
-                    display.v(
-                        f"COMMON [{self.fabric_name}] Multisite overlay "
-                        f"removed — all overlay data cleared"
-                    )
+        # Read-before-write: load whatever sentinel already exists on disk
+        # before this method makes any change to local state. A bad
+        # sentinel fails here, before the cache cleanup below or anything
+        # else runs, so a failed build never leaves things half-touched.
+        previous_overlay = self._load_overlay_sentinel(sentinel_file)
+        previous_had_vrfs = bool(previous_overlay.get('vrfs'))
+        previous_had_networks = bool(previous_overlay.get('networks'))
+
+        # Only now, after the sentinel is confirmed readable, clean up the
+        # deferred build cache from prior pipeline runs so that each
+        # playbook run starts with a fresh cache.
+        cache_file = os.path.join(self.output_path, '_msite_overlay_cache.json')
+        if os.path.exists(cache_file):
+            os.remove(cache_file)
+
+        # Nothing before, nothing now -- no sentinel to write, no change
+        # to detect.
+        if not overlay and not previous_overlay:
             return
 
-        # Backup previous sentinel file
-        if os.path.exists(sentinel_file):
-            shutil.copy2(sentinel_file, old_sentinel)
-            os.remove(sentinel_file)
+        # Current overlay is empty but a previous sentinel had content:
+        # the user removed all VRFs/networks from the data model. Record
+        # an empty sentinel and flag both resources for removal.
+        if not overlay:
+            self._write_overlay_sentinel(sentinel_file, old_sentinel, {})
+            if self.check_roles.get('save_previous', False):
+                self.change_flags['changes_detected_msite_overlay'] = True
+                self.change_flags['changes_detected_vrfs'] = True
+                self.change_flags['changes_detected_networks'] = True
+                display.v(
+                    f"COMMON [{self.fabric_name}] Multisite overlay "
+                    f"removed — all overlay data cleared"
+                )
+            return
 
         # Capture the ENTIRE overlay dict (vrfs, networks, vrf_attach_groups,
-        # network_attach_groups, etc.) for change detection. Previously only
-        # vrfs and networks were captured, missing attach group modifications.
-        overlay_content = yaml.dump(
-            overlay,
-            default_flow_style=False,
-            sort_keys=True,
-        )
-        with open(sentinel_file, 'w') as f:
-            f.write(overlay_content)
+        # network_attach_groups, etc.) for change detection -- not just
+        # vrfs and networks -- so attach-group-only edits are also caught.
+        normalized_overlay = self._normalize_for_yaml(overlay)
+        self._write_overlay_sentinel(sentinel_file, old_sentinel, normalized_overlay)
 
         overlay_vrfs = overlay.get('vrfs', [])
         overlay_networks = overlay.get('networks', [])
@@ -530,12 +564,12 @@ class ResourceDataBuilder:
         if self._run_diff_model_changes(old_sentinel, sentinel_file):
             if self.check_roles.get('save_previous', False):
                 self.change_flags['changes_detected_msite_overlay'] = True
-                # Set per-resource flags so pipeline steps pass their
-                # change_flag_guard checks. Both CREATE and REMOVE pipelines
-                # gate VRF/network steps on these flags.
-                if overlay_vrfs or self._sentinel_had_key(old_sentinel, 'vrfs'):
+                # A resource flag is set if it is non-empty now, or was
+                # non-empty before -- either way there is work to do:
+                # new items to create, or old ones to remove.
+                if overlay_vrfs or previous_had_vrfs:
                     self.change_flags['changes_detected_vrfs'] = True
-                if overlay_networks or self._sentinel_had_key(old_sentinel, 'networks'):
+                if overlay_networks or previous_had_networks:
                     self.change_flags['changes_detected_networks'] = True
                 display.v(
                     f"COMMON [{self.fabric_name}] Multisite overlay data "
@@ -543,21 +577,78 @@ class ResourceDataBuilder:
                     f"networks={len(overlay_networks)})"
                 )
 
-    def _sentinel_had_key(self, sentinel_path, key):
+    def _load_overlay_sentinel(self, sentinel_path):
         """
-        Check if a previous sentinel file contained a non-empty value for key.
+        Load the previous multisite overlay sentinel, or {} if none
+        exists yet.
 
-        Used by _detect_msite_overlay_changes to determine which per-resource
-        change flags to set when the overlay data model has changed.
+        Always reads with yaml.safe_load() -- there is no fallback loader
+        for the "!!python/object/apply:..." tag format written by
+        versions of this collection before this fix. A sentinel in that
+        format, valid YAML with the wrong structure (e.g. a list instead
+        of a mapping), or any other unparseable content, all raise
+        RuntimeError naming the same force_run_all: true recovery step --
+        they are all, functionally, an incompatible sentinel. A separate
+        exception is raised for filesystem-level failures (permissions,
+        I/O errors), since telling a user to re-run with
+        force_run_all: true would be misleading advice for a problem
+        that isn't about the file's content at all.
+
+        Call this before making any change to the sentinel file (backup,
+        delete, or overwrite). Because this is the very first thing
+        _detect_msite_overlay_changes() does with the sentinel, a bad
+        read here always leaves the existing file untouched.
         """
         if not os.path.exists(sentinel_path):
-            return False
+            return {}
+
         try:
-            with open(sentinel_path) as f:
-                prev_data = yaml.safe_load(f)
-            return bool(prev_data.get(key)) if isinstance(prev_data, dict) else False
-        except (yaml.YAMLError, IOError):
-            return False
+            with open(sentinel_path) as file:
+                data = yaml.safe_load(file)
+        except yaml.YAMLError as exc:
+            raise RuntimeError(
+                "The existing multisite overlay sentinel is incompatible "
+                "or corrupted. After upgrading the collection, run once "
+                "with force_run_all: true using the complete, unchanged "
+                "data model before removing VRFs or networks. "
+                f"Sentinel: {sentinel_path}. Error: {exc}"
+            )
+        except OSError as exc:
+            raise RuntimeError(
+                "Unable to read the multisite overlay sentinel. Check "
+                "the file permissions and local storage. "
+                f"Sentinel: {sentinel_path}. Error: {exc}"
+            )
+
+        if data is None:
+            return {}
+
+        if not isinstance(data, dict):
+            raise RuntimeError(
+                "The existing multisite overlay sentinel does not have "
+                "the expected structure (a YAML mapping) and is treated "
+                "as incompatible. After upgrading the collection, run "
+                "once with force_run_all: true using the complete, "
+                "unchanged data model before removing VRFs or networks. "
+                f"Sentinel: {sentinel_path}. Parsed type: {type(data).__name__}"
+            )
+
+        return data
+
+    def _write_overlay_sentinel(self, sentinel_file, old_sentinel, content):
+        """
+        Back up the current sentinel file (if any) to old_sentinel, then
+        write content as the new sentinel with yaml.safe_dump().
+
+        Called only after _load_overlay_sentinel() has already
+        successfully read whatever was there before, so this never
+        overwrites a sentinel we failed to understand.
+        """
+        if os.path.exists(sentinel_file):
+            shutil.copy2(sentinel_file, old_sentinel)
+            os.remove(sentinel_file)
+        with open(sentinel_file, 'w') as f:
+            f.write(yaml.safe_dump(content, default_flow_style=False, sort_keys=True))
 
     def _run_diff_compare(self, old_path, new_path):
         """

--- a/plugins/action/dtc/remove_resources.py
+++ b/plugins/action/dtc/remove_resources.py
@@ -201,7 +201,7 @@ class ResourceRemover(PipelineRunnerBase):
             )
             if (
                 full_run_strategy == 'controller_diff'
-                and self.fabric_type == 'MCFG'
+                and self.fabric_type in ('MCFG', 'MSD')
                 and resource_name in overlay
                 and overlay.get(resource_name) == []
             ):


### PR DESCRIPTION
## Related Issue(s)
Fixes #846

## Related Collection Role
- [ ] cisco.nac_dc_vxlan.validate
- [ ] cisco.nac_dc_vxlan.dtc.create
- [ ] cisco.nac_dc_vxlan.dtc.deploy
- [x] cisco.nac_dc_vxlan.dtc.remove
- [ ] other

## Related Data Model Element
- [ ] vxlan.fabric
- [ ] vxlan.global
- [ ] vxlan.topology
- [ ] vxlan.underlay
- [ ] vxlan.overlay
- [ ] vxlan.overlay_extensions
- [ ] vxlan.policy
- [x] vxlan.multisite
- [ ] defaults.vxlan
- [ ] other

## Proposed Changes

This replaces the sentinel read/write mismatch in `plugins/action/dtc/build_resource_data.py` that caused MCFG multisite overlay removal to be silently skipped.

**Root cause, in plain terms:** the collection keeps a small file per MCFG fabric (the sentinel, `_msite_overlay_sentinel.yml`) to remember what the overlay's VRFs/networks looked like last time, so the next run can tell if anything changed. The function that writes it — `_detect_msite_overlay_changes()` — didn't save plain values. Instead of `name: VRF01`, the file ended up with something like this for that same value:

```yaml
? !!python/object/apply:ansible.utils.unsafe_proxy.AnsibleUnsafeText
  - VRF01
```

That's a Python-specific instruction embedded in the file, not just plain text. The function that reads it back — `_sentinel_had_key()` — deliberately refuses to load a file containing that kind of instruction (a normal security precaution, so it never rebuilds arbitrary code from a file). The read always failed, and that failure was silently swallowed instead of surfaced, so the collection assumed "nothing existed before" every time.

That specific gap only matters once every VRF/network is removed: the current state becomes just an empty list either way, so the previous sentinel is the only place left to tell "these existed and were removed" from "there was never anything here." Since that read always silently failed, `changes_detected_vrfs`/`changes_detected_networks` never got set, `dcnm_network`/`dcnm_vrf` were never called, and nothing ever reached NDFC. Present since 0.8.0 (see #846).

**Fix** (single file, `plugins/action/dtc/build_resource_data.py`):

- Write with `yaml.safe_dump()` on values normalized to plain Python types (`_normalize_for_yaml()`), which raises `TypeError` rather than silently guessing via `str()` for any type it doesn't explicitly handle.
- Read with a single, load-before-mutate `_load_overlay_sentinel()` call, using `yaml.safe_load()` only — no custom loader. This read happens before the sentinel file (and the unrelated deferred-build cache file) are backed up, removed, or overwritten, so a bad read never leaves things half-touched.
- A sentinel this cannot read as a plain YAML mapping — the pre-existing Python-object-tagged format, a wrong top-level structure, or genuinely malformed YAML — now raises a `RuntimeError` naming the exact recovery step: re-run once with `force_run_all: true` and the complete, unchanged data model. A separate message is used for filesystem/permission failures, since `force_run_all: true` would not fix those.
- The failure-swallowing `_sentinel_had_key()` helper and its repeated sentinel reads are removed; the already-loaded sentinel is reused directly, so the sentinel is opened and parsed once per build instead of twice.

**Migration required for existing installations:** after upgrading, run once with `force_run_all: true` using the complete, unchanged data model before removing any VRFs/networks, so the existing sentinel gets regenerated in the new, plain-YAML format. Without this step, the next diff-run against a pre-upgrade sentinel will fail loud (by design) rather than silently skip the removal as before.

**Scope boundaries:**

- The reproduced and end-to-end validated scenario is MCFG. The modified sentinel implementation (`_detect_msite_overlay_changes()`, `_load_overlay_sentinel()`, `_write_overlay_sentinel()`) is shared by MCFG and MSD (`self.fabric_type in ('MSD', 'MCFG')`). No end-to-end MSD support claim is made by this PR — MSD has not been separately reproduced or validated.
- `_msite_build_overlay()` (`plugins/plugin_utils/pipeline_base.py`) is not modified by this PR. This PR covers the populated → empty transition. A separate, independent defect in the empty → populated (recreate) direction was found during this PR's live validation and is not fixed here — tracked separately, out of scope of this PR.

## Test Notes

**Local:** a 21-case/25-assertion matrix (`ResourceDataBuilder`/`ResourceRemover`/`PipelineRunnerBase`, no mocks of the fix itself) covering: the legacy sentinel format failing loud in diff-run (sentinel and cache file left byte-for-byte untouched); safe read/write round-tripping; missing/corrupt/wrong-structure/permission-denied sentinels (each producing the correct, distinct recovery message); full integration through a real `ResourceRemover.run_pipeline()` (controller-diff discovery, dispatch order, dispatch content); the run_map retry/self-healing path (unrelated to and unmodified by this fix); idempotent re-runs; and the full mandatory migration flow driven against the real, unmodified `ResourceDataBuilder.build()` (`force_run_all=True` → real `_cleanup_files()` → fresh safe sentinel → subsequent diff-run → real dispatch). Also covers several related scenarios to characterize `remove_resources.py`'s existing, unmodified behavior: only one resource type emptied while the other remains, a true partial removal within one resource type, and an attach-group-only change.

**Results:**

- Full matrix: **25/25 PASS**
- 19/25 assertions fail or differ against the baseline (reverted, original pre-fix code). Cases 20 and 21 pass on both versions because they characterize behavior unaffected by the sentinel defect (a real `diff.removed`-based partial removal, and an attach-group-only change that never needed the sentinel read to begin with), not evidence of the fix itself.

The test harness and captured results live in the integration repository, not in this PR.

**Live validation:** I also validated this live against ND 4.1.1g / NDFC 12.4.1.321 (virtual N9K-C9300v, NX-OS 10.6(2)), reproducing the exact reported scenario end to end. With the pre-migration (legacy) sentinel still on disk and a real data-model change (removing VRFs/networks) in diff-run mode, the build now fails with the exact `force_run_all: true` recovery message, leaving the sentinel completely untouched and zero controller requests made. `force_run_all: true` with the complete, unchanged data model then completes successfully and regenerates a plain, safe sentinel. The following diff-run correctly dispatches `dcnm_network`/`dcnm_vrf` with `state: deleted` (controller diff: 2 networks and 1 VRF on the controller, 0 in the data model, all discovered for deletion), and NDFC confirmed the actual deletion afterward.

## Cisco Nexus Dashboard Version

Confirmed on 4.1.1g (NDFC 12.4.1.321). The failure occurs before any controller request and has no NDFC-version conditional in the code, so it is expected on ND 4.2 as well — ND 4.2 has not yet been tested directly.

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [ ] New or updates to documentation has been made accordingly
- [ ] Assigned the proper reviewers
