### PR TITLE
fix: send default OSPF auth key ID (127) when authentication is disabled

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
@@ -10,8 +10,10 @@
 {% if not (vxlan.underlay.general.enable_ipv6_underlay | default(defaults.vxlan.underlay.general.enable_ipv6_underlay) | ansible.builtin.bool) %}
   OSPF_AUTH_ENABLE: {{ (vxlan.underlay.ospf.authentication_enable | default(defaults.vxlan.underlay.ospf.authentication_enable) | title) }}
 {% if vxlan.underlay.ospf.authentication_enable | default(defaults.vxlan.underlay.ospf.authentication_enable) | ansible.builtin.bool %}
-  OSPF_AUTH_KEY_ID: {{ vxlan.underlay.ospf.authentication_key_id | default(defaults.vxlan.underlay.ospf.authentication_key_id) }}
   OSPF_AUTH_KEY: {{ vxlan.underlay.ospf.authentication_key | default(omit) }}
+  OSPF_AUTH_KEY_ID: {{ vxlan.underlay.ospf.authentication_key_id | default(defaults.vxlan.underlay.ospf.authentication_key_id) }}
+{% else %}
+  OSPF_AUTH_KEY_ID: {{ defaults.vxlan.underlay.ospf.authentication_key_id }}
 {% endif %}
 {% if vxlan.underlay.bfd.enable | default(defaults.vxlan.underlay.bfd.enable) | ansible.builtin.bool %}
   BFD_OSPF_ENABLE: {{ vxlan.underlay.bfd.ospf | default(defaults.vxlan.underlay.bfd.ospf) }}


### PR DESCRIPTION
Fixes #869

## Related Collection Role

- [ ] cisco.nac_dc_vxlan.validate
- [x] cisco.nac_dc_vxlan.dtc.create
- [ ] cisco.nac_dc_vxlan.dtc.deploy
- [ ] cisco.nac_dc_vxlan.dtc.remove
- [ ] other

## Related Data Model Element

- [ ] vxlan.fabric
- [ ] vxlan.global
- [ ] vxlan.topology
- [x] vxlan.underlay
- [ ] vxlan.overlay
- [ ] vxlan.overlay_extensions
- [ ] vxlan.policy
- [ ] vxlan.multisite
- [ ] defaults.vxlan
- [ ] other

## Proposed Changes

When `ospf.authentication_enable: false`, NDFC rejects any `OSPF_AUTH_KEY_ID` value other than empty or `127`. Previously the template always sent the user-provided key ID, causing fabric update failures when auth was disabled but a key ID was defined in the data model.

### Template fix (`dc_vxlan_fabric_protocols.j2`)

| Condition | Before | After |
|-----------|--------|-------|
| `authentication_enable: true` | Sends user key ID + key | Sends user key ID + key (unchanged) |
| `authentication_enable: false` | Sends user key ID (fails if != 127) | Sends default key ID (`127` from defaults) |

The `else` branch now explicitly sends the default `OSPF_AUTH_KEY_ID` (127) when authentication is disabled. This is safe because:
- `127` is the NDFC default value for `OSPF_AUTH_KEY_ID` in the `dcnm_fabric` module
- `127` is accepted by NDFC in all scenarios (fresh fabric, previously enabled then disabled)
- `OSPF_AUTH_KEY` is not sent when auth is disabled (omitted from payload)

### Data Model Example

```yaml
vxlan:
  underlay:
    ospf:
      area_id: 0.0.0.0
      authentication_enable: false    # auth disabled
      authentication_key_id: 10       # ignored — template sends 127 instead
      authentication_key: my_key      # ignored — not sent to NDFC
```

## Test Notes

Tested with:
- Fresh fabric with auth disabled → ✅ deploys cleanly
- Fabric with auth previously enabled then disabled → ✅ `OSPF_AUTH_KEY_ID=127` accepted
- Fabric with auth enabled → ✅ user key ID sent as before

## Cisco Nexus Dashboard Version

12.4.1

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] New or updates to documentation has been made accordingly
- [ ] Assigned the proper reviewers