### PR TITLE
fix: omit OSPF_AUTH_KEY_ID when authentication is disabled

### DIFF
--- a/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
+++ b/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2
@@ -12,8 +12,6 @@
 {% if vxlan.underlay.ospf.authentication_enable | default(defaults.vxlan.underlay.ospf.authentication_enable) | ansible.builtin.bool %}
   OSPF_AUTH_KEY: {{ vxlan.underlay.ospf.authentication_key | default(omit) }}
   OSPF_AUTH_KEY_ID: {{ vxlan.underlay.ospf.authentication_key_id | default(defaults.vxlan.underlay.ospf.authentication_key_id) }}
-{% else %}
-  OSPF_AUTH_KEY_ID: {{ defaults.vxlan.underlay.ospf.authentication_key_id }}
 {% endif %}
 {% if vxlan.underlay.bfd.enable | default(defaults.vxlan.underlay.bfd.enable) | ansible.builtin.bool %}
   BFD_OSPF_ENABLE: {{ vxlan.underlay.bfd.ospf | default(defaults.vxlan.underlay.bfd.ospf) }}


### PR DESCRIPTION
## Summary

Hotfix for regression introduced by #870.

## Problem

After merging #870, both MCFG pipelines began failing at the fabric create step:

**ND 3.2** (`sac-nd-32-MCFG` [#223](https://engci-private-gpk.cisco.com/jenkins/cs-emear/job/netascode/job/nac-dc-vxlan-ansible/job/sac-nd-32-MCFG/223/consoleFull)):
```
Fabric: nac-mcfg-fabric1, OSPF_AUTH_KEY_ID(127) requires OSPF_AUTH_ENABLE == True,
OSPF_AUTH_ENABLE valid values: [False, True]
```

**ND 4.2** (`sac-nd-42-MCFG` [#152](https://engci-private-gpk.cisco.com/jenkins/cs-emear/job/netascode/job/nac-dc-vxlan-ansible/job/sac-nd-42-MCFG/152/consoleFull)):
```
Fabric: nac-mcfg-fabric2, OSPF_AUTH_KEY_ID(127) requires OSPF_AUTH_ENABLE == True,
OSPF_AUTH_ENABLE valid values: [False, True]
```

PR #870 added an `{% else %}` branch that explicitly sends `OSPF_AUTH_KEY_ID: 127` when OSPF authentication is disabled. This worked on NDFC 4.2.1.10 (as tested by the PR author in a standalone fabric) but both ND 3.2 and ND 4.2 MCFG environments reject **any** `OSPF_AUTH_KEY_ID` value — including 127 — when `OSPF_AUTH_ENABLE == False`.

## Fix

Remove the `{% else %}` branch entirely. When authentication is disabled, `OSPF_AUTH_KEY_ID` is no longer sent to NDFC at all. The `dcnm_fabric` module applies its built-in default of `127` internally without us sending the field explicitly:

- ND 3.2: no field sent → module default applies → ✅ accepted
- ND 4.2: no field sent → module default applies → ✅ accepted
- Original issue #869 scenario: custom key ID no longer sent when disabled → ✅ still fixed

## Related

- Fixes regression from #870
- Closes #869 (still fixed — custom key ID is not sent when disabled)

## Checklist

- [x] Latest commit is rebased from develop with merge conflicts resolved
- [x] No schema, default values, or code behavior changed other than template
- [x] Tested by code inspection (template no longer sends the field in the disabled branch)