### PR TITLE
Adding support for VLAN ID override, CLI Freeform and SVI admin status (ND >=4.1) under network attachments 

### DIFF
--- a/plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py
+++ b/plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py
@@ -19,13 +19,24 @@
 #
 # SPDX-License-Identifier: MIT
 
-from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import restructure_leaf_tor_data
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import (
+    restructure_leaf_tor_data,
+    resolve_switch_by_identifier,
+)
 
 
 class PreparePlugin:
     def __init__(self, **kwargs):
         self.kwargs = kwargs
         self.keys = []
+
+    def _resolve_mgmt_ip(self, identifier, topology_switches):
+        found = resolve_switch_by_identifier(identifier, topology_switches)
+        mgmt = found.get('management') or {}
+        return (
+            mgmt.get('management_ipv4_address')
+            or mgmt.get('management_ipv6_address')
+        )
 
     def prepare(self):
         data_model = self.kwargs['results']['model_extended']
@@ -48,14 +59,8 @@ class PreparePlugin:
                 vrf_grp_name_list.append(grp['name'])
                 for switch in grp['switches']:
                     data_model['vxlan']['overlay']['vrf_attach_groups_dict'][grp['name']].append(switch)
-                # If the switch is in the switch list and a hostname is used, replace the hostname with the management IP
                 for switch in data_model['vxlan']['overlay']['vrf_attach_groups_dict'][grp['name']]:
-                    if any(sw['name'] == switch['hostname'] for sw in switches):
-                        found_switch = next((item for item in switches if item["name"] == switch['hostname']))
-                        if found_switch.get('management').get('management_ipv4_address'):
-                            switch['mgmt_ip_address'] = found_switch['management']['management_ipv4_address']
-                        elif found_switch.get('management').get('management_ipv6_address'):
-                            switch['mgmt_ip_address'] = found_switch['management']['management_ipv6_address']
+                    switch['mgmt_ip_address'] = self._resolve_mgmt_ip(switch['hostname'], switches)
 
             # Remove vrf_attach_group from vrf if the group_name is not defined
             for vrf in data_model['vxlan']['overlay']['vrfs']:
@@ -78,25 +83,15 @@ class PreparePlugin:
 
                 for switch in grp['switches']:
                     data_model['vxlan']['overlay']['network_attach_groups_dict'][grp['name']].append(switch)
-                # If the switch is in the switch list and a hostname is used, replace the hostname with the management IP
                 for switch in data_model['vxlan']['overlay']['network_attach_groups_dict'][grp['name']]:
-                    if any(sw['name'] == switch['hostname'] for sw in switches):
-                        found_switch = next((item for item in switches if item["name"] == switch['hostname']))
-                        if found_switch.get('management').get('management_ipv4_address'):
-                            switch['mgmt_ip_address'] = found_switch['management']['management_ipv4_address']
-                        elif found_switch.get('management').get('management_ipv6_address'):
-                            switch['mgmt_ip_address'] = found_switch['management']['management_ipv6_address']
+                    switch['mgmt_ip_address'] = self._resolve_mgmt_ip(switch['hostname'], switches)
 
-                    # Process nested TOR entries and resolve their management IPs
                     if 'tors' in switch and switch['tors']:
                         for tor in switch['tors']:
-                            tor_hostname = tor.get('hostname')
-                            if tor_hostname and any(sw['name'] == tor_hostname for sw in switches):
-                                found_tor = next((item for item in switches if item["name"] == tor_hostname))
-                                if found_tor.get('management').get('management_ipv4_address'):
-                                    tor['mgmt_ip_address'] = found_tor['management']['management_ipv4_address']
-                                elif found_tor.get('management').get('management_ipv6_address'):
-                                    tor['mgmt_ip_address'] = found_tor['management']['management_ipv6_address']
+                            tor_id = tor.get('hostname')
+                            if not tor_id:
+                                continue
+                            tor['mgmt_ip_address'] = self._resolve_mgmt_ip(tor_id, switches)
 
             # Remove network_attach_group from net if the group_name is not defined
             for net in data_model['vxlan']['overlay']['networks']:
@@ -104,16 +99,15 @@ class PreparePlugin:
                     if net.get('network_attach_group') not in net_grp_name_list:
                         del net['network_attach_group']
 
-            # If the switch is in the switch list and a hostname is used, add the management IP to switch_attach_overrides
             for net in data_model['vxlan']['overlay']['networks']:
-                for override in net.get('switch_attach_overrides', []):
-                    hostname = override.get('hostname')
-                    if hostname and any(sw['name'] == hostname for sw in switches):
-                        found_switch = next(item for item in switches if item['name'] == hostname)
-                        if found_switch.get('management').get('management_ipv4_address'):
-                            override['mgmt_ip_address'] = found_switch['management']['management_ipv4_address']
-                        elif found_switch.get('management').get('management_ipv6_address'):
-                            override['mgmt_ip_address'] = found_switch['management']['management_ipv6_address']
+                overrides = net.get('switch_attach_overrides')
+                if not overrides:
+                    continue
+                for override in overrides:
+                    override_id = override.get('hostname')
+                    if not override_id:
+                        continue
+                    override['mgmt_ip_address'] = self._resolve_mgmt_ip(override_id, switches)
 
         self.kwargs['results']['model_extended'] = data_model
         return self.kwargs['results']

