### PR TITLE
Adding support for storm control on L2 interfaces and copy description on PC

### DIFF
--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
@@ -37,6 +37,28 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.monitor) | lower }}
+    enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_storm_control) | lower }}
+{% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_storm_control) %}
+    storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.storm_control_action) | lower }}
+{% if interface['storm_control_broadcast_level_percent'] is defined %}
+    storm_control_broadcast_level_percent: "{{ '%0.2f' % interface['storm_control_broadcast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_multicast_level_percent'] is defined %}
+    storm_control_multicast_level_percent: "{{ '%0.2f' % interface['storm_control_multicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_unicast_level_percent'] is defined %}
+    storm_control_unicast_level_percent: "{{ '%0.2f' % interface['storm_control_unicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_broadcast_level_pps'] is defined %}
+    storm_control_broadcast_level_pps: {{ interface['storm_control_broadcast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_multicast_level_pps'] is defined %}
+    storm_control_multicast_level_pps: {{ interface['storm_control_multicast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_unicast_level_pps'] is defined %}
+    storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
@@ -38,6 +38,7 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.monitor) | lower }}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
     enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_storm_control) | lower }}
 {% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.enable_storm_control) %}
     storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.storm_control_action) | lower }}
@@ -58,6 +59,7 @@
 {% endif %}
 {% if interface['storm_control_unicast_level_pps'] is defined %}
     storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
 {% endif %}
 {% endif %}
     cmds: |2-

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
@@ -23,6 +23,7 @@
     admin_state: {{ interface['enabled'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enabled) | lower }}
     mode: 'access'
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.description) }}"
+    copy_description: {{ interface['copy_description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.copy_description) | lower }}
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.mtu) }}
     speed: {{ interface['speed'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.speed) }}
     port_type_fast: {{ interface['spanning_tree_portfast'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.spanning_tree_portfast) }}
@@ -43,6 +44,28 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.monitor) | lower }}
+    enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_storm_control) | lower }}
+{% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_storm_control) %}
+    storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.storm_control_action) | lower }}
+{% if interface['storm_control_broadcast_level_percent'] is defined %}
+    storm_control_broadcast_level_percent: "{{ '%0.2f' % interface['storm_control_broadcast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_multicast_level_percent'] is defined %}
+    storm_control_multicast_level_percent: "{{ '%0.2f' % interface['storm_control_multicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_unicast_level_percent'] is defined %}
+    storm_control_unicast_level_percent: "{{ '%0.2f' % interface['storm_control_unicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_broadcast_level_pps'] is defined %}
+    storm_control_broadcast_level_pps: {{ interface['storm_control_broadcast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_multicast_level_pps'] is defined %}
+    storm_control_multicast_level_pps: {{ interface['storm_control_multicast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_unicast_level_pps'] is defined %}
+    storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access_po.j2
@@ -45,6 +45,7 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.monitor) | lower }}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
     enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_storm_control) | lower }}
 {% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_storm_control) %}
     storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.storm_control_action) | lower }}
@@ -65,6 +66,7 @@
 {% endif %}
 {% if interface['storm_control_unicast_level_pps'] is defined %}
     storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
 {% endif %}
 {% endif %}
     cmds: |2-

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
@@ -32,6 +32,7 @@
 {% if interface['orphan_port'] | default(false) %}
     orphan_port: {{ interface['orphan_port'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.orphan_port) | lower }}
 {% endif %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
     enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.enable_storm_control) | lower }}
 {% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.enable_storm_control) %}
     storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.storm_control_action) | lower }}
@@ -52,6 +53,7 @@
 {% endif %}
 {% if interface['storm_control_unicast_level_pps'] is defined %}
     storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
 {% endif %}
 {% endif %}
     cmds: |2-

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
@@ -31,6 +31,28 @@
 {% if interface['orphan_port'] | default(false) %}
     orphan_port: {{ interface['orphan_port'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.orphan_port) | lower }}
 {% endif %}
