### PR TITLE
fix: handle missing response key in ndfc_get_switch_policy_using_desc

### DIFF
--- a/plugins/plugin_utils/helper_functions.py
+++ b/plugins/plugin_utils/helper_functions.py
@@ -229,8 +229,13 @@ def ndfc_get_switch_policy_using_desc(self, task_vars, tmp, switch_serial_number
     """
     policy_data = ndfc_get_switch_policy(self, task_vars, tmp, switch_serial_number)
 
+    policy_response = policy_data.get("response") or policy_data.get("msg") or {}
+    return_code = policy_response.get("RETURN_CODE")
+    if return_code != 200:
+        raise Exception(f"Policy lookup failed for switch {switch_serial_number}: {policy_response}")
+
     policy_match = [
-        item for item in policy_data["response"]["DATA"]
+        item for item in policy_response.get("DATA", [])
         if item.get("description", None) and item.get("description", None).startswith(prefix) and item["source"] == ""
     ]
 

--- a/plugins/plugin_utils/helper_functions.py
+++ b/plugins/plugin_utils/helper_functions.py
@@ -229,7 +229,11 @@ def ndfc_get_switch_policy_using_desc(self, task_vars, tmp, switch_serial_number
     """
     policy_data = ndfc_get_switch_policy(self, task_vars, tmp, switch_serial_number)
 
-    policy_response = policy_data.get("response") or policy_data.get("msg") or {}
+    # Fallback to an empty dict if the result is not a dictionary
+    policy_response = policy_data.get("response") or policy_data.get("msg")
+    if not isinstance(policy_response, dict):
+        policy_response = {}
+
     return_code = policy_response.get("RETURN_CODE")
     if return_code != 200:
         raise Exception(f"Policy lookup failed for switch {switch_serial_number}: {policy_response}")


### PR DESCRIPTION
## Summary

Defensive robustness improvement for `ndfc_get_switch_policy_using_desc`.

## Problem

On `sac-nd-41-ca/273`, the remove stage failed with:

```
REMOVE [nac-fabric2-ca] Discovering and removing unmanaged policies across 4 switch(es)
fatal: [nac-fabric2-ca]: FAILED! => {"changed": false, "msg": "Remove resources failed: 'response'"}
```

`ndfc_get_switch_policy_using_desc` (line 233) does a bare key access `policy_data["response"]["DATA"]`. When `dcnm_rest` returns without a `"response"` key (e.g. a transient NDFC API failure or connection error), this raises `KeyError: 'response'`, which propagates as the cryptic `Remove resources failed: 'response'` message.

`ndfc_get_switch_policy_using_template` already had this fixed (line 184) with the defensive `.get()` pattern. `ndfc_get_switch_policy_using_desc` was missed.

## Root Cause

Build 273 failed due to a **transient NDFC API failure** — `dcnm_rest` returned without a `"response"` key. Builds 270–271 on the same code path passed without issue. `dcnm_rest.py` in `cisco.dcnm` has not changed since March 2026. This is a pre-existing defensive gap, not a regression introduced by today's merges (#870, #874, #775).

**Recommended action for `sac-nd-41-ca`**: rerun the pipeline. This PR does not prevent failure if NDFC is unresponsive — it ensures the failure surfaces with a clear, actionable error message instead of a cryptic `KeyError`.

## Fix

Apply the same pattern already used in `ndfc_get_switch_policy_using_template`:

```python
# Before
policy_match = [
    item for item in policy_data["response"]["DATA"]
    ...
]

# After
policy_response = policy_data.get("response") or policy_data.get("msg") or {}
return_code = policy_response.get("RETURN_CODE")
if return_code != 200:
    raise Exception(f"Policy lookup failed for switch {switch_serial_number}: {policy_response}")

policy_match = [
    item for item in policy_response.get("DATA", [])
    ...
]
```

## Related

- Observed on `sac-nd-41-ca` Run 273
- Pre-existing defensive gap — not caused by today's merges

## Checklist

- [x] Single-file fix — no schema, template, or default changes
- [x] Follows existing defensive `.get()` pattern from `ndfc_get_switch_policy_using_template`
- [x] Replaces cryptic `KeyError` with a descriptive exception message for easier future debugging