--- a/plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py
+++ b/plugins/action/common/prepare_plugins/prep_105_fabric_overlay.py
@@ -104,5 +104,16 @@ class PreparePlugin:
                     if net.get('network_attach_group') not in net_grp_name_list:
                         del net['network_attach_group']
 
+            # If the switch is in the switch list and a hostname is used, add the management IP to switch_attach_overrides
+            for net in data_model['vxlan']['overlay']['networks']:
+                for override in net.get('switch_attach_overrides', []):
+                    hostname = override.get('hostname')
+                    if hostname and any(sw['name'] == hostname for sw in switches):
+                        found_switch = next(item for item in switches if item['name'] == hostname)
+                        if found_switch.get('management').get('management_ipv4_address'):
+                            override['mgmt_ip_address'] = found_switch['management']['management_ipv4_address']
+                        elif found_switch.get('management').get('management_ipv6_address'):
+                            override['mgmt_ip_address'] = found_switch['management']['management_ipv6_address']
+
         self.kwargs['results']['model_extended'] = data_model
         return self.kwargs['results']

--- a/plugins/action/dtc/prepare_msite_data.py
+++ b/plugins/action/dtc/prepare_msite_data.py
@@ -29,6 +29,7 @@ from ansible.plugins.action import ActionBase
 from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import ndfc_get_fabric_attributes
 from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import ndfc_get_fabric_switches
 from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import restructure_leaf_tor_data
+from ansible_collections.cisco.nac_dc_vxlan.plugins.plugin_utils.helper_functions import resolve_child_fabric_switch
 from ansible_collections.cisco.nac_dc_vxlan.plugins.filter.version_compare import version_compare
 import re
 
@@ -277,23 +278,18 @@ class ActionModule(ActionBase):
                 data_model['vxlan']['multisite']['overlay']['vrf_attach_groups_dict'][grp['name']].append(switch)
             # If the switch is in the switch list and a hostname is used, replace the hostname with the management IP
             for switch in data_model['vxlan']['multisite']['overlay']['vrf_attach_groups_dict'][grp['name']]:
+                # FQDN-tolerant match; preprovision switches (hostname=None) are skipped
                 for child_fabric in child_fabrics_data.keys():
-                    for sw in child_fabrics_data[child_fabric]['switches']:
-                        # When switch is in preprovision, sw['hostname'] is None.
-                        if sw.get('hostname') is not None:
-                            # Compare switches with regex to catch hostname when ip domain-name is configured
-                            # Check both directions: data model name vs NDFC name and vice versa
-                            fwd_pattern = f"^{re.escape(switch['hostname'])}$|^{re.escape(switch['hostname'])}\\..*$"
-                            rev_pattern = f"^{re.escape(sw['hostname'])}$|^{re.escape(sw['hostname'])}\\..*$"
-                            if re.search(fwd_pattern, sw['hostname']) or re.search(rev_pattern, switch['hostname']):
-                                switch['mgmt_ip_address'] = sw['mgmt_ip_address']
+                    resolved = resolve_child_fabric_switch(switch['hostname'], child_fabrics_data[child_fabric]['switches'])
+                    if resolved is not None:
+                        switch['mgmt_ip_address'] = resolved['mgmt_ip_address']
+                        break
 
                 if 'mgmt_ip_address' not in switch:
                     results['failed'] = True
                     results['msg'] = (
-                        f"Unable to resolve management IP for switch '{switch['hostname']}' "
-                        f"in VRF attach group '{grp['name']}'. "
-                        f"Verify the hostname matches a discovered switch in a child fabric of '{parent_fabric}'."
+                        f"vrf attach group {grp['name']} hostname {switch['hostname']} "
+                        f"does not match any switch name in child fabrics of '{parent_fabric}'."
                     )
                     return results
 
@@ -327,31 +323,40 @@ class ActionModule(ActionBase):
                 data_model['vxlan']['multisite']['overlay']['network_attach_groups_dict'][grp['name']].append(switch)
             # If the switch is in the switch list and a hostname is used, replace the hostname with the management IP
             for switch in data_model['vxlan']['multisite']['overlay']['network_attach_groups_dict'][grp['name']]:
+                # FQDN-tolerant match; preprovision switches (hostname=None) are skipped
                 for child_fabric in child_fabrics_data.keys():
-                    for sw in child_fabrics_data[child_fabric]['switches']:
-                        if sw.get('hostname') is not None:
-                            # Check both directions: data model name vs NDFC name and vice versa
-                            fwd_pattern = f"^{re.escape(switch['hostname'])}$|^{re.escape(switch['hostname'])}\\..*$"
-                            rev_pattern = f"^{re.escape(sw['hostname'])}$|^{re.escape(sw['hostname'])}\\..*$"
-                            if re.search(fwd_pattern, sw['hostname']) or re.search(rev_pattern, switch['hostname']):
-                                switch['mgmt_ip_address'] = sw['mgmt_ip_address']
+                    resolved = resolve_child_fabric_switch(switch['hostname'], child_fabrics_data[child_fabric]['switches'])
+                    if resolved is not None:
+                        switch['mgmt_ip_address'] = resolved['mgmt_ip_address']
 
