### PR TITLE
fix ipv4 subnet mask with manual allocation ebgp

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/ebgp_vxlan_fabric_general.j2
@@ -14,9 +14,11 @@
 {% endif %}
   UNDERLAY_IS_V6: {{ vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | title }}
   STATIC_UNDERLAY_IP_ALLOC: {{ vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | title }}
-{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   SUBNET_TARGET_MASK: "{{ vxlan.underlay.ipv4.subnet_mask | default(defaults.vxlan.underlay.ipv4.subnet_mask) }}"
+{% endif %}
+{% if not (vxlan.underlay.general.manual_underlay_allocation | default(defaults.vxlan.underlay.general.manual_underlay_allocation) | ansible.builtin.bool) %}
+{% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   SUBNET_RANGE: {{ vxlan.underlay.ipv4.underlay_subnet_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_subnet_ip_range) }}
 {% endif %}
   LOOPBACK0_IP_RANGE: {{ vxlan.underlay.ipv4.underlay_routing_loopback_ip_range | default(defaults.vxlan.underlay.ipv4.underlay_routing_loopback_ip_range) }}


### PR DESCRIPTION
## Related Issue(s)

Fixes missing `SUBNET_TARGET_MASK` in eBGP VXLAN fabric payload when `manual_underlay_allocation` is enabled.

## Related Collection Role

* [x] cisco.nac_dc_vxlan.dtc.create
* [x] other — `roles/dtc/common/templates/ndfc_fabric/ebgp_vxlan_fabric/general/`

## Related Data Model Element

* [x] vxlan.underlay

## Proposed Changes

The `SUBNET_TARGET_MASK` parameter was nested inside the `manual_underlay_allocation == false` guard in the eBGP fabric template. This meant that when using manual underlay allocation, the subnet mask was not sent to NDFC — causing fabric creation/update to use NDFC defaults instead of the user-defined value.

`SUBNET_TARGET_MASK` is required by NDFC regardless of whether IP allocation is manual or automatic — it defines the point-to-point link prefix length for the underlay. The only condition where it should be omitted is when IPv6 underlay is enabled (since IPv6 uses a different parameter).

**Fix:** Moved `SUBNET_TARGET_MASK` outside the `manual_underlay_allocation` guard, keeping only the `enable_ipv6_underlay` condition:

| Condition | Before (broken) | After (fixed) |
|---|---|---|
| `manual=false`, `ipv6=false` | ✅ Rendered | ✅ Rendered |
| `manual=true`, `ipv6=false` | ❌ Missing | ✅ Rendered |
| `manual=false`, `ipv6=true` | ❌ Omitted | ❌ Omitted |
| `manual=true`, `ipv6=true` | ❌ Omitted | ❌ Omitted |

## Test Notes

Tested with eBGP VXLAN fabric using `manual_underlay_allocation: true` and `subnet_mask: 30`. Verified:
- `SUBNET_TARGET_MASK: "30"` now appears in the fabric payload ✅
- `SUBNET_RANGE` remains correctly omitted for manual allocation ✅
- IPv6 underlay correctly omits `SUBNET_TARGET_MASK` ✅

## Cisco Nexus Dashboard Version

ND 4.1+

## Checklist

* [x] Latest commit is rebased from develop with merge conflicts resolved
* [x] New or updates to documentation has been made accordingly
* [x] Assigned the proper reviewers