+    enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.enable_storm_control) | lower }}
+{% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.enable_storm_control) %}
+    storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.storm_control_action) | lower }}
+{% if interface['storm_control_broadcast_level_percent'] is defined %}
+    storm_control_broadcast_level_percent: "{{ '%0.2f' % interface['storm_control_broadcast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_multicast_level_percent'] is defined %}
+    storm_control_multicast_level_percent: "{{ '%0.2f' % interface['storm_control_multicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_unicast_level_percent'] is defined %}
+    storm_control_unicast_level_percent: "{{ '%0.2f' % interface['storm_control_unicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_broadcast_level_pps'] is defined %}
+    storm_control_broadcast_level_pps: {{ interface['storm_control_broadcast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_multicast_level_pps'] is defined %}
+    storm_control_multicast_level_pps: {{ interface['storm_control_multicast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_unicast_level_pps'] is defined %}
+    storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_po_routed.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_po_routed.j2
@@ -25,6 +25,7 @@
     ipv4_mask_len: {{ ipv4_address__mask[1] | default(omit) }}
 {% endif %}
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.description) }}"
+    copy_description: {{ interface['copy_description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.copy_description) | lower }}
     route_tag: {{ interface['ipv4_route_tag'] | default(omit) }}
     int_vrf: {{ interface['vrf'] | default(omit) }}
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_po_interface.mtu) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
@@ -40,6 +40,7 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.monitor) | lower }}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
     enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.enable_storm_control) | lower }}
 {% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.enable_storm_control) %}
     storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.storm_control_action) | lower }}
@@ -60,6 +61,7 @@
 {% endif %}
 {% if interface['storm_control_unicast_level_pps'] is defined %}
     storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
 {% endif %}
 {% endif %}
     cmds: |2-

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
@@ -39,6 +39,28 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.monitor) | lower }}
+    enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.enable_storm_control) | lower }}
+{% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.enable_storm_control) %}
+    storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.storm_control_action) | lower }}
+{% if interface['storm_control_broadcast_level_percent'] is defined %}
+    storm_control_broadcast_level_percent: "{{ '%0.2f' % interface['storm_control_broadcast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_multicast_level_percent'] is defined %}
+    storm_control_multicast_level_percent: "{{ '%0.2f' % interface['storm_control_multicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_unicast_level_percent'] is defined %}
+    storm_control_unicast_level_percent: "{{ '%0.2f' % interface['storm_control_unicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_broadcast_level_pps'] is defined %}
+    storm_control_broadcast_level_pps: {{ interface['storm_control_broadcast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_multicast_level_pps'] is defined %}
+    storm_control_multicast_level_pps: {{ interface['storm_control_multicast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_unicast_level_pps'] is defined %}
+    storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
@@ -24,6 +24,7 @@
     admin_state: {{ interface['enabled'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled) | lower }}
     mode: 'trunk'
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.description) }}"
+    copy_description: {{ interface['copy_description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.copy_description) | lower }}
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.mtu) }}
     speed: {{ interface['speed'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.speed) }}
     port_type_fast: {{ interface['spanning_tree_portfast'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.spanning_tree_portfast) }}
@@ -45,6 +46,28 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.monitor) | lower }}
+    enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_storm_control) | lower }}
+{% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_storm_control) %}
+    storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.storm_control_action) | lower }}
+{% if interface['storm_control_broadcast_level_percent'] is defined %}
+    storm_control_broadcast_level_percent: "{{ '%0.2f' % interface['storm_control_broadcast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_multicast_level_percent'] is defined %}
+    storm_control_multicast_level_percent: "{{ '%0.2f' % interface['storm_control_multicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_unicast_level_percent'] is defined %}
+    storm_control_unicast_level_percent: "{{ '%0.2f' % interface['storm_control_unicast_level_percent'] }}"
+{% endif %}
+{% if interface['storm_control_broadcast_level_pps'] is defined %}
+    storm_control_broadcast_level_pps: {{ interface['storm_control_broadcast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_multicast_level_pps'] is defined %}
+    storm_control_multicast_level_pps: {{ interface['storm_control_multicast_level_pps'] }}
+{% endif %}
+{% if interface['storm_control_unicast_level_pps'] is defined %}
+    storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
@@ -25,7 +25,7 @@
     enable_cdp: {{ interface['enable_cdp'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_cdp) | lower }}
     mode: 'trunk'
     description: "{{ interface['description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.description) }}"
-    copy_description: {{ interface['copy_description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.copy_description) | lower }}
+    copy_description: {{ interface['copy_description'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.copy_description) | lower }}
     mtu: {{ interface['mtu'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.mtu) }}
     speed: {{ interface['speed'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.speed) }}
     port_type_fast: {{ interface['spanning_tree_portfast'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.spanning_tree_portfast) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk_po.j2
@@ -47,6 +47,7 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.monitor) | lower }}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
     enable_storm_control: {{ interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_storm_control) | lower }}
 {% if interface['enable_storm_control'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_storm_control) %}
     storm_control_action: {{ interface['storm_control_action'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.storm_control_action) | lower }}
@@ -67,6 +68,7 @@
 {% endif %}
 {% if interface['storm_control_unicast_level_pps'] is defined %}
     storm_control_unicast_level_pps: {{ interface['storm_control_unicast_level_pps'] }}
+{% endif %}
 {% endif %}
 {% endif %}
     cmds: |2-

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
@@ -17,20 +17,21 @@
     - {{ switches[peer2]['mgmt_ip_address'] }}
   deploy: false
   profile:
-    admin_state: {{ switches[peer1].enabled | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled) | lower }}
     mode: {{ switches[peer1].mode }}
     peer1_pcid: {{ switches[peer1].name | regex_replace('[^0-9]', '') }}
     peer2_pcid: {{ switches[peer2].name | regex_replace('[^0-9]', '') }}
-    port_type_fast: {{ switches[peer1].spanning_tree_portfast | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.spanning_tree_portfast) | lower }}
-    mtu: {{ switches[peer1].mtu | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.mtu) }}
-    speed: {{ switches[peer1].speed | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.speed) }}
-    pc_mode: "{{ switches[peer1].pc_mode | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.pc_mode) }}"
     peer1_members: {{ switches[peer1].members | to_json }}
     peer2_members: {{ switches[peer2].members | to_json }}
     peer1_cmds: |2-
       {{ switches[peer1].freeform_config | default('') | indent(6, false) }}
     peer2_cmds: |2-
       {{ switches[peer2].freeform_config | default('') | indent(6, false)  }}