-                    # Process nested TOR entries and resolve their management IPs
                     if 'tors' in switch and switch['tors']:
                         for tor in switch['tors']:
                             tor_hostname = tor.get('hostname')
-                            if tor_hostname and any(sw['name'] == tor_hostname for sw in child_fabrics_data[child_fabric]['switches']):
-                                found_tor = next((item for item in child_fabrics_data[child_fabric]['switches'] if item["name"] == tor_hostname))
-                                tor['mgmt_ip_address'] = found_tor['mgmt_ip_address']
+                            if not tor_hostname:
+                                continue
+                            # FQDN-tolerant match; preprovision switches (hostname=None) are skipped
+                            resolved_tor = resolve_child_fabric_switch(tor_hostname, child_fabrics_data[child_fabric]['switches'])
+                            if resolved_tor is not None:
+                                tor['mgmt_ip_address'] = resolved_tor['mgmt_ip_address']
 
                 if 'mgmt_ip_address' not in switch:
                     results['failed'] = True
                     results['msg'] = (
-                        f"Unable to resolve management IP for switch '{switch['hostname']}' "
-                        f"in network attach group '{grp['name']}'. "
-                        f"Verify the hostname matches a discovered switch in a child fabric of '{parent_fabric}'."
+                        f"network attach group {grp['name']} hostname {switch['hostname']} "
+                        f"does not match any switch name in child fabrics of '{parent_fabric}'."
                     )
                     return results
+
+                if 'tors' in switch and switch['tors']:
+                    for tor in switch['tors']:
+                        if tor.get('hostname') and 'mgmt_ip_address' not in tor:
+                            results['failed'] = True
+                            results['msg'] = (
+                                f"network attach group {grp['name']} tor {tor['hostname']} "
+                                f"under leaf {switch['hostname']} does not match any switch name "
+                                f"in child fabrics of '{parent_fabric}'."
+                            )
+                            return results
 
                 # Append switch to a flat list of switches for cross comparison later when we query the
                 # MSD fabric information.  We need to stop execution if the list returned by the MSD query
@@ -364,20 +369,50 @@ class ActionModule(ActionBase):
                 if net.get('network_attach_group') not in net_grp_name_list:
                     del net['network_attach_group']
 
-        # If the switch is in a child fabric and a hostname is used, add the management IP to switch_attach_overrides
         for net in data_model['vxlan']['multisite']['overlay']['networks']:
-            for override in net.get('switch_attach_overrides', []):
+            overrides = net.get('switch_attach_overrides')
+            if not overrides:
+                continue
+            net_name = net.get('name')
+            net_attach_group = net.get('network_attach_group')
+            group_hostnames = set()
+            if net_attach_group:
+                group_hostnames = {
+                    s.get('hostname')
+                    for s in data_model['vxlan']['multisite']['overlay']['network_attach_groups_dict'].get(net_attach_group, [])
+                    if s.get('hostname')
+                }
+
+            for override in overrides:
                 hostname = override.get('hostname')
                 if not hostname:
                     continue
+
+                resolved = None
+                # FQDN-tolerant match; preprovision switches (hostname=None) are skipped
                 for child_fabric in child_fabrics_data.keys():
-                    for sw in child_fabrics_data[child_fabric]['switches']:
-                        if sw.get('hostname') is None:
-                            continue
-                        fwd_pattern = f"^{re.escape(hostname)}$|^{re.escape(hostname)}\\..*$"
-                        rev_pattern = f"^{re.escape(sw['hostname'])}$|^{re.escape(sw['hostname'])}\\..*$"
-                        if re.search(fwd_pattern, sw['hostname']) or re.search(rev_pattern, hostname):
-                            override['mgmt_ip_address'] = sw['mgmt_ip_address']
+                    resolved = resolve_child_fabric_switch(hostname, child_fabrics_data[child_fabric]['switches'])
+                    if resolved is not None:
+                        override['mgmt_ip_address'] = resolved['mgmt_ip_address']
+                        break
+
+                if resolved is None:
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"Network '{net_name}' switch_attach_overrides identifier "
+                        f"'{hostname}' does not match any switch name in child "
+                        f"fabrics of '{parent_fabric}'."
+                    )
+                    return results
+
+                if net_attach_group and hostname not in group_hostnames:
+                    results['failed'] = True
+                    results['msg'] = (
+                        f"Network '{net_name}' switch_attach_overrides identifier "
+                        f"'{hostname}' could not be resolved to a switch attached "
+                        f"through network_attach_group '{net_attach_group}'."
+                    )
+                    return results
 
         results['overlay_attach_groups'] = data_model['vxlan']['multisite']['overlay']
         return results

