### PR TITLE
Release 0.9.0 Prep

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,10 +16,12 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 Added
 -----
 
+* Added support for ND 4.3.1
 * Added ``env_var_`` prefix support to secure data model secrets via environment variables
 * Added FEC support for physical interfaces (NDFC 12.4.1+)
 * Added discovery credential support for external and ISN fabrics
-* Added VLAN ID override, CLI Freeform config, and SVI admin status support under network attachment groups (ND >= 4.1)
+* Added VLAN ID Override and CLI Freeform config support for Network Attachments​
+* Added SVI Admin State for Network Attachments (ND ≥ 4.1)​
 * Added NGOAM heartbeat timer and network xconnect support
 * Added CDP enable/disable support on L2 interfaces
 * Added storm control support on L2 interfaces

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,10 +18,11 @@ Added
 
 * Added support for ND 4.3.1
 * Added ``env_var_`` prefix support to secure data model secrets via environment variables
-* Added FEC support for physical interfaces (NDFC 12.4.1+)
+* Added FEC support for physical interfaces (ND ≥ 4.1)​
 * Added discovery credential support for external and ISN fabrics
 * Added VLAN ID Override and CLI Freeform config support for Network Attachments​
 * Added SVI Admin State for Network Attachments (ND ≥ 4.1)​
+* Added QoS Policies for routed interfaces
 * Added NGOAM heartbeat timer and network xconnect support
 * Added CDP enable/disable support on L2 interfaces
 * Added storm control support on L2 interfaces

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,40 @@ This project adheres to `Semantic Versioning <http://semver.org/>`_.
 
 .. contents:: ``Release Versions``
 
+`0.9.0`_
+=====================
+
+**Release Date:** ``2026-08-27``
+
+Added
+-----
+
+* Added ``env_var_`` prefix support to secure data model secrets via environment variables
+* Added FEC support for physical interfaces (NDFC 12.4.1+)
+* Added discovery credential support for external and ISN fabrics
+* Added VLAN ID override, CLI Freeform config, and SVI admin status support under network attachment groups (ND >= 4.1)
+* Added NGOAM heartbeat timer and network xconnect support
+* Added CDP enable/disable support on L2 interfaces
+* Added storm control support on L2 interfaces
+* Added BGP authentication Type 6 support
+* Added manual underlay allocation support for eBGP fabrics
+
+Fixed
+-----
+
+* https://github.com/netascode/ansible-dc-vxlan/issues/719
+* https://github.com/netascode/ansible-dc-vxlan/issues/750
+* https://github.com/netascode/ansible-dc-vxlan/issues/840
+* https://github.com/netascode/ansible-dc-vxlan/issues/841
+* https://github.com/netascode/ansible-dc-vxlan/issues/854
+* https://github.com/netascode/ansible-dc-vxlan/issues/857
+* https://github.com/netascode/ansible-dc-vxlan/issues/859
+* https://github.com/netascode/ansible-dc-vxlan/issues/861
+* https://github.com/netascode/ansible-dc-vxlan/issues/863
+* https://github.com/netascode/ansible-dc-vxlan/issues/864
+* https://github.com/netascode/ansible-dc-vxlan/issues/869
+* https://github.com/netascode/ansible-dc-vxlan/issues/873
+
 `0.8.1`_
 =====================
 
@@ -606,6 +640,7 @@ The following roles have been added to the collection:
 
 This version of the collection includes support for an IPv4 Underlay only.  Support for IPv6 Underlay will be available in the next release.
 
+.. _0.9.0: https://github.com/netascode/ansible-dc-vxlan/compare/0.8.1...0.9.0
 .. _0.8.1: https://github.com/netascode/ansible-dc-vxlan/compare/0.8.0...0.8.1
 .. _0.8.0: https://github.com/netascode/ansible-dc-vxlan/compare/0.7.2...0.8.0
 .. _0.7.2: https://github.com/netascode/ansible-dc-vxlan/compare/0.7.1...0.7.2

--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ This collection is intended for use with the following release versions:
 * `Cisco Nexus Dashboard Fabric Controller (NDFC) Release 12.2.2`
 * `Cisco Nexus Dashboard Fabric Controller (NDFC) Release 12.2.3`
 * `Cisco Nexus Dashboard Release 4.1.1g` - Unified Nexus Dashboard (Legacy APIs)
+* `Cisco Nexus Dashboard Release 4.2.1` - Unified Nexus Dashboard (Legacy APIs)
+* `Cisco Nexus Dashboard Release 4.3.1` - Unified Nexus Dashboard (Legacy APIs)
 
 <!--start requires_ansible-->
 ## Ansible Version Compatibility

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: nac_dc_vxlan
-version: 0.8.1-dev
+version: 0.9.0-dev
 readme: README.md
 authors:
   - Charly Coueffe <ccoueffe>
@@ -19,6 +19,8 @@ authors:
   - Michal Kilar <mkilar>
   - Matt Thurston <mthurstocisco>
   - Peter Lewis <peter8498>
+  - Juan Andres Rocha Bravo <juarocha>
+  - Daniel Castillo Martinez <dacasti2mx>
 description: Ansible Solution Collection for VXLAN
 
 repository: https://github.com/netascode/ansible-dc-vxlan
@@ -32,5 +34,5 @@ tags: [cisco, dc, nd, ndfc, nxos, networking, vxlan, evpn, nac, sac]
 
 dependencies:
   "ansible.netcommon": ">=4.1.0"
-  "cisco.dcnm": ">=3.12.1"
+  "cisco.dcnm": ">=3.13.1"
   "community.general": ">=8.5.0"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -34,5 +34,5 @@ tags: [cisco, dc, nd, ndfc, nxos, networking, vxlan, evpn, nac, sac]
 
 dependencies:
   "ansible.netcommon": ">=4.1.0"
-  "cisco.dcnm": ">=3.13.1"
+  "cisco.dcnm": ">=3.13.0"
   "community.general": ">=8.5.0"


### PR DESCRIPTION
## Release 0.9.0 Prep

Updates `galaxy.yml` and `CHANGELOG.rst` for the 0.9.0 release.

### Changes

- `galaxy.yml`: version bumped to `0.9.0-dev`, `cisco.dcnm` minimum bumped to `>=3.13.1`
- `CHANGELOG.rst`: Added 0.9.0 release section

### Added
- `env_var_` prefix support to secure data model secrets via environment variables
- FEC support for physical interfaces (NDFC 12.4.1+)
- Discovery credential support for external and ISN fabrics
- VLAN ID Override and CLI Freeform config support for Network Attachments​
- Added SVI Admin State for Network Attachments (ND ≥ 4.1)​
- Added QoS Policies for routed interfaces
- NGOAM heartbeat timer and network xconnect support
- CDP enable/disable support on L2 interfaces
- Storm control support on L2 interfaces
- BGP authentication Type 6 support
- Manual underlay allocation support for eBGP fabrics

### Fixed
- #719, #750, #840, #841, #854, #857, #859, #861, #863, #864, #869, #873