### PR TITLE
Add FEC support for physical interfaces (NDFC 12.4.1+)

### DIFF
--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
@@ -38,7 +38,7 @@
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.monitor) | lower }}
 {% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
-    fec: {{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.fec) }}
+    fec: "{{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.fec) }}"
 {% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_access.j2
@@ -37,6 +37,9 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.monitor) | lower }}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+    fec: {{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_access_interface.fec) }}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
@@ -31,6 +31,9 @@
 {% if interface['orphan_port'] | default(false) %}
     orphan_port: {{ interface['orphan_port'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.orphan_port) | lower }}
 {% endif %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+    fec: {{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.fec) }}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_dot1q.j2
@@ -32,7 +32,7 @@
     orphan_port: {{ interface['orphan_port'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.orphan_port) | lower }}
 {% endif %}
 {% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
-    fec: {{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.fec) }}
+    fec: "{{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_dot1q_interface.fec) }}"
 {% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_routed.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_routed.j2
@@ -39,6 +39,9 @@
     qos_policy: {{ interface['qos_policy'] | default("") }}
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+    fec: {{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.fec) }}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_routed.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_routed.j2
@@ -40,7 +40,7 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
 {% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
-    fec: {{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.fec) }}
+    fec: "{{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_routed_interface.fec) }}"
 {% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
@@ -40,7 +40,7 @@
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.monitor) | lower }}
 {% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
-    fec: {{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.fec) }}
+    fec: "{{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.fec) }}"
 {% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}

--- a/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
+++ b/roles/dtc/common/templates/ndfc_interfaces/ndfc_interface_trunk.j2
@@ -39,6 +39,9 @@
     queuing_policy: {{ interface['queuing_policy'] | default("") }}
 {% endif %}
     enable_monitor: {{ interface['monitor'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.monitor) | lower }}
+{% if ndfc_version | cisco.nac_dc_vxlan.version_compare('12.4.1', '>=') %}
+    fec: {{ interface['fec'] | default(defaults.vxlan.topology.switches.interfaces.topology_switch_trunk_interface.fec) }}
+{% endif %}
     cmds: |2-
       {{ interface['freeform_config'] | default('') | indent(6, false) }}
 {% endif %}

--- a/roles/validate/files/defaults.yml
+++ b/roles/validate/files/defaults.yml
@@ -172,6 +172,7 @@ factory_defaults:
             orphan_port: false
             enable_qos: false
             monitor: false
+            fec: auto
           topology_switch_trunk_interface:
             description: "NetAsCode Trunk Interface"
             mtu: jumbo
@@ -185,6 +186,7 @@ factory_defaults:
             native_vlan: ""
             enable_qos: false
             monitor: false
+            fec: auto
           topology_switch_access_po_interface:
             description: "NetAsCode Access PO Interface"
             mtu: jumbo
@@ -230,12 +232,14 @@ factory_defaults:
             enable_bpdu_guard: true
             duplex: auto
             orphan_port: false
+            fec: auto
           topology_switch_routed_interface:
             description: "NetAsCode Routed Interface"
             mtu: 9216
             speed: auto
             enabled: true
             enable_qos: false
+            fec: auto
           topology_switch_routed_sub_interface:
             description: "NetAsCode Routed Sub Interface"
             mtu: 9216


### PR DESCRIPTION
## Related Issue(s)

Depends on [CiscoDevNet/ansible-dcnm#661](https://github.com/CiscoDevNet/ansible-dcnm/pull/661) — adds `fec` parameter to `dcnm_interface` module.

## Related Collection Role

- [x] cisco.nac_dc_vxlan.validate
- [x] cisco.nac_dc_vxlan.dtc.create
- [ ] cisco.nac_dc_vxlan.dtc.deploy
- [ ] cisco.nac_dc_vxlan.dtc.remove
- [ ] other

## Related Data Model Element

- [ ] vxlan.fabric
- [ ] vxlan.global
- [x] vxlan.topology
- [ ] vxlan.underlay
- [ ] vxlan.overlay
- [ ] vxlan.overlay_extensions
- [ ] vxlan.policy
- [ ] vxlan.multisite
- [x] defaults.vxlan
- [ ] other

## Proposed Changes

Adds Forward Error Correction (FEC) support for physical ethernet interfaces, gated behind NDFC >= 12.4.1.

### Templates updated

FEC attribute added (with version gate `version_compare('12.4.1', '>=')`):

| Template | Interface type |
|----------|---------------|
| `ndfc_interface_trunk.j2` | Trunk |
| `ndfc_interface_access.j2` | Access |
| `ndfc_interface_routed.j2` | Routed |
| `ndfc_interface_dot1q.j2` | Dot1Q tunnel |

### Defaults added

Default `fec: auto` added for all four interface types in `defaults.yml`:
- `topology_switch_access_interface.fec`
- `topology_switch_trunk_interface.fec`
- `topology_switch_dot1q_interface.fec`
- `topology_switch_routed_interface.fec`

### Data Model Example

```yaml
vxlan:
  topology:
    switches:
      - name: DC1-LEAF1
        interfaces:
          - name: Ethernet1/12
            mode: trunk
            speed: 25Gb
            fec: rs-fec
            description: "25G link with RS-FEC"
```

### Supported FEC values

`auto`, `fc-fec`, `off`, `rs-cons16`, `rs-fec`, `rs-ieee`

## Test Notes

Tested with NDFC 12.4.1:
- Trunk interface with `fec: rs-fec` → FEC applied, idempotent on second run
- Access interface with `fec: fc-fec` → FEC applied
- Routed interface with `fec: rs-fec` → FEC applied
- Templates correctly omit FEC on NDFC < 12.4.1

## Cisco Nexus Dashboard Version

12.4.1+ (ND 4.1.1+)

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updates to documentation has been made accordingly
- [ ] Assigned the proper reviewers