--- a/plugins/action/dtc/prepare_msite_data.py
+++ b/plugins/action/dtc/prepare_msite_data.py
@@ -364,5 +364,20 @@ class ActionModule(ActionBase):
                 if net.get('network_attach_group') not in net_grp_name_list:
                     del net['network_attach_group']
 
+        # If the switch is in a child fabric and a hostname is used, add the management IP to switch_attach_overrides
+        for net in data_model['vxlan']['multisite']['overlay']['networks']:
+            for override in net.get('switch_attach_overrides', []):
+                hostname = override.get('hostname')
+                if not hostname:
+                    continue
+                for child_fabric in child_fabrics_data.keys():
+                    for sw in child_fabrics_data[child_fabric]['switches']:
+                        if sw.get('hostname') is None:
+                            continue
+                        fwd_pattern = f"^{re.escape(hostname)}$|^{re.escape(hostname)}\\..*$"
+                        rev_pattern = f"^{re.escape(sw['hostname'])}$|^{re.escape(sw['hostname'])}\\..*$"
+                        if re.search(fwd_pattern, sw['hostname']) or re.search(rev_pattern, hostname):
+                            override['mgmt_ip_address'] = sw['mgmt_ip_address']
+
         results['overlay_attach_groups'] = data_model['vxlan']['multisite']['overlay']
         return results

--- a/plugins/plugin_utils/helper_functions.py
+++ b/plugins/plugin_utils/helper_functions.py
@@ -102,6 +102,16 @@ def hostname_to_ip_mapping(data_model):
     return data_model
 
 
+def resolve_switch_by_identifier(identifier, topology_switches):
+    """Return the topology switch dict whose name matches identifier, or None."""
+    if not identifier or not topology_switches:
+        return None
+    for sw in topology_switches:
+        if sw.get('name') == identifier:
+            return sw
+    return None
+
+
 def ndfc_get_switch_policy(self, task_vars, tmp, switch_serial_number):
     """
     Get NDFC policy for a given managed switch by the switch's serial number.

--- a/plugins/plugin_utils/helper_functions.py
+++ b/plugins/plugin_utils/helper_functions.py
@@ -112,6 +112,27 @@ def resolve_switch_by_identifier(identifier, topology_switches):
     return None
 
 
+def resolve_child_fabric_switch(identifier, child_fabric_switches):
+    """Return the child fabric switch dict whose hostname matches identifier, or None.
+
+    FQDN-tolerant: also matches when either side is the bare form of the
+    other (e.g. data model uses 'leaf1' but NDFC returns 'leaf1.example.com').
+    Preprovisioned switches (hostname == None) are skipped.
+    """
+    if not identifier or not child_fabric_switches:
+        return None
+    import re
+    for sw in child_fabric_switches:
+        sw_hostname = sw.get('hostname')
+        if sw_hostname is None:
+            continue
+        fwd = f"^{re.escape(identifier)}$|^{re.escape(identifier)}\\..*$"
+        rev = f"^{re.escape(sw_hostname)}$|^{re.escape(sw_hostname)}\\..*$"
+        if re.search(fwd, sw_hostname) or re.search(rev, identifier):
+            return sw
+    return None
+
+
 def ndfc_get_switch_policy(self, task_vars, tmp, switch_serial_number):
     """
     Get NDFC policy for a given managed switch by the switch's serial number.