+{% if switches[peer1].mode == 'trunk' %}
+    admin_state: {{ switches[peer1].enabled | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enabled) | lower }}
+    port_type_fast: {{ switches[peer1].spanning_tree_portfast | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.spanning_tree_portfast) | lower }}
+    mtu: {{ switches[peer1].mtu | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.mtu) }}
+    speed: {{ switches[peer1].speed | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.speed) }}
+    pc_mode: "{{ switches[peer1].pc_mode | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.pc_mode) }}"
     bpdu_guard: {{ switches[peer1].enable_bpdu_guard | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_bpdu_guard) | lower }}
     disable_lacp_suspend_individual: {{ switches[peer1].disable_lacp_suspend_individual | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.disable_lacp_suspend_individual) | lower }}
     enable_lacp_vpc_convergence: {{ switches[peer1].enable_lacp_vpc_convergence | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_lacp_vpc_convergence) | lower }}
@@ -41,7 +42,29 @@
     qos_policy: {{ switches[peer1].qos_policy | default("") }}
     queuing_policy: {{ switches[peer1].queuing_policy | default("") }}
 {% endif %}
-{% if switches[peer1].mode == 'trunk' %}
+    copy_description: {{ switches[peer1].copy_description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.copy_description) | lower }}
+    enable_storm_control: {{ switches[peer1].enable_storm_control | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_storm_control) | lower }}
+{% if switches[peer1].enable_storm_control | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_storm_control) %}
+    storm_control_action: {{ switches[peer1].storm_control_action | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.storm_control_action) | lower }}
+{% if switches[peer1].storm_control_broadcast_level_percent is defined %}
+    storm_control_broadcast_level_percent: "{{ '%0.2f' % switches[peer1].storm_control_broadcast_level_percent }}"
+{% endif %}
+{% if switches[peer1].storm_control_multicast_level_percent is defined %}
+    storm_control_multicast_level_percent: "{{ '%0.2f' % switches[peer1].storm_control_multicast_level_percent }}"
+{% endif %}
+{% if switches[peer1].storm_control_unicast_level_percent is defined %}
+    storm_control_unicast_level_percent: "{{ '%0.2f' % switches[peer1].storm_control_unicast_level_percent }}"
+{% endif %}
+{% if switches[peer1].storm_control_broadcast_level_pps is defined %}
+    storm_control_broadcast_level_pps: {{ switches[peer1].storm_control_broadcast_level_pps }}
+{% endif %}
+{% if switches[peer1].storm_control_multicast_level_pps is defined %}
+    storm_control_multicast_level_pps: {{ switches[peer1].storm_control_multicast_level_pps }}
+{% endif %}
+{% if switches[peer1].storm_control_unicast_level_pps is defined %}
+    storm_control_unicast_level_pps: {{ switches[peer1].storm_control_unicast_level_pps }}
+{% endif %}
+{% endif %}
     peer1_allowed_vlans: "{{ convert_ranges(switches[peer1].trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
     peer2_allowed_vlans: "{{ convert_ranges(switches[peer2].trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
     peer1_description: "{{ switches[peer1].description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.description) }}"
