### PR TITLE
Fix manual_underlay_allocation with TOR switches

### DIFF
--- a/roles/dtc/common/templates/ndfc_underlay_ip_address.j2
+++ b/roles/dtc/common/templates/ndfc_underlay_ip_address.j2
@@ -25,6 +25,7 @@
 {%- endif %}
 {%- endfor %}
 {% if not ((switch.role == 'spine' or switch.role == 'super_spine') and loopback_id == vtep_lo_id) %}
+{% if switch.role != 'tor' %}
 - entity_name: "{{ switch_list[switch.name].serial_number }}~loopback{{ loopback_id }}"
   pool_type: IP
   pool_name: "LOOPBACK{{ loopback_id }}_IP_POOL"
@@ -32,6 +33,7 @@
   resource: "{{ ns.ipv4 }}"
   switch:
     - "{{ switch_list[switch.name].management_ipv4_address }}"
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endmacro %}
@@ -42,6 +44,7 @@
 {# resource for leaf in vPC #}
 {% if data_model_extended.vxlan.topology.vpc_peers is defined %}
 {% for peer in data_model_extended.vxlan.topology.vpc_peers %}
+{% if switch_list[peer.peer1].role != 'tor' and switch_list[peer.peer2].role != 'tor' %}
 - entity_name: "{{ switch_list[peer.peer1].serial_number }}~{{ switch_list[peer.peer2].serial_number }}~loopback{{ vtep_lo_id }}"
   pool_type: IP
   pool_name: "LOOPBACK{{ vtep_lo_id }}_IP_POOL"
@@ -49,6 +52,7 @@
   resource: "{{ peer.vtep_vip }}"
   switch:
     - "{{ switch_list[peer.peer1].management_ipv4_address }}"
+{% endif %}
 {% endfor %}
 {% endif %}
 {# build p2p links - Check if ipv4 or ipv6 is present to distinct with fabric_link with template #}

--- a/roles/dtc/common/templates/ndfc_underlay_ip_address.j2
+++ b/roles/dtc/common/templates/ndfc_underlay_ip_address.j2
@@ -60,7 +60,7 @@
 
 {% if data_model_extended.vxlan.topology.fabric_links is defined %}
 {% for switch in data_model_extended.vxlan.topology.fabric_links %}
-{% if switch.ipv4 is defined and switch.ipv4 is iterable %}
+{% if switch.ipv4 is defined and switch.ipv4 is iterable and switch_list[switch.source_device].role != 'tor' and switch_list[switch.dest_device].role != 'tor' %}
 - entity_name: "{{ switch_list[switch.source_device].serial_number }}~{{ switch.source_interface }}~{{ switch_list[switch.dest_device].serial_number }}~{{ switch.dest_interface }}"
   pool_type: SUBNET
   pool_name: "SUBNET"

--- a/roles/validate/files/rules/common_vxlan/406_tor_no_underlay_allocation.py
+++ b/roles/validate/files/rules/common_vxlan/406_tor_no_underlay_allocation.py
@@ -1,0 +1,113 @@
+class Rule:
+    id = "406"
+    description = "Verify TOR switches do not have VXLAN underlay configuration when manual_underlay_allocation is true"
+    severity = "HIGH"
+
+    @classmethod
+    def match(cls, data_model):
+        results = []
+
+        check = cls.data_model_key_check(data_model, ['vxlan', 'underlay', 'general', 'manual_underlay_allocation'])
+        if 'manual_underlay_allocation' not in check['keys_data']:
+            return results
+
+        general = cls.safeget(data_model, ['vxlan', 'underlay', 'general'])
+        if not general.get("manual_underlay_allocation"):
+            return results
+
+        check = cls.data_model_key_check(data_model, ['vxlan', 'topology', 'switches'])
+        if 'switches' not in check['keys_data']:
+            return results
+
+        switches = cls.safeget(data_model, ["vxlan", "topology", "switches"])
+        tor_names = {sw.get("name", "") for sw in switches if sw.get("role", "").lower() == "tor"}
+
+        if not tor_names:
+            return results
+
+        underlay_general = cls.safeget(data_model, ["vxlan", "underlay", "general"])
+        routing_lo_id = underlay_general.get("underlay_routing_loopback_id")
+        vtep_lo_id = underlay_general.get("underlay_vtep_loopback_id")
+
+        for switch in switches:
+            switch_name = switch.get("name")
+            switch_role = switch.get("role", "").lower()
+
+            if switch_role != "tor":
+                continue
+
+            interfaces = switch.get("interfaces", [])
+            for interface in interfaces:
+                intf_name = interface.get("name", "").lower()
+                if intf_name in (f"loopback{routing_lo_id}", f"lo{routing_lo_id}",
+                                 f"loopback{vtep_lo_id}", f"lo{vtep_lo_id}"):
+                    if interface.get("ipv4_address"):
+                        results.append(
+                            f"TOR switch '{switch_name}': underlay loopback '{interface.get('name')}' with IPv4 "
+                            "should not be defined (TOR switches do not participate in VXLAN underlay)."
+                        )
+
+        # Check TOR vPC peers vtep_vip
+        check = cls.data_model_key_check(data_model, ["vxlan", "topology", "vpc_peers"])
+        if 'vpc_peers' in check['keys_data']:
+            vpc_peers = cls.safeget(data_model, ["vxlan", "topology", "vpc_peers"])
+            switch_role_map = {sw.get("name", ""): sw.get("role", "").lower() for sw in switches}
+
+            for peer in vpc_peers:
+                peer1_role = switch_role_map.get(peer.get("peer1", ""), "")
+                peer2_role = switch_role_map.get(peer.get("peer2", ""), "")
+                if peer1_role == "tor" or peer2_role == "tor":
+                    if peer.get("vtep_vip"):
+                        peer_name = f"{peer.get('peer1')}-{peer.get('peer2')}"
+                        results.append(
+                            f"vPC peer '{peer_name}': vtep_vip should not be defined for TOR switches "
+                            "(TOR switches do not participate in VXLAN underlay)."
+                        )
+
+        # Check TOR fabric links have no IPv4
+        check = cls.data_model_key_check(data_model, ["vxlan", "topology", "fabric_links"])
+        if 'fabric_links' in check['keys_data']:
+            fabric_links = cls.safeget(data_model, ["vxlan", "topology", "fabric_links"])
+            for link in fabric_links:
+                src = link.get("source_device", "")
+                dst = link.get("dest_device", "")
+                ipv4_config = link.get("ipv4", {})
+
+                if not ipv4_config:
+                    continue
+
+                if src in tor_names or dst in tor_names:
+                    tor_device = src if src in tor_names else dst
+                    if ipv4_config.get("subnet") or ipv4_config.get("source_ipv4") or ipv4_config.get("dest_ipv4"):
+                        results.append(
+                            f"Fabric link '{src}' → '{dst}': IPv4 underlay configuration should not be defined "
+                            f"for TOR switch '{tor_device}' (TOR switches do not participate in VXLAN underlay)."
+                        )
+
+        return results
+
+    @classmethod
+    def data_model_key_check(cls, tested_object, keys):
+        dm_key_dict = {'keys_found': [], 'keys_not_found': [], 'keys_data': [], 'keys_no_data': []}
+        for key in keys:
+            if tested_object and key in tested_object:
+                dm_key_dict['keys_found'].append(key)
+                tested_object = tested_object[key]
+                if tested_object:
+                    dm_key_dict['keys_data'].append(key)
+                else:
+                    dm_key_dict['keys_no_data'].append(key)
+            else:
+                dm_key_dict['keys_not_found'].append(key)
+        return dm_key_dict
+
+    @classmethod
+    def safeget(cls, dict, keys):
+        for key in keys:
+            if dict is None:
+                return None
+            if key in dict:
+                dict = dict[key]
+            else:
+                return None
+        return dict

--- a/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
+++ b/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
@@ -51,6 +51,7 @@ class Rule:
             switch_role = switch.get("role", "").lower()
 
             if switch_role == "tor":
+                cls.validate_tor_no_underlay(switch, switch_name, underlay_routing_loopback_id, underlay_vtep_loopback_id)
                 continue
 
             if "interfaces" not in switch:
@@ -79,7 +80,59 @@ class Rule:
         # Check if vtep_ip exist in vpc_peers
         cls.validate_vpc_peers_and_vtep_vip(data_model)
 
+        # Check if TOR switches have IPv4 on fabric links
+        cls.validate_tor_no_fabric_link_ipv4(data_model)
+
         return cls.results
+
+    @classmethod
+    def validate_tor_no_underlay(cls, switch, switch_name, routing_lo_id, vtep_lo_id):
+        """
+        Validates that TOR switches do not have underlay IP configuration.
+        TOR switches do not participate in the VXLAN underlay.
+        """
+        interfaces = switch.get("interfaces", [])
+        for interface in interfaces:
+            intf_name = interface.get("name", "").lower()
+            if intf_name in (f"loopback{routing_lo_id}", f"lo{routing_lo_id}",
+                             f"loopback{vtep_lo_id}", f"lo{vtep_lo_id}"):
+                if interface.get("ipv4_address"):
+                    cls.results.append(
+                        f"TOR switch '{switch_name}': underlay loopback '{interface.get('name')}' with IPv4 "
+                        "should not be defined (TOR switches do not participate in VXLAN underlay)."
+                    )
+
+    @classmethod
+    def validate_tor_no_fabric_link_ipv4(cls, data_model):
+        """
+        Validates that fabric links involving TOR switches do not have IPv4 underlay configuration.
+        """
+        check = cls.data_model_key_check(data_model, ["vxlan", "topology", "fabric_links"])
+        if 'fabric_links' not in check['keys_data']:
+            return
+
+        switches = cls.safeget(data_model, ["vxlan", "topology", "switches"]) or []
+        tor_names = {sw.get("name", "") for sw in switches if sw.get("role", "").lower() == "tor"}
+
+        if not tor_names:
+            return
+
+        fabric_links = cls.safeget(data_model, ["vxlan", "topology", "fabric_links"])
+        for link in fabric_links:
+            src = link.get("source_device", "")
+            dst = link.get("dest_device", "")
+            ipv4_config = link.get("ipv4", {})
+
+            if not ipv4_config:
+                continue
+
+            if src in tor_names or dst in tor_names:
+                tor_device = src if src in tor_names else dst
+                if ipv4_config.get("subnet") or ipv4_config.get("source_ipv4") or ipv4_config.get("dest_ipv4"):
+                    cls.results.append(
+                        f"Fabric link '{src}' → '{dst}': IPv4 underlay configuration should not be defined "
+                        f"for TOR switch '{tor_device}' (TOR switches do not participate in VXLAN underlay)."
+                    )
 
     @classmethod
     def validate_vpc_peers_and_vtep_vip(cls, data_model):
@@ -103,6 +156,11 @@ class Rule:
             peer1_role = switch_role_map.get(peer.get("peer1", ""), "")
             peer2_role = switch_role_map.get(peer.get("peer2", ""), "")
             if peer1_role == "tor" or peer2_role == "tor":
+                if peer.get("vtep_vip"):
+                    cls.results.append(
+                        f"vPC peer '{peer_name}': vtep_vip should not be defined for TOR switches "
+                        "(TOR switches do not participate in VXLAN underlay)."
+                    )
                 continue
 
             vtep_vip = peer.get("vtep_vip", False)
@@ -203,7 +261,7 @@ class Rule:
         # and P2P configured
 
         switches = cls.safeget(data_model, ["vxlan", "topology", "switches"])
-        switch_names = [switch.get("name") for switch in switches if switch.get("role", "").lower() not in ["spine", "border_gateway_spine"]]
+        switch_names = [switch.get("name") for switch in switches if switch.get("role", "").lower() not in ["spine", "border_gateway_spine", "tor"]]
 
         # If switch in switch_names not in regex fabric_links_list:
         # Switch doesn't have fabric link configured
@@ -233,10 +291,15 @@ class Rule:
 
         # Check if vpc_peers is on fabric_link
         vpc_peers = cls.safeget(data_model, ["vxlan", "topology", "vpc_peers"])
+        switch_role_map = {sw.get("name", ""): sw.get("role", "").lower() for sw in switches}
         for peer in vpc_peers:
             peer1 = f"{peer.get('peer1')}-{peer.get('peer2')}"
             peer2 = f"{peer.get('peer2')}-{peer.get('peer1')}"
             fabric_peering = peer.get("fabric_peering", False)
+
+            if switch_role_map.get(peer.get("peer1", ""), "") == "tor" or switch_role_map.get(peer.get("peer2", ""), "") == "tor":
+                continue
+
             # Skip fabric link validation when fabric_peering is true
             # because vPC uses virtual peer-link instead of physical fabric links
             if fabric_peering is False:

--- a/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
+++ b/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
@@ -51,7 +51,6 @@ class Rule:
             switch_role = switch.get("role", "").lower()
 
             if switch_role == "tor":
-                cls.validate_tor_no_underlay(switch, switch_name, underlay_routing_loopback_id, underlay_vtep_loopback_id)
                 continue
 
             if "interfaces" not in switch:
@@ -72,7 +71,7 @@ class Rule:
             vtep_loopback_name = f"loopback{underlay_vtep_loopback_id}"
             vtep_loopback_found = cls.check_interface_with_ipv4(interfaces, vtep_loopback_name)
 
-            if not vtep_loopback_found and switch_role not in ["spine"]:
+            if not vtep_loopback_found and switch_role not in ["spine", "super_spine"]:
                 cls.results.append(
                     f"Switch '{switch_name}' is missing a configured interface '{vtep_loopback_name}' with an IPv4 address."
                 )
@@ -80,59 +79,9 @@ class Rule:
         # Check if vtep_ip exist in vpc_peers
         cls.validate_vpc_peers_and_vtep_vip(data_model)
 
-        # Check if TOR switches have IPv4 on fabric links
-        cls.validate_tor_no_fabric_link_ipv4(data_model)
-
         return cls.results
 
-    @classmethod
-    def validate_tor_no_underlay(cls, switch, switch_name, routing_lo_id, vtep_lo_id):
-        """
-        Validates that TOR switches do not have underlay IP configuration.
-        TOR switches do not participate in the VXLAN underlay.
-        """
-        interfaces = switch.get("interfaces", [])
-        for interface in interfaces:
-            intf_name = interface.get("name", "").lower()
-            if intf_name in (f"loopback{routing_lo_id}", f"lo{routing_lo_id}",
-                             f"loopback{vtep_lo_id}", f"lo{vtep_lo_id}"):
-                if interface.get("ipv4_address"):
-                    cls.results.append(
-                        f"TOR switch '{switch_name}': underlay loopback '{interface.get('name')}' with IPv4 "
-                        "should not be defined (TOR switches do not participate in VXLAN underlay)."
-                    )
 
-    @classmethod
-    def validate_tor_no_fabric_link_ipv4(cls, data_model):
-        """
-        Validates that fabric links involving TOR switches do not have IPv4 underlay configuration.
-        """
-        check = cls.data_model_key_check(data_model, ["vxlan", "topology", "fabric_links"])
-        if 'fabric_links' not in check['keys_data']:
-            return
-
-        switches = cls.safeget(data_model, ["vxlan", "topology", "switches"]) or []
-        tor_names = {sw.get("name", "") for sw in switches if sw.get("role", "").lower() == "tor"}
-
-        if not tor_names:
-            return
-
-        fabric_links = cls.safeget(data_model, ["vxlan", "topology", "fabric_links"])
-        for link in fabric_links:
-            src = link.get("source_device", "")
-            dst = link.get("dest_device", "")
-            ipv4_config = link.get("ipv4", {})
-
-            if not ipv4_config:
-                continue
-
-            if src in tor_names or dst in tor_names:
-                tor_device = src if src in tor_names else dst
-                if ipv4_config.get("subnet") or ipv4_config.get("source_ipv4") or ipv4_config.get("dest_ipv4"):
-                    cls.results.append(
-                        f"Fabric link '{src}' → '{dst}': IPv4 underlay configuration should not be defined "
-                        f"for TOR switch '{tor_device}' (TOR switches do not participate in VXLAN underlay)."
-                    )
 
     @classmethod
     def validate_vpc_peers_and_vtep_vip(cls, data_model):
@@ -156,11 +105,6 @@ class Rule:
             peer1_role = switch_role_map.get(peer.get("peer1", ""), "")
             peer2_role = switch_role_map.get(peer.get("peer2", ""), "")
             if peer1_role == "tor" or peer2_role == "tor":
-                if peer.get("vtep_vip"):
-                    cls.results.append(
-                        f"vPC peer '{peer_name}': vtep_vip should not be defined for TOR switches "
-                        "(TOR switches do not participate in VXLAN underlay)."
-                    )
                 continue
 
             vtep_vip = peer.get("vtep_vip", False)
@@ -203,22 +147,23 @@ class Rule:
             return
 
         fabric_links = cls.safeget(data_model, ["vxlan", "topology", "fabric_links"])
-        peer_link = None
-        for link in fabric_links:
-            src = link.get("source_device", "")
-            dst = link.get("dest_device", "")
-            if (src == peer1 and dst == peer2) or (src == peer2 and dst == peer1):
-                peer_link = link
-                break
+        matching_links = [
+            link for link in fabric_links
+            if (link.get("source_device", "") == peer1 and link.get("dest_device", "") == peer2)
+            or (link.get("source_device", "") == peer2 and link.get("dest_device", "") == peer1)
+        ]
 
-        if not peer_link:
+        if not matching_links:
             cls.results.append(
                 f"Fabric link between '{peer1}' and '{peer2}' is missing (required for vPC with fabric_peering=false)."
             )
             return
 
-        ipv4_config = peer_link.get("ipv4", {})
-        if not ipv4_config or not ipv4_config.get("subnet") or not ipv4_config.get("source_ipv4") or not ipv4_config.get("dest_ipv4"):
+        has_complete_ipv4 = any(
+            link.get("ipv4", {}).get("subnet") and link.get("ipv4", {}).get("source_ipv4") and link.get("ipv4", {}).get("dest_ipv4")
+            for link in matching_links
+        )
+        if not has_complete_ipv4:
             cls.results.append(
                 f"Fabric link between '{peer1}' and '{peer2}' is missing IPv4 configuration (required for vPC with fabric_peering=false)."
             )

--- a/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
+++ b/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
@@ -1,5 +1,6 @@
 import re
 
+
 class Rule:
     id: str = "208"
     description: str = "Verify IP addresses when manual_underlay_allocation is true"
@@ -79,7 +80,6 @@ class Rule:
         cls.validate_vpc_peers_and_vtep_vip(data_model)
 
         return cls.results
-
 
 
     @classmethod

--- a/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
+++ b/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
@@ -1,6 +1,5 @@
 import re
 
-
 class Rule:
     id: str = "208"
     description: str = "Verify IP addresses when manual_underlay_allocation is true"

--- a/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
+++ b/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
@@ -48,6 +48,10 @@ class Rule:
         switches = cls.safeget(data_model, ["vxlan", "topology", "switches"])
         for switch in switches:
             switch_name = switch.get("name")
+            switch_role = switch.get("role", "").lower()
+
+            if switch_role == "tor":
+                continue
 
             if "interfaces" not in switch:
                 cls.results.append(f"Missing interfaces in vxlan.topology.switches.{switch_name}")
@@ -67,9 +71,7 @@ class Rule:
             vtep_loopback_name = f"loopback{underlay_vtep_loopback_id}"
             vtep_loopback_found = cls.check_interface_with_ipv4(interfaces, vtep_loopback_name)
 
-            switch_role = switch.get("role", "").lower()
-
-            if not vtep_loopback_found and switch_role != "spine":
+            if not vtep_loopback_found and switch_role not in ["spine"]:
                 cls.results.append(
                     f"Switch '{switch_name}' is missing a configured interface '{vtep_loopback_name}' with an IPv4 address."
                 )
@@ -89,14 +91,21 @@ class Rule:
             # If switches key is missing, no need to proceed
             return cls.results
         vpc_peers = cls.safeget(data_model, ["vxlan", "topology", "vpc_peers"])
+        switches = cls.safeget(data_model, ["vxlan", "topology", "switches"]) or []
+        switch_role_map = {sw.get("name", ""): sw.get("role", "").lower() for sw in switches}
         vtep_vip_list = set()
         vpc_peers_list = []
 
         for peer in vpc_peers:
             peer_name = f"{peer.get('peer1')}-{peer.get('peer2')}"
             vpc_peers_list.append(peer_name)
+
+            peer1_role = switch_role_map.get(peer.get("peer1", ""), "")
+            peer2_role = switch_role_map.get(peer.get("peer2", ""), "")
+            if peer1_role == "tor" or peer2_role == "tor":
+                continue
+
             vtep_vip = peer.get("vtep_vip", False)
-            # Check if vtep_vip is defined
             if not vtep_vip:
                 cls.results.append(f"vPC peer '{peer_name}' is missing a defined vtep_vip address.")
                 continue
@@ -114,7 +123,47 @@ class Rule:
                 # Check IP address under vxlan.topology.fabric_link only if
                 # fabric numbering is P2P or fabric peering is false (Use Fabric Peer-Link)
                 if peer.get("fabric_peering") is False or interface_numbering["fabric_interface_numbering"] == "p2p":
-                    cls.validate_fabric_links(data_model, vpc_peers_list)
+                    if interface_numbering["fabric_interface_numbering"] == "p2p":
+                        cls.validate_fabric_links(data_model, vpc_peers_list)
+                    else:
+                        cls.validate_vpc_peer_fabric_link(data_model, peer)
+
+    @classmethod
+    def validate_vpc_peer_fabric_link(cls, data_model, peer):
+        """
+        Validates that a specific vPC peer with fabric_peering=false has a fabric link with IPv4 config.
+        Only checks the link between the two peers, not all switches.
+        """
+        peer1 = peer.get("peer1")
+        peer2 = peer.get("peer2")
+
+        check = cls.data_model_key_check(data_model, ["vxlan", "topology", "fabric_links"])
+        if 'fabric_links' not in check['keys_data']:
+            cls.results.append(
+                f"Fabric link between '{peer1}' and '{peer2}' is missing (required for vPC with fabric_peering=false)."
+            )
+            return
+
+        fabric_links = cls.safeget(data_model, ["vxlan", "topology", "fabric_links"])
+        peer_link = None
+        for link in fabric_links:
+            src = link.get("source_device", "")
+            dst = link.get("dest_device", "")
+            if (src == peer1 and dst == peer2) or (src == peer2 and dst == peer1):
+                peer_link = link
+                break
+
+        if not peer_link:
+            cls.results.append(
+                f"Fabric link between '{peer1}' and '{peer2}' is missing (required for vPC with fabric_peering=false)."
+            )
+            return
+
+        ipv4_config = peer_link.get("ipv4", {})
+        if not ipv4_config or not ipv4_config.get("subnet") or not ipv4_config.get("source_ipv4") or not ipv4_config.get("dest_ipv4"):
+            cls.results.append(
+                f"Fabric link between '{peer1}' and '{peer2}' is missing IPv4 configuration (required for vPC with fabric_peering=false)."
+            )
 
     @classmethod
     def validate_fabric_links(cls, data_model, vpc_peers_list):

--- a/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
+++ b/roles/validate/files/rules/ibgp_vxlan/208_manual_ipaddress_allocation.py
@@ -81,7 +81,6 @@ class Rule:
 
         return cls.results
 
-
     @classmethod
     def validate_vpc_peers_and_vtep_vip(cls, data_model):
         """


### PR DESCRIPTION
## Related Issue(s)

Fixes #867

Fixes TOR switch support with `manual_underlay_allocation: true`. Without this fix, the validate role and underlay IP template fail when TOR switches are present in the topology.

## Related Collection Role

- [x] cisco.nac_dc_vxlan.validate
- [x] cisco.nac_dc_vxlan.dtc.create
- [ ] cisco.nac_dc_vxlan.dtc.deploy
- [ ] cisco.nac_dc_vxlan.dtc.remove
- [ ] other

## Related Data Model Element

- [ ] vxlan.fabric
- [ ] vxlan.global
- [x] vxlan.topology
- [x] vxlan.underlay
- [ ] vxlan.overlay
- [ ] vxlan.overlay_extensions
- [ ] vxlan.policy
- [ ] vxlan.multisite
- [ ] defaults.vxlan
- [ ] other

## Proposed Changes

TOR switches do not participate in the VXLAN underlay — they have no loopback IPs, no VTEP, no `vtep_vip`, and no underlay P2P or backup links. When `manual_underlay_allocation: true`, the validate rule and underlay IP template must skip TOR switches entirely and warn if underlay configuration is incorrectly provided for TOR.

### Rule 208 (`208_manual_ipaddress_allocation.py`)

**TOR exclusions (nothing mandatory for TOR):**

| Fix | Description |
|-----|-------------|
| Skip TOR in loopback validation | TOR switches no longer require `Loopback0` or `Loopback1` with IPv4 |
| Skip TOR vPC peers in `vtep_vip` validation | TOR vPC pairs no longer require `vtep_vip` |
| Skip TOR in `validate_fabric_links` switch list | TOR excluded from "missing fabric link" checks in P2P mode |
| Skip TOR vPC peers in fabric link peer check | TOR pairs with `fabric_peering: false` no longer require a fabric link entry |

**Error if TOR has underlay config (catch misconfigurations):**

| Check | Error message |
|-------|---------------|
| TOR switch with underlay loopback + IPv4 | `"TOR switch 'X': underlay loopback 'Loopback0' with IPv4 should not be defined..."` |
| TOR vPC pair with `vtep_vip` defined | `"vPC peer 'X-Y': vtep_vip should not be defined for TOR switches..."` |
| Fabric link with IPv4 involving a TOR switch | `"Fabric link 'X' → 'Y': IPv4 underlay configuration should not be defined for TOR switch..."` |

**Fix `fabric_peering: false` + `unnumbered` interaction:**

| Fix | Description |
|-----|-------------|
| New method `validate_vpc_peer_fabric_link()` | When `fabric_interface_numbering: unnumbered`, only validates the specific vPC peer-link between two peers (not all fabric links for all switches) |

### Underlay IP template (`ndfc_underlay_ip_address.j2`)

| Fix | Description |
|-----|-------------|
| Skip TOR in loopback resource generation | TOR switches no longer generate `LOOPBACK0_IP_POOL` or `LOOPBACK1_IP_POOL` entries |
| Skip TOR vPC peers in vtep_vip resource | TOR vPC pairs no longer generate `vtep_vip` resource manager entries |

### Data Model Example (TOR topology)

```yaml
vxlan:
  underlay:
    general:
      manual_underlay_allocation: true
      fabric_interface_numbering: unnumbered
  topology:
    vpc_peers:
      - peer1: dc1-lf1
        peer2: dc1-lf2
        domain_id: 10
        fabric_peering: true
        vtep_vip: 100.2.0.10
      - peer1: dc1-tor-1       # TOR pair — no underlay config needed
        peer2: dc1-tor-2
        domain_id: 12
        fabric_peering: false
    tor_peers:
      - parent_leaf1: dc1-lf1
        parent_leaf2: dc1-lf2
        tor1: dc1-tor-1
        tor2: dc1-tor-2
    switches:
      - name: dc1-lf1
        role: leaf
        interfaces:             # Loopbacks with IPv4 required
          - name: Loopback0
            ipv4_address: 100.0.0.1
          - name: Loopback1
            ipv4_address: 100.1.0.1
      - name: dc1-tor-1
        role: tor               # No underlay IP configuration needed
```

## Test Notes

Tested with a VXLAN_EVPN fabric containing:
- 1 spine, 1 border_gateway, 2 leaves, 1 border, 2 pre-provisioned leaves, 2 TOR switches
- `manual_underlay_allocation: true` + `fabric_interface_numbering: unnumbered`
- TOR vPC pair with `fabric_peering: false`
- TOR switches have no underlay IPs (no loopbacks, no vtep_vip, no P2P IPs)
- Validate passes cleanly
- Template renders without `'dict object' has no attribute 'vtep_vip'` error
- Misconfigurations (loopback IPv4 on TOR, vtep_vip on TOR pair, IPv4 on TOR fabric link) correctly produce errors

## Cisco Nexus Dashboard Version

12.4.1

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updates to documentation has been made accordingly
- [ ] Assigned the proper reviewers