--- a/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
@@ -1,4 +1,4 @@
-{# Auto-generated NDFC DC VXLAN EVPN VRFs config data structure for fabric {{ vxlan.fabric.name }} #}
+{# Auto-generated NDFC DC VXLAN EVPN Networks config data structure for fabric {{ vxlan.fabric.name }} #}
 {% set networks = [] %}
 {% if data_model_extended.vxlan.overlay.networks is defined and data_model_extended.vxlan.overlay.networks %}
 {% set networks = data_model_extended.vxlan.overlay.networks %}
@@ -65,6 +65,22 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if net['switch_attach_overrides'] is defined %}
+{% for switch_override in net['switch_attach_overrides'] %}
+{% if switch_override['mgmt_ip_address'] == attach['mgmt_ip_address'] %}
+{% if switch_override['vlan_id'] is defined and switch_override['vlan_id'] != net['vlan_id'] %}
+      vlan_id: {{ switch_override['vlan_id'] }}
+{% endif %}
+{% if switch_override['freeform_config'] is defined %}
+      freeform_config: |-
+{{ switch_override['freeform_config'] | cisco.nac_dc_vxlan.dedent | indent(8, true) }}
+{% endif %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+      svi_enabled: {{ switch_override['svi_enabled'] | default(defaults.vxlan.overlay.networks.svi_enabled) }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/mcfg_fabric/mcfg_fabric_networks.j2
@@ -4,6 +4,10 @@
 {% else %}
 {% set networks = [] %}
 {% endif %}
+{% set net_overrides = {} %}
+{% for _n in runtime_mcfg_data_model.overlay_attach_groups.networks | default([], true) %}
+{% set _ = net_overrides.update({_n['name']: _n.get('switch_attach_overrides') or []}) %}
+{% endfor %}
 {% for net in networks %}
 - net_name: {{ net['name'] }}
 {# ------------------------------------------------------ #}
@@ -74,6 +78,20 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% for switch_override in net_overrides.get(net['name'], []) %}
+{% if switch_override['mgmt_ip_address'] == attach['mgmt_ip_address'] %}
+{% if switch_override['vlan_id'] is defined and switch_override['vlan_id'] != net['vlan_id'] %}
+      vlan_id: {{ switch_override['vlan_id'] }}
+{% endif %}
+{% if switch_override['freeform_config'] is defined %}
+      freeform_config: |-
+{{ switch_override['freeform_config'] | cisco.nac_dc_vxlan.dedent | indent(8, true) }}
+{% endif %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+      svi_enabled: {{ switch_override['svi_enabled'] | default(defaults.vxlan.overlay.networks.svi_enabled) }}
+{% endif %}
+{% endif %}
+{% endfor %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
@@ -1,6 +1,6 @@
 {# Auto-generated NDFC MSD network_attach_groups_dict config data structure for fabric {{ vxlan.fabric.name }} #}
-{% if data_model_extended.vxlan.multisite.overlay.networks is defined and data_model_extended.vxlan.multisite.overlay.networks %}
-{% set networks = data_model_extended.vxlan.multisite.overlay.networks %}
+{% if runtime_msd_data_model.overlay_attach_groups.networks is defined and runtime_msd_data_model.overlay_attach_groups.networks %}
+{% set networks = runtime_msd_data_model.overlay_attach_groups.networks %}
 {% else %}
 {% set networks = [] %}
 {% endif %}
@@ -74,6 +74,22 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
+{% if net['switch_attach_overrides'] is defined %}
+{% for switch_override in net['switch_attach_overrides'] %}
+{% if switch_override['mgmt_ip_address'] == attach['mgmt_ip_address'] %}
+{% if switch_override['vlan_id'] is defined and switch_override['vlan_id'] != net['vlan_id'] %}
+      vlan_id: {{ switch_override['vlan_id'] }}
+{% endif %}
+{% if switch_override['freeform_config'] is defined %}
+      freeform_config: |-
+{{ switch_override['freeform_config'] | cisco.nac_dc_vxlan.dedent | indent(8, true) }}
+{% endif %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+      svi_enabled: {{ switch_override['svi_enabled'] | default(defaults.vxlan.overlay.networks.svi_enabled) }}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/msd_fabric/msd_fabric_networks.j2
@@ -1,9 +1,13 @@
 {# Auto-generated NDFC MSD network_attach_groups_dict config data structure for fabric {{ vxlan.fabric.name }} #}
-{% if runtime_msd_data_model.overlay_attach_groups.networks is defined and runtime_msd_data_model.overlay_attach_groups.networks %}
-{% set networks = runtime_msd_data_model.overlay_attach_groups.networks %}
+{% if data_model_extended.vxlan.multisite.overlay.networks is defined and data_model_extended.vxlan.multisite.overlay.networks %}
+{% set networks = data_model_extended.vxlan.multisite.overlay.networks %}
 {% else %}
 {% set networks = [] %}
 {% endif %}
+{% set net_overrides = {} %}
+{% for _n in runtime_msd_data_model.overlay_attach_groups.networks | default([], true) %}
+{% set _ = net_overrides.update({_n['name']: _n.get('switch_attach_overrides') or []}) %}
+{% endfor %}
 {% for net in networks %}
 - net_name: {{ net['name'] }}
 {# ------------------------------------------------------ #}
@@ -74,8 +78,7 @@
 {% endif %}
 {% for attach in network_attach_groups_dict[net['network_attach_group']] %}
     - ip_address: {{ attach['mgmt_ip_address'] }}
-{% if net['switch_attach_overrides'] is defined %}
-{% for switch_override in net['switch_attach_overrides'] %}
+{% for switch_override in net_overrides.get(net['name'], []) %}
 {% if switch_override['mgmt_ip_address'] == attach['mgmt_ip_address'] %}
 {% if switch_override['vlan_id'] is defined and switch_override['vlan_id'] != net['vlan_id'] %}
       vlan_id: {{ switch_override['vlan_id'] }}
@@ -89,7 +92,6 @@
 {% endif %}
 {% endif %}
 {% endfor %}
-{% endif %}
 {% if attach['ports'] is defined %}
       ports: {{ attach['ports'] }}
 {% endif %}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -368,6 +368,7 @@ factory_defaults:
         trm_enable: false
         # Staging trmv6 attribute for later usage after low-level collection adds support.
         # trmv6_enable: false
+        svi_enabled: true
       vrf_attach_groups:
         switches: []
       network_attach_groups:

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -515,6 +515,7 @@ factory_defaults:
           route_target_both: false
           route_tag: 12345
           trm_enable: false
+          svi_enabled: true
       isn:
         auth_proto: MD5
         sub_int_range: 2-511

--- a/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
+++ b/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
@@ -68,6 +68,8 @@ class Rule:
             if sm_networks and network_attach_groups:
                 results = cls.cross_reference_switches(network_attach_groups, switches, 'network', results)
                 results = cls.cross_reference_vpc_peers(network_attach_groups, vpc_peers, 'network', results)
+            if sm_networks:
+                results = cls.cross_reference_switch_overrides(sm_networks, switches, 'network', results)
 
         return results
 
@@ -177,5 +179,26 @@ class Rule:
                             f"which has vPC peer '{vpc_peer}', but the vPC peer is not included "
                             f"in the same attach group. Both vPC peers should be in the same attach group."
                         )
+
+        return results
+
+    @classmethod
+    def cross_reference_switch_overrides(cls, attach_overrides, switches, target, results):
+        if not attach_overrides:
+            return results
+
+        for attach_override in attach_overrides:
+            for override in attach_override.get('switch_attach_overrides', []):
+                hostname = override.get('hostname')
+                if not hostname:
+                    continue
+
+                if not any(s.get('name') == hostname for s in switches):
+                    if not any(s.get('management', {}).get('management_ipv4_address') == hostname for s in switches):
+                        if not any(s.get('management', {}).get('management_ipv6_address') == hostname for s in switches):
+                            results.append(
+                                f"switch: {hostname}, defined under {target} {attach_override.get('name')}.switch_attach_overrides"
+                                f" does not match any switch in the topology."
+                            )
 
         return results

--- a/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
+++ b/roles/validate/files/rules/common_vxlan/401_overlay_cross_reference.py
@@ -69,7 +69,9 @@ class Rule:
                 results = cls.cross_reference_switches(network_attach_groups, switches, 'network', results)
                 results = cls.cross_reference_vpc_peers(network_attach_groups, vpc_peers, 'network', results)
             if sm_networks:
-                results = cls.cross_reference_switch_overrides(sm_networks, switches, 'network', results)
+                results = cls.cross_reference_switch_attach_overrides(
+                    sm_networks, network_attach_groups, switches, results
+                )
 
         return results
 
@@ -124,16 +126,17 @@ class Rule:
 
     @classmethod
     def cross_reference_switches(cls, attach_groups, switches, target, results):
-        # target is either vrf or network
         for attach_group in attach_groups:
             for switch in attach_group.get("switches"):
-                if switch.get("hostname"):
-                    if not any(s.get("name") == switch.get("hostname") for s in switches):
-                        if not any(s.get('management').get('management_ipv4_address') == switch.get("hostname") for s in switches):
-                            if not any(s.get('management').get('management_ipv6_address') == switch.get("hostname") for s in switches):
-                                ag = attach_group.get("name")
-                                hn = switch.get("hostname")
-                                results.append(f"{target} attach group {ag} hostname {hn} does not match any switch in the topology.")
+                hn = switch.get("hostname")
+                if not hn:
+                    continue
+                if any(s.get("name") == hn for s in switches):
+                    continue
+                ag = attach_group.get("name")
+                results.append(
+                    f"{target} attach group {ag} hostname {hn} does not match any switch name in vxlan.topology.switches."
+                )
 
         return results
 
@@ -183,22 +186,56 @@ class Rule:
         return results
 
     @classmethod
-    def cross_reference_switch_overrides(cls, attach_overrides, switches, target, results):
-        if not attach_overrides:
+    def cross_reference_switch_attach_overrides(cls, sm_networks, network_attach_groups, switches, results):
+        if not sm_networks or not switches:
             return results
 
-        for attach_override in attach_overrides:
-            for override in attach_override.get('switch_attach_overrides', []):
-                hostname = override.get('hostname')
-                if not hostname:
+        attach_group_identifiers = {}
+        if network_attach_groups:
+            for ag in network_attach_groups:
+                ag_name = ag.get('name')
+                identifiers = set()
+                for sw in ag.get('switches', []) or []:
+                    hostname = sw.get('hostname')
+                    if hostname:
+                        identifiers.add(hostname)
+                attach_group_identifiers[ag_name] = identifiers
+
+        for net in sm_networks:
+            overrides = net.get('switch_attach_overrides')
+            if not overrides:
+                continue
+
+            net_name = net.get('name')
+            net_attach_group = net.get('network_attach_group')
+
+            for override in overrides:
+                override_id = override.get('hostname')
+                if not override_id:
                     continue
 
-                if not any(s.get('name') == hostname for s in switches):
-                    if not any(s.get('management', {}).get('management_ipv4_address') == hostname for s in switches):
-                        if not any(s.get('management', {}).get('management_ipv6_address') == hostname for s in switches):
-                            results.append(
-                                f"switch: {hostname}, defined under {target} {attach_override.get('name')}.switch_attach_overrides"
-                                f" does not match any switch in the topology."
-                            )
+                resolved = None
+                for s in switches:
+                    if s.get('name') == override_id:
+                        resolved = s
+                        break
+
+                if resolved is None:
+                    results.append(
+                        f"Network '{net_name}' switch_attach_overrides identifier "
+                        f"'{override_id}' does not match any switch name in vxlan.topology.switches."
+                    )
+                    continue
+
+                if net_attach_group and net_attach_group in attach_group_identifiers:
+                    group_ids = attach_group_identifiers[net_attach_group]
+                    resolved_name = resolved.get('name')
+
+                    if resolved_name not in group_ids:
+                        results.append(
+                            f"Network '{net_name}' switch_attach_overrides identifier "
+                            f"'{override_id}' could not be resolved to a switch attached "
+                            f"through network_attach_group '{net_attach_group}'."
+                        )
 
         return results

--- a/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
+++ b/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
@@ -22,12 +22,12 @@ class Rule:
         # Check if vpc_peer_mapping is not empty and networks are defined
         if not vpc_peer_mapping and networks:
             for network in networks:
-                attach_overrides = cls.safeget(network,['switch_attach_overrides'])
+                attach_overrides = cls.safeget(network, ['switch_attach_overrides'])
                 if attach_overrides:
                     vlan_overrides = {o['hostname']: o.get('vlan_id') for o in attach_overrides}
                     for override in attach_overrides:
                         switch = override['hostname']
-                        vlan_override = cls.safeget(override,['vlan_id'])
+                        vlan_override = cls.safeget(override, ['vlan_id'])
                         if vlan_override:
                             if switch in vpc_peer_mapping:
                                 peer = vpc_peer_mapping[switch]
@@ -36,9 +36,9 @@ class Rule:
 
                                 if vlan_override != peer_vlan_id:
                                     results.append(
-                                    f"Networks.{network['name']}: switches {switch} and {peer} "
-                                    f"are vPC peers but have different vlan_id: "
-                                    f"{vlan_override} != {peer_vlan_id}"
+                                        f"Networks.{network['name']}: switches {switch} and {peer} "
+                                        f"are vPC peers but have different vlan_id: "
+                                        f"{vlan_override} != {peer_vlan_id}"
                                     )
 
         return results

--- a/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
+++ b/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
@@ -20,7 +20,7 @@ class Rule:
                     vpc_peer_mapping[peer2] = peer1
 
         # Check if vpc_peer_mapping is not empty and networks are defined
-        if not vpc_peer_mapping and networks:
+        if vpc_peer_mapping and networks:
             for network in networks:
                 attach_overrides = cls.safeget(network, ['switch_attach_overrides'])
                 if attach_overrides:

--- a/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
+++ b/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
@@ -11,14 +11,16 @@ class Rule:
 
         #  Build a mapping of vPC peers: hostname -> peer_hostname
         vpc_peer_mapping = {}
-        for vpc_pair in vpc_peers:
-            peer1 = vpc_pair.get('peer1')
-            peer2 = vpc_pair.get('peer2')
-            if peer1 and peer2:
-                vpc_peer_mapping[peer1] = peer2
-                vpc_peer_mapping[peer2] = peer1
+        if vpc_peers:
+            for vpc_pair in vpc_peers:
+                peer1 = vpc_pair.get('peer1')
+                peer2 = vpc_pair.get('peer2')
+                if peer1 and peer2:
+                    vpc_peer_mapping[peer1] = peer2
+                    vpc_peer_mapping[peer2] = peer1
 
-        if networks:
+        # Check if vpc_peer_mapping is not empty and networks are defined
+        if not vpc_peer_mapping and networks:
             for network in networks:
                 attach_overrides = cls.safeget(network,['switch_attach_overrides'])
                 if attach_overrides:
@@ -31,8 +33,7 @@ class Rule:
                                 peer = vpc_peer_mapping[switch]
                                 peer_override = vlan_overrides.get(peer)
                                 peer_vlan_id = peer_override if peer_override is not None else cls.safeget(network, ['vlan_id'])
-    
-    
+
                                 if vlan_override != peer_vlan_id:
                                     results.append(
                                     f"Networks.{network['name']}: switches {switch} and {peer} "

--- a/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
+++ b/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
@@ -1,0 +1,70 @@
+class Rule:
+    id = "405"
+    description = "Verify Network vlan_id override attribute are the same on vPC Peers"
+    severity = "HIGH"
+
+    @classmethod
+    def match(cls, data_model):
+        results = []
+        networks = cls.safeget(data_model, ['vxlan', 'overlay', 'networks'])
+        vpc_peers = cls.safeget(data_model, ['vxlan', 'topology', 'vpc_peers'])
+
+        #  Build a mapping of vPC peers: hostname -> peer_hostname
+        vpc_peer_mapping = {}
+        for vpc_pair in vpc_peers:
+            peer1 = vpc_pair.get('peer1')
+            peer2 = vpc_pair.get('peer2')
+            if peer1 and peer2:
+                vpc_peer_mapping[peer1] = peer2
+                vpc_peer_mapping[peer2] = peer1
+
+        for network in networks:
+            attach_overrides = cls.safeget(network,['switch_attach_overrides'])
+            if attach_overrides:
+                vlan_overrides = {o['hostname']: o.get('vlan_id') for o in attach_overrides}
+                for override in attach_overrides:
+                    switch = override['hostname']
+                    vlan_override = cls.safeget(override,['vlan_id'])
+                    if vlan_override:
+                        if switch in vpc_peer_mapping:
+                            peer = vpc_peer_mapping[switch]
+                            peer_override = vlan_overrides.get(peer)
+                            peer_vlan_id = peer_override if peer_override is not None else cls.safeget(network, ['vlan_id'])
+
+
+                            if vlan_override != peer_vlan_id:
+                                results.append(
+                                f"Networks.{network['name']}: switches {switch} and {peer} "
+                                f"are vPC peers but have different vlan_id: "
+                                f"{vlan_override} != {peer_vlan_id}"
+                                )
+
+        return results
+
+    @classmethod
+    def data_model_key_check(cls, tested_object, keys):
+        dm_key_dict = {'keys_found': [], 'keys_not_found': [], 'keys_data': [], 'keys_no_data': []}
+        for key in keys:
+            if tested_object and key in tested_object:
+                dm_key_dict['keys_found'].append(key)
+                tested_object = tested_object[key]
+                if tested_object:
+                    dm_key_dict['keys_data'].append(key)
+                else:
+                    dm_key_dict['keys_no_data'].append(key)
+            else:
+                dm_key_dict['keys_not_found'].append(key)
+        return dm_key_dict
+
+    @classmethod
+    def safeget(cls, dict, keys):
+        # Utility function to safely get nested dictionary values
+        for key in keys:
+            if dict is None:
+                return None
+            if key in dict:
+                dict = dict[key]
+            else:
+                return None
+
+        return dict

--- a/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
+++ b/roles/validate/files/rules/common_vxlan/405_overlay_networks_vpc_switch_override.py
@@ -18,26 +18,27 @@ class Rule:
                 vpc_peer_mapping[peer1] = peer2
                 vpc_peer_mapping[peer2] = peer1
 
-        for network in networks:
-            attach_overrides = cls.safeget(network,['switch_attach_overrides'])
-            if attach_overrides:
-                vlan_overrides = {o['hostname']: o.get('vlan_id') for o in attach_overrides}
-                for override in attach_overrides:
-                    switch = override['hostname']
-                    vlan_override = cls.safeget(override,['vlan_id'])
-                    if vlan_override:
-                        if switch in vpc_peer_mapping:
-                            peer = vpc_peer_mapping[switch]
-                            peer_override = vlan_overrides.get(peer)
-                            peer_vlan_id = peer_override if peer_override is not None else cls.safeget(network, ['vlan_id'])
-
-
-                            if vlan_override != peer_vlan_id:
-                                results.append(
-                                f"Networks.{network['name']}: switches {switch} and {peer} "
-                                f"are vPC peers but have different vlan_id: "
-                                f"{vlan_override} != {peer_vlan_id}"
-                                )
+        if networks:
+            for network in networks:
+                attach_overrides = cls.safeget(network,['switch_attach_overrides'])
+                if attach_overrides:
+                    vlan_overrides = {o['hostname']: o.get('vlan_id') for o in attach_overrides}
+                    for override in attach_overrides:
+                        switch = override['hostname']
+                        vlan_override = cls.safeget(override,['vlan_id'])
+                        if vlan_override:
+                            if switch in vpc_peer_mapping:
+                                peer = vpc_peer_mapping[switch]
+                                peer_override = vlan_overrides.get(peer)
+                                peer_vlan_id = peer_override if peer_override is not None else cls.safeget(network, ['vlan_id'])
+    
+    
+                                if vlan_override != peer_vlan_id:
+                                    results.append(
+                                    f"Networks.{network['name']}: switches {switch} and {peer} "
+                                    f"are vPC peers but have different vlan_id: "
+                                    f"{vlan_override} != {peer_vlan_id}"
+                                    )
 
         return results
 


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #807 
Fixes #820 
Fixes #831
Fixes #863 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [ ] vxlan.topology
* [ ] vxlan.underlay
* [X] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->
New key under network, **switch_attach_overrides** that will handle this 3 new features for each networks

```yaml
vxlan:
  overlay:
    networks:
      - name: Network1
        vlan_id: 2301
        network_attach_group: attach_group
        switch_attach_overrides:               <<<<<
          - hostname: leaf1
            vlan_id: 10
            svi_enabled: false
            freeform_config: |
              interface Vlan3101
              no autostate
          - hostname: leaf2
            vlan_id: 10
    network_attach_groups:
      - name: attach_group
        switches:
          - hostname: leaf1
            ports: [Ethernet1/13]
          - hostname: leaf2
            ports: [Ethernet1/13]
```

## Test Notes
<!--- Please provide notes or description of testing -->
Depends on base collection [PR #711](https://github.com/CiscoDevNet/ansible-dcnm/pull/711)

## Cisco Nexus Dashboard Version
<!-- Please provide Cisco Nexus Dashboard version developed against -->
3.1, 3.2, 4.1 and 4.2

## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