@@ -49,6 +72,44 @@
     peer1_native_vlan: "{{ switches[peer1].native_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.native_vlan) }}"
     peer2_native_vlan: "{{ switches[peer2].native_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.native_vlan) }}"
 {% elif switches[peer1].mode == 'access' %}
+    admin_state: {{ switches[peer1].enabled | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enabled) | lower }}
+    port_type_fast: {{ switches[peer1].spanning_tree_portfast | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.spanning_tree_portfast) | lower }}
+    mtu: {{ switches[peer1].mtu | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.mtu) }}
+    speed: {{ switches[peer1].speed | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.speed) }}
+    pc_mode: "{{ switches[peer1].pc_mode | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.pc_mode) }}"
+    bpdu_guard: {{ switches[peer1].enable_bpdu_guard | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_bpdu_guard) | lower }}
+    disable_lacp_suspend_individual: {{ switches[peer1].disable_lacp_suspend_individual | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.disable_lacp_suspend_individual) | lower }}
+    enable_lacp_vpc_convergence: {{ switches[peer1].enable_lacp_vpc_convergence | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_lacp_vpc_convergence) | lower }}
+    lacp_port_priority: {{ switches[peer1].lacp_port_priority | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.lacp_port_priority) }}
+    lacp_rate: {{ switches[peer1].lacp_rate | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.lacp_rate) }}
+    enable_qos: {{ switches[peer1].enable_qos | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_qos) | lower }}
+{% if switches[peer1].enable_qos | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_qos) %}
+    qos_policy: {{ switches[peer1].qos_policy | default("") }}
+    queuing_policy: {{ switches[peer1].queuing_policy | default("") }}
+{% endif %}
+    copy_description: {{ switches[peer1].copy_description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.copy_description) | lower }}
+    enable_storm_control: {{ switches[peer1].enable_storm_control | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_storm_control) | lower }}
+{% if switches[peer1].enable_storm_control | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_storm_control) %}
+    storm_control_action: {{ switches[peer1].storm_control_action | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.storm_control_action) | lower }}
+{% if switches[peer1].storm_control_broadcast_level_percent is defined %}
+    storm_control_broadcast_level_percent: "{{ '%0.2f' % switches[peer1].storm_control_broadcast_level_percent }}"
+{% endif %}
+{% if switches[peer1].storm_control_multicast_level_percent is defined %}
+    storm_control_multicast_level_percent: "{{ '%0.2f' % switches[peer1].storm_control_multicast_level_percent }}"
+{% endif %}
+{% if switches[peer1].storm_control_unicast_level_percent is defined %}
+    storm_control_unicast_level_percent: "{{ '%0.2f' % switches[peer1].storm_control_unicast_level_percent }}"
+{% endif %}
+{% if switches[peer1].storm_control_broadcast_level_pps is defined %}
+    storm_control_broadcast_level_pps: {{ switches[peer1].storm_control_broadcast_level_pps }}
+{% endif %}
+{% if switches[peer1].storm_control_multicast_level_pps is defined %}
+    storm_control_multicast_level_pps: {{ switches[peer1].storm_control_multicast_level_pps }}
+{% endif %}
+{% if switches[peer1].storm_control_unicast_level_pps is defined %}
+    storm_control_unicast_level_pps: {{ switches[peer1].storm_control_unicast_level_pps }}
+{% endif %}
+{% endif %}
     peer1_access_vlan: {{ switches[peer1].access_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan) }}
     peer2_access_vlan: {{ switches[peer2].access_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan)  }}
     peer1_description: "{{ switches[peer1].description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.description) }}"

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_vpc.j2
@@ -44,6 +44,7 @@
     queuing_policy: {{ switches[peer1].queuing_policy | default("") }}
 {% endif %}
     copy_description: {{ switches[peer1].copy_description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.copy_description) | lower }}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
     enable_storm_control: {{ switches[peer1].enable_storm_control | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_storm_control) | lower }}
 {% if switches[peer1].enable_storm_control | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.enable_storm_control) %}
     storm_control_action: {{ switches[peer1].storm_control_action | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.storm_control_action) | lower }}
@@ -64,6 +65,7 @@
 {% endif %}
 {% if switches[peer1].storm_control_unicast_level_pps is defined %}
     storm_control_unicast_level_pps: {{ switches[peer1].storm_control_unicast_level_pps }}
