### PR TITLE
Update ndfc_underlay_ip_address.j2

### DIFF
--- a/roles/dtc/common/templates/ndfc_underlay_ip_address.j2
+++ b/roles/dtc/common/templates/ndfc_underlay_ip_address.j2
@@ -24,7 +24,7 @@
 {%- set ns.ipv4 = interface.ipv4_address %}
 {%- endif %}
 {%- endfor %}
-{% if not (switch.role == 'spine' and loopback_id == vtep_lo_id) %}
+{% if not ((switch.role == 'spine' or switch.role == 'super_spine') and loopback_id == vtep_lo_id) %}
 - entity_name: "{{ switch_list[switch.name].serial_number }}~loopback{{ loopback_id }}"
   pool_type: IP
   pool_name: "LOOPBACK{{ loopback_id }}_IP_POOL"


### PR DESCRIPTION
## Related Issue(s)

Fixes VTEP loopback IP resource allocation failure for `super_spine` role switches when using manual underlay allocation.

## Related Collection Role

* [x] cisco.nac_dc_vxlan.dtc.create
* [x] other — `roles/dtc/common/templates/ndfc_underlay_ip_address.j2`

## Related Data Model Element

* [x] vxlan.underlay
* [x] vxlan.topology

## Proposed Changes

The `ndfc_underlay_ip_address.j2` template generates NDFC resource manager entries for loopback IP allocation. Spines do not have a VTEP loopback (NVE interface), so the template already skipped the VTEP loopback resource for `spine` role switches.

However, `super_spine` role switches also lack a VTEP loopback, but were not excluded. This caused `dcnm_resource_manager` to attempt allocating a VTEP loopback IP for super-spines, which either fails or creates an unnecessary resource entry on NDFC.

**Fix:** Extended the VTEP loopback skip condition to include both `spine` and `super_spine` roles:

```jinja2
# Before
{% if not (switch.role == 'spine' and loopback_id == vtep_lo_id) %}

# After
{% if not ((switch.role == 'spine' or switch.role == 'super_spine') and loopback_id == vtep_lo_id) %}
```

## Test Notes

Tested with eBGP VXLAN fabric containing super-spine topology. Verified:
- Routing loopback IP is still allocated for super-spines ✅
- VTEP loopback IP is no longer allocated for super-spines ✅
- No change in behavior for leaf, border, border_gateway roles ✅

## Cisco Nexus Dashboard Version

ND 4.1+

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
