### PR TITLE
add keys xconnect/heartbeat timer + defaults values

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/advanced/dc_vxlan_fabric_advanced.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/advanced/dc_vxlan_fabric_advanced.j2
@@ -53,3 +53,11 @@
   MPLS_LB_ID: {{ vxlan.global.ibgp.mpls_handoff.loopback_id | default(defaults.vxlan.global.ibgp.mpls_handoff.loopback_id) }}
   MPLS_ISIS_AREA_NUM: "{{ '{:0>4s}'.format(vxlan.global.ibgp.mpls_handoff.isis_net_area_number | default(defaults.vxlan.global.ibgp.mpls_handoff.isis_net_area_number) | string) }}"
 {% endif %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+{% if vxlan.global.ibgp.enable_ngoam | default(defaults.vxlan.global.ibgp.enable_ngoam) | ansible.builtin.bool %}
+  ENABLE_NGOAM: true
+  heartbeatInterval: {{ vxlan.global.ibgp.heartbeat_interval | default(defaults.vxlan.global.ibgp.heartbeat_interval) }}
+{% else %}
+  ENABLE_NGOAM: false
+{% endif %}
+{% endif %}

--- a/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
+++ b/roles/dtc/common/templates/ndfc_networks/dc_vxlan_fabric/dc_vxlan_fabric_networks.j2
@@ -55,6 +55,9 @@
   routing_tag: {{ net['route_tag'] | default(defaults.vxlan.overlay.networks.route_tag) }}
   trm_enable: {{ net['trm_enable'] | default(defaults.vxlan.overlay.networks.trm_enable) }}
 {#  trmv6_enable: {{ net['trmv6_enable'] | default(defaults.vxlan.overlay.networks.trmv6_enable) }} #}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+  xconnect: {{ net['xconnect'] | default(defaults.vxlan.overlay.networks.xconnect) }}
+{% endif %}
 {# ------------------------------------------------------ #}
 {# Attach Group Section #}
 {# ------------------------------------------------------ #}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -132,6 +132,8 @@ factory_defaults:
           loopback_id: 101
           loopback_ip_range: 10.101.0.0/25
           isis_net_area_number: "0001"
+        heartbeat_interval: 190
+        enable_ngoam: true
       external:
         auth_proto: MD5
         enable_nxapi_http: false
@@ -368,6 +370,7 @@ factory_defaults:
         trm_enable: false
         # Staging trmv6 attribute for later usage after low-level collection adds support.
         # trmv6_enable: false
+        xconnect: false
       vrf_attach_groups:
         switches: []
       network_attach_groups:


### PR DESCRIPTION
## Related Issue(s)

N/A — Feature enhancement to support new NDFC 12.4.1+ fabric settings.

## Related Collection Role

- [x] cisco.nac_dc_vxlan.validate
- [x] cisco.nac_dc_vxlan.dtc.create
- [ ] cisco.nac_dc_vxlan.dtc.deploy
- [ ] cisco.nac_dc_vxlan.dtc.remove
- [ ] other

## Related Data Model Element

- [ ] vxlan.fabric
- [x] vxlan.global
- [ ] vxlan.topology
- [ ] vxlan.underlay
- [x] vxlan.overlay
- [ ] vxlan.overlay_extensions
- [ ] vxlan.policy
- [ ] vxlan.multisite
- [x] defaults.vxlan
- [ ] other

## Proposed Changes

This PR adds support for two new NDFC 12.4.1+ features:

### 1. NGOAM Heartbeat Timer (`vxlan.global.ibgp`)

Adds the `ENABLE_NGOAM` and `heartbeatInterval` fabric advanced settings, gated behind a version check (`>= 12.4.1`).

- **New data model keys**: `vxlan.global.ibgp.enable_ngoam`, `vxlan.global.ibgp.heartbeat_interval`
- **Defaults**: `enable_ngoam: true`, `heartbeat_interval: 190`
- When NGOAM is disabled, only `ENABLE_NGOAM: false` is rendered (no heartbeat interval).

### 2. Network xconnect (`vxlan.overlay.networks`)

Adds the `xconnect` attribute to network templates, also gated behind `>= 12.4.1`.

- **New data model key**: `vxlan.overlay.networks[].xconnect`
- **Default**: `xconnect: false`

### Files Changed

| File | Change |
|------|--------|
| `roles/dtc/common/templates/ndfc_fabric/.../dc_vxlan_fabric_advanced.j2` | Added NGOAM/heartbeat Jinja2 block |
| `roles/dtc/common/templates/ndfc_networks/.../dc_vxlan_fabric_networks.j2` | Added xconnect attribute |
| `roles/validate/files/defaults.yml` | Added default values for all three new keys |

## Data Model Examples

### Heartbeat interval (fabric-level)

```yaml
vxlan:
  fabric:
    name: DC1-FABRIC
    type: VXLAN_EVPN
  global:
    ibgp:
      bgp_asn: "65000"
      route_reflectors: 2
      anycast_gateway_mac: 2020.0000.00aa
      enable_nxapi_http: false
      enable_nxapi_https: true
      dns_servers:
        - ip_address: 10.1.1.100
          vrf: management
      ntp_servers:
        - ip_address: 10.1.1.100
          vrf: management
      heartbeat_interval: 5000
```

### Network xconnect (overlay-level)

```yaml
vxlan:
  overlay:
    networks:
      - name: xconnect1
        is_l2_only: true
        net_id: 20001
        vlan_id: 2001
        xconnect: true
        multicast_group_address: 239.0.0.5
        network_attach_group: xconnect1
    network_attach_groups:
      - name: xconnect1
        switches:
          - hostname: DC1-LEAF1
```

## Test Notes

Tested with NDFC 12.4.1 — templates render correctly with version gating (attributes omitted on older versions).

## Cisco Nexus Dashboard Version

12.4.1+

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updates to documentation has been made accordingly
- [x] Assigned the proper reviewers