+{% endif %}
 {% endif %}
 {% endif %}
     peer1_allowed_vlans: "{{ convert_ranges(switches[peer1].trunk_allowed_vlans, defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_po_interface.trunk_allowed_vlans) | trim }}"
@@ -90,6 +92,7 @@
     queuing_policy: {{ switches[peer1].queuing_policy | default("") }}
 {% endif %}
     copy_description: {{ switches[peer1].copy_description | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.copy_description) | lower }}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
     enable_storm_control: {{ switches[peer1].enable_storm_control | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_storm_control) | lower }}
 {% if switches[peer1].enable_storm_control | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.enable_storm_control) %}
     storm_control_action: {{ switches[peer1].storm_control_action | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.storm_control_action) | lower }}
@@ -110,6 +113,7 @@
 {% endif %}
 {% if switches[peer1].storm_control_unicast_level_pps is defined %}
     storm_control_unicast_level_pps: {{ switches[peer1].storm_control_unicast_level_pps }}
+{% endif %}
 {% endif %}
 {% endif %}
     peer1_access_vlan: {{ switches[peer1].access_vlan | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_po_interface.access_vlan) }}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -172,6 +172,8 @@ factory_defaults:
             orphan_port: false
             enable_qos: false
             monitor: false
+            enable_storm_control: false
+            storm_control_action: default
           topology_switch_trunk_interface:
             description: "NetAsCode Trunk Interface"
             mtu: jumbo
@@ -185,8 +187,11 @@ factory_defaults:
             native_vlan: ""
             enable_qos: false
             monitor: false
+            enable_storm_control: false
+            storm_control_action: default
           topology_switch_access_po_interface:
             description: "NetAsCode Access PO Interface"
+            copy_description: false
             mtu: jumbo
             speed: auto
             enabled: true
@@ -202,8 +207,11 @@ factory_defaults:
             lacp_rate: normal
             enable_qos: false
             monitor: false
+            enable_storm_control: false
+            storm_control_action: default
           topology_switch_trunk_po_interface:
             description: "NetAsCode Trunk PO Interface"
+            copy_description: false
             mtu: jumbo
             speed: auto
             enabled: true
@@ -220,6 +228,8 @@ factory_defaults:
             lacp_rate: normal
             enable_qos: false
             monitor: false
+            enable_storm_control: false
+            storm_control_action: default
           topology_switch_dot1q_interface:
             description: "NetAsCode Dot1q Interface"
             mtu: jumbo
@@ -230,6 +240,8 @@ factory_defaults:
             enable_bpdu_guard: true
             duplex: auto
             orphan_port: false
+            enable_storm_control: false
+            storm_control_action: default
           topology_switch_routed_interface:
             description: "NetAsCode Routed Interface"
             mtu: 9216
@@ -243,6 +255,7 @@ factory_defaults:
             enabled: true
           topology_switch_routed_po_interface:
             description: "NetAsCode Routed PO Interface"
+            copy_description: false
             mtu: 9216
             speed: auto
             enabled: true

--- a/roles/validate/files/rules/common/305_topology_switch_interfaces_vpc.py
+++ b/roles/validate/files/rules/common/305_topology_switch_interfaces_vpc.py
@@ -19,6 +19,15 @@ class Rule:
             "enabled",
             "spanning_tree_portfast",
             "pc_mode",
+            "copy_description",
+            "enable_storm_control",
+            "storm_control_action",
+            "storm_control_broadcast_level_percent",
+            "storm_control_broadcast_level_pps",
+            "storm_control_multicast_level_percent",
+            "storm_control_multicast_level_pps",
+            "storm_control_unicast_level_percent",
+            "storm_control_unicast_level_pps",
         ]
         vpc_peers_list = cls.get_vpc_peers(data_model)
         # Check if fabric topology switches are defined

--- a/roles/validate/files/rules/common/305_topology_switch_interfaces_vpc.py
+++ b/roles/validate/files/rules/common/305_topology_switch_interfaces_vpc.py
@@ -169,20 +169,21 @@ class Rule:
                     )
 
         for vpc_id, interfaces in vpc_interfaces_dict_parameters.items():
