### PR TITLE
Adding support for enable/disable cdp on l2 interfaces 

### DIFF
--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
@@ -20,6 +20,7 @@
   deploy: false
   profile:
     admin_state: {{ interface['enabled'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enabled) | lower }}
+    enable_cdp: {{ interface['enable_cdp'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_cdp) | lower }}
     mode: 'access'
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.description) }}"
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.mtu) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
@@ -21,6 +21,7 @@
   deploy: false
   profile:
     admin_state: {{ interface['enabled'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enabled) | lower }}
+    enable_cdp: {{ interface['enable_cdp'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_cdp) | lower }}
     mode: 'access'
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.description) }}"
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.mtu) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
@@ -20,6 +20,7 @@
   deploy: false
   profile:
     admin_state: {{ interface['enabled'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.enabled) | lower }}
+    enable_cdp: {{ interface['enable_cdp'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.enable_cdp) | lower }}
     mode: dot1q
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.description) }}"
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.mtu) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
@@ -21,6 +21,7 @@
   deploy: false
   profile:
     admin_state: {{ interface['enabled'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.enabled) | lower }}
+    enable_cdp: {{ interface['enable_cdp'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.enable_cdp) | lower }}
     mode: 'trunk'
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.description) }}"
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.mtu) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
@@ -22,6 +22,7 @@
   deploy: false
   profile:
     admin_state: {{ interface['enabled'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled) | lower }}
+    enable_cdp: {{ interface['enable_cdp'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_cdp) | lower }}
     mode: 'trunk'
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.description) }}"
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.mtu) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
@@ -18,6 +18,7 @@
   deploy: false
   profile:
     admin_state: {{ switches[peer1].enabled | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled) | lower }}
+    enable_cdp: {{ switches[peer1].enable_cdp | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_cdp) | lower }}
     mode: {{ switches[peer1].mode }}
     peer1_pcid: {{ switches[peer1].name | regex_replace('[^0-9]', '') }}
     peer2_pcid: {{ switches[peer2].name | regex_replace('[^0-9]', '') }}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -165,7 +165,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
-            cdp_enable: true
+            enable_cdp: true
             access_vlan: 1
             spanning_tree_portfast: true
             enable_bpdu_guard: true
@@ -178,7 +178,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
-            cdp_enable: true
+            enable_cdp: true
             trunk_allowed_vlans: none
             spanning_tree_portfast: true
             enable_bpdu_guard: true
@@ -192,7 +192,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
-            cdp_enable: true
+            enable_cdp: true
             access_vlan: 1
             pc_mode: active
             spanning_tree_portfast: true
@@ -210,7 +210,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
-            cdp_enable: true
+            enable_cdp: true
             trunk_allowed_vlans: none
             pc_mode: active
             spanning_tree_portfast: true
@@ -229,7 +229,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
-            cdp_enable: true
+            enable_cdp: true
             access_vlan: 1
             spanning_tree_portfast: true
             enable_bpdu_guard: true

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -165,6 +165,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
+            cdp_enable: true
             access_vlan: 1
             spanning_tree_portfast: true
             enable_bpdu_guard: true
@@ -177,6 +178,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
+            cdp_enable: true
             trunk_allowed_vlans: none
             spanning_tree_portfast: true
             enable_bpdu_guard: true
@@ -190,6 +192,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
+            cdp_enable: true
             access_vlan: 1
             pc_mode: active
             spanning_tree_portfast: true
@@ -207,6 +210,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
+            cdp_enable: true
             trunk_allowed_vlans: none
             pc_mode: active
             spanning_tree_portfast: true
@@ -225,6 +229,7 @@ factory_defaults:
             mtu: jumbo
             speed: auto
             enabled: true
+            cdp_enable: true
             access_vlan: 1
             spanning_tree_portfast: true
             enable_bpdu_guard: true


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #850 


## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [X] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
Adding a new key, enable_cdp for L2 interface


## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
4.1, 4.2


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