-            # Check if vPC interfaces have same values for parameters on vpc_params_to_match list
-            if len(interfaces["interfaces"]) == 2:
-                for param in vpc_params_to_match:
-                    if (
-                        interfaces["interfaces"][
-                            list(interfaces["interfaces"].keys())[0]
-                        ][param]
-                        != interfaces["interfaces"][
-                            list(interfaces["interfaces"].keys())[1]
-                        ][param]
-                    ):
-                        results.append(
-                            f"vpc_id : {vpc_id} interfaces {', '.join(interfaces['interfaces'].keys())} have different {param} values"
-                        )
+            for pairs in vpc_peers_list:
+                pair_keys = [
+                    k
+                    for k in interfaces["interfaces"]
+                    if k.split(":", 1)[0] in pairs
+                ]
+                if len(pair_keys) == 2:
+                    a = interfaces["interfaces"][pair_keys[0]]
+                    b = interfaces["interfaces"][pair_keys[1]]
+                    for param in vpc_params_to_match:
+                        if a[param] != b[param]:
+                            results.append(
+                                f"vpc_id : {vpc_id} interfaces {', '.join(pair_keys)} "
+                                f"have different {param} values"
+                            )
         return results
 
     # Normalize interface name

--- a/roles/validate/files/rules/common/312_topology_interface_storm_control.py
+++ b/roles/validate/files/rules/common/312_topology_interface_storm_control.py
@@ -8,7 +8,7 @@ class Rule:
         results = []
         switches = []
         pct_keys = {'storm_control_broadcast_level_percent', 'storm_control_multicast_level_percent', 'storm_control_unicast_level_percent'}
-        pps_keys= {'storm_control_broadcast_level_pps', 'storm_control_multicast_level_pps', 'storm_control_unicast_level_pps'}
+        pps_keys = {'storm_control_broadcast_level_pps', 'storm_control_multicast_level_pps', 'storm_control_unicast_level_pps'}
 
         check = cls.data_model_key_check(data_model, ['vxlan', 'topology', 'switches'])
         if 'switches' in check['keys_data']:

--- a/roles/validate/files/rules/common/312_topology_interface_storm_control.py
+++ b/roles/validate/files/rules/common/312_topology_interface_storm_control.py
@@ -20,6 +20,10 @@ class Rule:
             check = cls.data_model_key_check(switch, ['interfaces'])
             if 'interfaces' in check['keys_data']:
                 for interface in switch.get('interfaces'):
+
+                    if not interface.get('enable_storm_control', False):
+                        continue
+
                     pct_set = [k for k in pct_keys if interface.get(k) is not None]
                     pps_set = [k for k in pps_keys if interface.get(k) is not None]
                     if pct_set and pps_set:

--- a/roles/validate/files/rules/common/312_topology_interface_storm_control.py
+++ b/roles/validate/files/rules/common/312_topology_interface_storm_control.py
@@ -1,6 +1,6 @@
 class Rule:
     id = "312"
-    description = "Verify either percentage or PPS is configured for storm-control"
+    description = "Verify either percentage or PPS is configured on the switch for storm-control"
     severity = "HIGH"
 
     @classmethod
@@ -19,16 +19,20 @@ class Rule:
         for switch in switches:
             check = cls.data_model_key_check(switch, ['interfaces'])
             if 'interfaces' in check['keys_data']:
-                interfaces = switch.get('interfaces')
-                for interface in interfaces:
-                    pct = {k for k in pct_keys if interface.get(k) is not None}
-                    pps = {k for k in pps_keys if interface.get(k) is not None}
-                    if pct and pps:
-                        results.append(
-                            f"switch {switch.get('name')} interface {interface.get('name')}: "
-                            f"storm_control percent and pps are mutually exclusive; "
-                            f"got {sorted(pct)} and {sorted(pps)}"
-                        )
+                pct_ifaces = []
+                pps_ifaces = []
+                for interface in switch.get('interfaces'):
+                    if any(interface.get(k) is not None for k in pct_keys):
+                        pct_ifaces.append(interface.get('name'))
+                    if any(interface.get(k) is not None for k in pps_keys):
+                        pps_ifaces.append(interface.get('name'))
+
+                if pct_ifaces and pps_ifaces:
+                    results.append(
+                        f"switch {switch.get('name')}: storm_control mode must be consistent "
+                        f"across all interfaces; percent-mode interfaces: {pct_ifaces}; "
+                        f"pps-mode interfaces: {pps_ifaces}"
+                    )
 
         return results
 

--- a/roles/validate/files/rules/common/312_topology_interface_storm_control.py
+++ b/roles/validate/files/rules/common/312_topology_interface_storm_control.py
@@ -16,22 +16,46 @@ class Rule:
         else:
             return results
 
+        level_keys = pct_keys | pps_keys
+
         for switch in switches:
-            check = cls.data_model_key_check(switch, ['interfaces'])
-            if 'interfaces' in check['keys_data']:
-                for interface in switch.get('interfaces'):
+            for interface in switch.get('interfaces', []):
+                enabled = interface.get('enable_storm_control', False)
+                action = interface.get('storm_control_action')
+                configured_levels = sorted(
+                    k for k in level_keys if interface.get(k) is not None
+                )
 
-                    if not interface.get('enable_storm_control', False):
-                        continue
+                if not enabled:
+                    invalid_keys = list(configured_levels)
+                    if action not in (None, 'default'):
+                        invalid_keys.append('storm_control_action')
 
-                    pct_set = [k for k in pct_keys if interface.get(k) is not None]
-                    pps_set = [k for k in pps_keys if interface.get(k) is not None]
-                    if pct_set and pps_set:
+                    if invalid_keys:
                         results.append(
-                            f"switch {switch.get('name')} interface {interface.get('name')}: "
-                            f"storm_control cannot mix percent and pps on the same interface; "
-                            f"percent keys: {pct_set}; pps keys: {pps_set}"
+                            f"switch {switch.get('name')} "
+                            f"interface {interface.get('name')}: "
+                            "storm_control action and level fields require "
+                            "enable_storm_control: true; "
+                            f"invalid keys: {sorted(invalid_keys)}"
                         )
+                    continue
+
+                pct_set = sorted(
+                    k for k in pct_keys if interface.get(k) is not None
+                )
+                pps_set = sorted(
+                    k for k in pps_keys if interface.get(k) is not None
+                )
+
+                if pct_set and pps_set:
+                    results.append(
+                        f"switch {switch.get('name')} "
+                        f"interface {interface.get('name')}: "
+                        "storm_control cannot mix percent and pps "
+                        "on the same interface; "
+                        f"percent keys: {pct_set}; pps keys: {pps_set}"
+                    )
 
         return results
 

--- a/roles/validate/files/rules/common/312_topology_interface_storm_control.py
+++ b/roles/validate/files/rules/common/312_topology_interface_storm_control.py
@@ -1,0 +1,48 @@
+class Rule:
+    id = "312"
+    description = "Verify either percentage or PPS is configured for storm-control"
+    severity = "HIGH"
+
+    @classmethod
+    def match(cls, data_model):
+        results = []
+        switches = []
+        pct_keys = {'storm_control_broadcast_level_percent', 'storm_control_multicast_level_percent', 'storm_control_unicast_level_percent'}
+        pps_keys= {'storm_control_broadcast_level_pps', 'storm_control_multicast_level_pps', 'storm_control_unicast_level_pps'}
+
+        check = cls.data_model_key_check(data_model, ['vxlan', 'topology', 'switches'])
+        if 'switches' in check['keys_data']:
+            switches = data_model.get('vxlan').get('topology').get('switches')
+        else:
+            return results
+
+        for switch in switches:
+            check = cls.data_model_key_check(switch, ['interfaces'])
+            if 'interfaces' in check['keys_data']:
+                interfaces = switch.get('interfaces')
+                for interface in interfaces:
+                    pct = {k for k in pct_keys if interface.get(k) is not None}
+                    pps = {k for k in pps_keys if interface.get(k) is not None}
+                    if pct and pps:
+                        results.append(
+                            f"switch {switch.get('name')} interface {interface.get('name')}: "
+                            f"storm_control percent and pps are mutually exclusive; "
+                            f"got {sorted(pct)} and {sorted(pps)}"
+                        )
+
+        return results
+
+    @classmethod
+    def data_model_key_check(cls, tested_object, keys):
+        dm_key_dict = {'keys_found': [], 'keys_not_found': [], 'keys_data': [], 'keys_no_data': []}
+        for key in keys:
+            if tested_object and key in tested_object:
+                dm_key_dict['keys_found'].append(key)
+                tested_object = tested_object[key]
+                if tested_object:
+                    dm_key_dict['keys_data'].append(key)
+                else:
+                    dm_key_dict['keys_no_data'].append(key)
+            else:
+                dm_key_dict['keys_not_found'].append(key)
+        return dm_key_dict

--- a/roles/validate/files/rules/common/312_topology_interface_storm_control.py
+++ b/roles/validate/files/rules/common/312_topology_interface_storm_control.py
@@ -1,6 +1,6 @@
 class Rule:
     id = "312"
-    description = "Verify either percentage or PPS is configured on the switch for storm-control"
+    description = "Verify either percentage or PPS is configured on each interface for storm-control (not both)"
     severity = "HIGH"
 
     @classmethod
@@ -19,20 +19,15 @@ class Rule:
         for switch in switches:
             check = cls.data_model_key_check(switch, ['interfaces'])
             if 'interfaces' in check['keys_data']:
-                pct_ifaces = []
-                pps_ifaces = []
                 for interface in switch.get('interfaces'):
-                    if any(interface.get(k) is not None for k in pct_keys):
-                        pct_ifaces.append(interface.get('name'))
-                    if any(interface.get(k) is not None for k in pps_keys):
-                        pps_ifaces.append(interface.get('name'))
-
-                if pct_ifaces and pps_ifaces:
-                    results.append(
-                        f"switch {switch.get('name')}: storm_control mode must be consistent "
-                        f"across all interfaces; percent-mode interfaces: {pct_ifaces}; "
-                        f"pps-mode interfaces: {pps_ifaces}"
-                    )
+                    pct_set = [k for k in pct_keys if interface.get(k) is not None]
+                    pps_set = [k for k in pps_keys if interface.get(k) is not None]
+                    if pct_set and pps_set:
+                        results.append(
+                            f"switch {switch.get('name')} interface {interface.get('name')}: "
+                            f"storm_control cannot mix percent and pps on the same interface; "
+                            f"percent keys: {pct_set}; pps keys: {pps_set}"
+                        )
 
         return results
 

--- a/roles/validate/files/rules/common/312_topology_interface_storm_control.py
+++ b/roles/validate/files/rules/common/312_topology_interface_storm_control.py
@@ -1,6 +1,6 @@
 class Rule:
     id = "312"
-    description = "Verify either percentage or PPS is configured on each interface for storm-control (not both)"
+    description = "Verify that storm-control percent-based and pps-based settings are not mixed on the same interface"
     severity = "HIGH"
 
     @classmethod
@@ -16,31 +16,8 @@ class Rule:
         else:
             return results
 
-        level_keys = pct_keys | pps_keys
-
         for switch in switches:
             for interface in switch.get('interfaces', []):
-                enabled = interface.get('enable_storm_control', False)
-                action = interface.get('storm_control_action')
-                configured_levels = sorted(
-                    k for k in level_keys if interface.get(k) is not None
-                )
-
-                if not enabled:
-                    invalid_keys = list(configured_levels)
-                    if action not in (None, 'default'):
-                        invalid_keys.append('storm_control_action')
-
-                    if invalid_keys:
-                        results.append(
-                            f"switch {switch.get('name')} "
-                            f"interface {interface.get('name')}: "
-                            "storm_control action and level fields require "
-                            "enable_storm_control: true; "
-                            f"invalid keys: {sorted(invalid_keys)}"
-                        )
-                    continue
-
                 pct_set = sorted(
                     k for k in pct_keys if interface.get(k) is not None
                 )


### PR DESCRIPTION
<!--- Please ensure that the WIP label is not being applied if ready for review -->
<!--- If the wip label is applied to your PR, no one will look at it -->
<!--- Please feel free to ask for help -->

## Related Issue(s)
<!--- Please link the relevant issue(s) -->
Fixes #850
Fixes #853 
Fixes #854 
Fixes #857

## Related Collection Role
<!-- If a new role to the collection, please specify -->
* [ ] cisco.nac_dc_vxlan.validate
* [X] cisco.nac_dc_vxlan.dtc.create
* [ ] cisco.nac_dc_vxlan.dtc.deploy
* [ ] cisco.nac_dc_vxlan.dtc.remove
* [ ] other

## Related Data Model Element
<!-- If a new element to the data model, please specify -->
* [ ] vxlan.fabric
* [ ] vxlan.global
* [X] vxlan.topology
* [ ] vxlan.underlay
* [ ] vxlan.overlay
* [ ] vxlan.overlay_extensions
* [ ] vxlan.policy
* [ ] vxlan.multisite
* [ ] defaults.vxlan
* [ ] other

## Proposed Changes
<!--- Please provide a description of proposed changes -->

For storm control, adding new keys for  under L2 interfaces:
- enable_storm_control
- storm_control_action
- storm_control_broadcast_level_percent
- storm_control_multicast_level_percent
- storm_control_unicast_level_percent
- storm_control_broadcast_level_pps
- storm_control_multicast_level_pps
- storm_control_unicast_level_pps

For copy description, adding new keys for under port-channel interfaces:
- copy_description

## Test Notes
<!--- Please provide notes or description of testing -->


## Cisco Nexus Dashboard Version
4.1


## Checklist

* [X] Latest commit is rebased from develop with merge conflicts resolved
* [X] New or updates to documentation has been made accordingly
* [X] Assigned the proper reviewers
